### PR TITLE
runner script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,14 @@ dependencies = [
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enclave-runner 0.1.0-rc1",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx-isa 0.2.0-rc1",
  "sgxs 0.6.0-rc1",
  "sgxs-loaders 0.1.0-rc1",
+ "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -378,6 +383,14 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num_cpus"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl"
 version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +440,14 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro2"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "protobuf"
 version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +474,14 @@ dependencies = [
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -506,6 +535,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rustc-std-workspace-core"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "sgx-isa"
@@ -580,6 +624,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "0.15.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "synom"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +689,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ucd-util"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +714,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -768,15 +835,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
 "checksum num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e96f040177bb3da242b5b1ecf3f54b5d5af3efbbfb18608977a5d2767b22f10"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238"
 "checksum openssl 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ed18a0f40ec4e9a8a81f8865033d823b7195d16a0a5721e10963ee1b0c2980ca"
 "checksum openssl 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b34cd77cf91301fff3123fbd46b065c3b728b17a392835de34c397315dce5586"
 "checksum openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)" = "d8abc04833dcedef24221a91852931df2f63e3369ae003134e70aff3645775cc"
 "checksum pe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "de31e953ee9f97fce65decc96536d4df6a9ac7e51e13e2b635aae46e507b9048"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
+"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "52fbc45bf6709565e44ef31847eb7407b3c3c80af811ee884a04da071dcca12b"
 "checksum protoc 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ad0f6d6911ee5a10a078099476f1c573894a8b90e86701a6a7a3bd66bfe75749"
 "checksum protoc-rust 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "31e894f64966af9641e9c2b2bfa3a4c00216eea2a226034f6bc609d23d6df740"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "3041aeb6000db123d2c9c751433f526e1f404b23213bd733167ab770c3989b4d"
 "checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
@@ -784,18 +854,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-std-workspace-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1956f5517128a2b6f23ab2dadf1a976f4f5b27962e7724c2bf3d45e539ec098c"
+"checksum serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)" = "0e732ed5a5592c17d961555e3b552985baf98d50ce418b7b655f31f6ba7eb1b7"
+"checksum serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d6115a3ca25c224e409185325afc16a0d5aaaabc15c42b09587d6f1ba39a5b"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
+"checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f8bfa9ff0cadcd210129ad9d2c5f145c13e9ced3d3e5d948a6213487d52444"
 "checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unix_socket2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e9519c1ca5e520aa78a5d2ff977ea02bc571797be6064865a736c935c07f675"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cbe533e138811704c0e3cbde65a818b35d3240409b4346256c5ede403e082474"

--- a/fortanix-sgx-tools/Cargo.toml
+++ b/fortanix-sgx-tools/Cargo.toml
@@ -23,6 +23,11 @@ sgxs = { version = "0.6.0-rc1", path = "../sgxs" }
 sgx-isa = { version = "0.2.0-rc1", path = "../sgx-isa" }
 
 # External dependencies
-xmas-elf = "0.6.0" # Apache-2.0/MIT
-clap = "2.2.5"     # MIT
-failure = "0.1.1"  # MIT/Apache-2.0
+xmas-elf = "0.6.0"         # Apache-2.0/MIT
+clap = "2.2.5"             # MIT
+failure = "0.1.1"          # MIT/Apache-2.0
+failure_derive = "0.1.1"   # MIT/Apache-2.0
+serde_derive = "1.0.84"    # MIT/Apache-2.0
+serde = "1.0.84"           # MIT/Apache-2.0
+toml = "0.4.10"            # MIT/Apache-2.0
+num_cpus = "1.9.0"         # MIT/Apache-2.0

--- a/fortanix-sgx-tools/src/bin/ftxsgx-runner-cargo.rs
+++ b/fortanix-sgx-tools/src/bin/ftxsgx-runner-cargo.rs
@@ -1,0 +1,114 @@
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
+
+use std::env;
+use std::fs::File;
+use std::io::{self, Read};
+use std::process::{self, Command, ExitStatus};
+use failure::{Error, ResultExt};
+
+const HEAP_SIZE: u64 = 0x2000000;
+const SSAFRAMESIZE: u32 = 1;
+const STACK_SIZE: u32 = 0x20000;
+const DEBUG: bool = true;
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+struct Target {
+    heap_size: Option<u64>,
+    ssaframesize: Option<u32>,
+    stack_size: Option<u32>,
+    threads: Option<u32>,
+    debug: Option<bool>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+struct Metadata {
+    fortanix_sgx: Target
+}
+
+#[derive(Deserialize, Debug)]
+struct Package {
+    metadata: Metadata
+}
+
+#[derive(Deserialize, Debug)]
+struct Config {
+    package: Package
+}
+
+#[derive(Debug, Fail)]
+enum CommandFail {
+    #[fail(display = "failed to run {}, {}", _0, _1)]
+    Io(String, io::Error),
+    #[fail(display = "while running {} got {}", _0, _1)]
+    Status(String, ExitStatus),
+}
+
+fn run_command(mut cmd: Command) -> Result<(), CommandFail> {
+    match cmd.status() {
+        Err(e) => Err(CommandFail::Io(format!("{:?}", cmd), e)),
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => Err(CommandFail::Status(format!("{:?}", cmd), status)),
+    }
+}
+
+fn run() -> Result<(), Error> {
+    let key = "CARGO_MANIFEST_DIR";
+    let mut filepath = env::var_os(key)
+        .ok_or_else(|| format_err!("{} is not defined in the environment.", key))?;
+    filepath.push("/Cargo.toml");
+    let mut file = File::open(filepath).context("Unable to open the manifest")?;
+    let mut content = String::new();
+    file.read_to_string(&mut content).context("Unable to read the manifest")?;
+    let config: Config = toml::from_str(&content).context("Unable to parse the manifest")?;
+    let heap_size = config.package.metadata.fortanix_sgx.heap_size.unwrap_or(HEAP_SIZE).to_string();
+    let ssaframesize = config.package.metadata.fortanix_sgx.ssaframesize.unwrap_or(SSAFRAMESIZE).to_string();
+    let stack_size = config.package.metadata.fortanix_sgx.stack_size.unwrap_or(STACK_SIZE).to_string();
+    let available_cpus = num_cpus::get() as u32;
+    let threads = config.package.metadata.fortanix_sgx.threads.unwrap_or(available_cpus).to_string();
+    let debug = config.package.metadata.fortanix_sgx.debug.unwrap_or(DEBUG);
+
+    let args: Vec<String> = env::args().collect();
+    let mut ftxsgx_elf2sgxs_command = Command::new("ftxsgx-elf2sgxs");
+    ftxsgx_elf2sgxs_command.arg(&args[1])
+        .arg("--heap-size")
+        .arg(heap_size)
+        .arg("--ssaframesize")
+        .arg(ssaframesize)
+        .arg("--stack-size")
+        .arg(stack_size)
+        .arg("--threads")
+        .arg(threads);
+    if debug {
+        ftxsgx_elf2sgxs_command.arg("--debug");
+    }
+    run_command(ftxsgx_elf2sgxs_command)?;
+
+    let bin_with_ext = args[1].clone() + ".sgxs";
+    let mut sgxs_append_command = Command::new("sgxs-append");
+    sgxs_append_command.arg("-i")
+        .arg(&bin_with_ext);
+    run_command(sgxs_append_command)?;
+
+    let mut ftxsgx_runner_command = Command::new("ftxsgx-runner");
+    ftxsgx_runner_command.arg(&bin_with_ext);
+    run_command(ftxsgx_runner_command)?;
+
+    Ok(())
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("ERROR: {}", e);
+        process::exit(match e.downcast_ref::<CommandFail>() {
+            Some(CommandFail::Status(_, status)) => status.code().unwrap(),
+            _ => 1,
+        })
+    }
+}


### PR DESCRIPTION
This script encapsulates the three steps listed [here](https://github.com/fortanix/rust-sgx/issues/49) under `Running`.

To trigger this script on `cargo run`, add .cargo/config file within crate with content:

> [target.x86_64-fortanix-unknown-sgx]
> runner = "ftxsgx-runner-cargo"

And to set custom values for arguments to `ftxsgx-elf2sgxs` script, add `package.metadata` section in Cargo.toml

> [package.metadata]
> threads=15