### PR TITLE
Fix warnings and update to new version of compiler

### DIFF
--- a/libenclave/Cargo.toml
+++ b/libenclave/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/jethrogb/sgx-utils/tree/master/libenclave"
 build = "build.rs"
 
 [dependencies]
+rlibc = "1.0.0"  # MIT/Apache-2.0
 spin = "0.4.2"   # MIT
 alloc_buddy_simple2 = { version = "0.1.2" } # Apache-2.0/MIT
 sgx-isa = "0.1"  # Apache-2.0/MIT

--- a/libenclave/Cargo.toml
+++ b/libenclave/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/jethrogb/sgx-utils/tree/master/libenclave"
 build = "build.rs"
 
 [dependencies]
-rlibc = "1.0.0"  # MIT/Apache-2.0
 spin = "0.4.2"   # MIT
 alloc_buddy_simple2 = { version = "0.1.2" } # Apache-2.0/MIT
 sgx-isa = "0.1"  # Apache-2.0/MIT

--- a/libenclave/src/lib.rs
+++ b/libenclave/src/lib.rs
@@ -8,20 +8,20 @@
  * Free Software Foundation, either version 3 of the License, or (at your
  * option) any later version.
  */
+#![deny(unused_extern_crates)]
+#![deny(unused_imports)]
+#![deny(unused_import_braces, unused_qualifications)]
 
-#![feature(linkage,lang_items,unwind_attributes,asm,const_fn,collections,unicode,alloc,oom,heap_api)]
+#![feature(linkage,lang_items,unwind_attributes,asm,const_fn,collections,alloc,oom,heap_api)]
 #![no_std]
 
 extern crate collections;
-extern crate std_unicode;
 extern crate alloc as rustc_alloc;
 extern crate sgx_isa;
 #[cfg(not(test))] pub extern crate core_io as io;
 
 extern crate spin;
-extern crate rlibc;
 extern crate alloc_buddy_simple;
-extern crate bitflags;
 
 // runtime features
 mod alloc;

--- a/libenclave/src/lib.rs
+++ b/libenclave/src/lib.rs
@@ -12,8 +12,8 @@
 #![feature(linkage,lang_items,unwind_attributes,asm,const_fn,collections,unicode,alloc,oom,heap_api)]
 #![no_std]
 
-#[macro_use] extern crate collections;
-extern crate rustc_unicode;
+extern crate collections;
+extern crate std_unicode;
 extern crate alloc as rustc_alloc;
 extern crate sgx_isa;
 #[cfg(not(test))] pub extern crate core_io as io;
@@ -21,7 +21,7 @@ extern crate sgx_isa;
 extern crate spin;
 extern crate rlibc;
 extern crate alloc_buddy_simple;
-#[macro_use] extern crate bitflags;
+extern crate bitflags;
 
 // runtime features
 mod alloc;

--- a/libenclave/src/lib.rs
+++ b/libenclave/src/lib.rs
@@ -8,7 +8,6 @@
  * Free Software Foundation, either version 3 of the License, or (at your
  * option) any later version.
  */
-#![deny(unused_extern_crates)]
 #![deny(unused_imports)]
 #![deny(unused_import_braces, unused_qualifications)]
 
@@ -21,6 +20,7 @@ extern crate sgx_isa;
 #[cfg(not(test))] pub extern crate core_io as io;
 
 extern crate spin;
+extern crate rlibc;
 extern crate alloc_buddy_simple;
 
 // runtime features

--- a/libenclave/src/sgx.rs
+++ b/libenclave/src/sgx.rs
@@ -25,7 +25,7 @@ pub fn egetkey(req: &Keyrequest) -> Result<[u8;16],ErrorCode> {
 		req_p=heap::allocate(mem::size_of::<Keyrequest>(),512) as *mut Keyrequest;
 		out_p=heap::allocate(16,16) as *mut [u8;16];
 
-		if req_p==ptr::null_mut() || out_p==ptr::null_mut() { oom::oom() }
+		if req_p==ptr::null_mut() || out_p==ptr::null_mut() { oom() }
 		ptr::copy(req,req_p,1);
 
 		asm!("enclu":"={eax}"(error):"{eax}"(Enclu::EGetkey),"{rbx}"(req_p),"{rcx}"(out_p));
@@ -75,7 +75,7 @@ fn ereport_internal(tinfo: Option<&Targetinfo>, rdata: Option<&[u8; 64]>) -> Rep
 		rdata_p=heap::allocate(64,128) as *mut [u8;64];
 		report_p=heap::allocate(mem::size_of::<Report>(),512) as *mut Report;
 
-		if tinfo_p==ptr::null_mut() || rdata_p==ptr::null_mut() || report_p==ptr::null_mut() { oom::oom() }
+		if tinfo_p==ptr::null_mut() || rdata_p==ptr::null_mut() || report_p==ptr::null_mut() { oom() }
 
 		match tinfo {
 			Some(tinfo) => ptr::copy(tinfo,tinfo_p,1),


### PR DESCRIPTION
This fixes a couple of warnings related to unused macros, and makes the library compile with newer compilers.