### PR TITLE
Script to parse rust-sgx backtrace.

### DIFF
--- a/enclave-runner/src/command.rs
+++ b/enclave-runner/src/command.rs
@@ -7,24 +7,40 @@
 use std::path::Path;
 
 use failure::Error;
-use sgxs::loader::Load;
+use sgxs::loader::{Load, MappingInfo};
 
 use loader::{EnclaveBuilder, ErasedTcs};
+use std::os::raw::c_void;
 use usercalls::EnclaveState;
 
+#[derive(Debug)]
 pub struct Command {
     main: ErasedTcs,
     threads: Vec<ErasedTcs>,
+    address: *mut c_void,
+    size: usize,
+}
+
+impl MappingInfo for Command {
+    fn address(&self) -> *mut c_void {
+        self.address
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
 }
 
 impl Command {
     /// # Panics
     /// Panics if the number of TCSs is 0.
-    pub(crate) fn internal_new(mut tcss: Vec<ErasedTcs>) -> Command {
+    pub(crate) fn internal_new(mut tcss: Vec<ErasedTcs>, address: *mut c_void, size: usize) -> Command {
         let main = tcss.remove(0);
         Command {
             main,
             threads: tcss,
+            address,
+            size,
         }
     }
 

--- a/enclave-runner/src/library.rs
+++ b/enclave-runner/src/library.rs
@@ -8,19 +8,44 @@ use std::path::Path;
 use std::sync::Arc;
 
 use failure::Error;
-use sgxs::loader::Load;
+use sgxs::loader::{Load, MappingInfo};
 
 use loader::{EnclaveBuilder, ErasedTcs};
+use std::fmt;
+use std::os::raw::c_void;
 use usercalls::EnclaveState;
 
 pub struct Library {
     enclave: Arc<EnclaveState>,
+    address: *mut c_void,
+    size: usize,
+}
+
+impl fmt::Debug for Library {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Library")
+            .field("address", &self.address)
+            .field("size", &self.size)
+            .finish()
+    }
+}
+
+impl MappingInfo for Library {
+    fn address(&self) -> *mut c_void {
+        self.address
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
 }
 
 impl Library {
-    pub(crate) fn internal_new(tcss: Vec<ErasedTcs>) -> Library {
+    pub(crate) fn internal_new(tcss: Vec<ErasedTcs>, address: *mut c_void, size: usize) -> Library {
         Library {
             enclave: EnclaveState::library(tcss),
+            address,
+            size,
         }
     }
 

--- a/fortanix-sgx-tools/src/bin/ftxsgx-runner.rs
+++ b/fortanix-sgx-tools/src/bin/ftxsgx-runner.rs
@@ -37,6 +37,8 @@ fn main() -> Result<(), Error> {
     let mut device = IsgxDevice::open(DEFAULT_DEVICE_PATH, AesmClient::new())
         .context("While opening SGX device")?;
     let enclave = Command::new(&file, &mut device).context("While loading SGX enclave")?;
-    enclave.run().context("While executing SGX enclave")?;
-    Ok(())
+    enclave.run().map_err(|e| {
+        println!("Error while executing SGX enclave.\n{}", e);
+        std::process::exit(-1)
+    })
 }

--- a/scripts/stack-trace-resolve
+++ b/scripts/stack-trace-resolve
@@ -1,0 +1,164 @@
+#! /bin/bash
+
+
+set -e
+
+
+terminal=
+script_name="$(basename ${0})"
+stack_pattern="stack backtrace:"
+reset_state="waiting_stack"
+executable=
+trace_file=
+default_options="-Cfp"
+options="${default_options}"
+supress=0
+stack_trace_pattern_1="^[[:blank:]]*[0-9]*:[[:blank:]]*0x[[:xdigit:]]*$"
+stack_trace_pattern_2="^[[:blank:]]*[0-9]*:.*\(0x.[[:xdigit:]]*\)$"
+
+detect_term()
+{
+    if [ -t 0 ]; then
+        terminal=1
+    else
+        terminal=0
+    fi
+}
+
+drain()
+{
+    local line=;
+    if [ ${terminal} == 0 ]; then
+        while read -r line; do
+        :
+        done
+    fi
+    exit -1
+}
+
+echo_opt()
+{
+    if [ "${supress}" == "0" ]; then
+        printf %s "${1}"
+	printf "\n"
+    fi
+}
+
+err_print()
+{
+    printf %s "${1}" 1>&2;
+    printf "\n" 1>&2
+}
+
+
+parse_line()
+{
+    local line=$1
+    if [[ $line = *[![:ascii:]]* ]]; then
+        err_print "Non Ascii Characters detected in input\n"
+        usage
+        drain
+    fi
+    line=`printf "%s" "${line}" | awk '{$1=$1};1'`
+
+    if [ "${state}" == "waiting_stack" ]; then
+        echo_opt "${line}"
+        if [ "${line}" == "${stack_pattern}" ]; then
+            state="printing"
+        fi
+    elif  [ "${state}" == "printing" ]; then
+        sr_no=`printf %s "${line}" | awk '{print $1}'`
+        offset=`printf %s "${line}" | awk '{print $NF}'`
+        offset=`printf %s "${offset}" | sed 's/(//g' | sed 's/)//g'`
+        if [[ "${line}" =~ ${stack_trace_pattern_1} || "${line}" =~ ${stack_trace_pattern_2} ]]; then
+            echo "$sr_no `addr2line ${options} -e ${executable} ${offset}`"
+        else
+            state=${reset_state}
+            if [ ${state} != "printing" ]; then
+                parse_line "${line}"
+            else
+                echo_opt "${line}"
+            fi
+        fi
+    fi
+}
+
+parse_input()
+{
+    local line=
+    while IFS='' read -r line || [[ -n "$line" ]]; do
+        parse_line "${line}"
+    done
+}
+
+parse_file() {
+    local line=
+    while IFS='' read -r line || [[ -n "$line" ]]; do
+        parse_line "${line}"
+    done < "$1"
+    check_state
+}
+
+usage() {
+    echo \
+"USAGE:
+    ${script_name} [OPTIONS] -e <ELF>
+OPTIONS:
+    -e <ELF>       Specify the path to the ELF file containing the symbol table
+    -h             Print this help message
+    -f <INPUT>     Read the stack trace from INPUT [default: /dev/stdin]
+    -r             Parse only stack trace lines.
+    -o <OPT>       Options to pass to addr2line for symbol resolution
+                   [default: ${default_options}]
+    -s             Don't print parts of the output that are not part of the
+                   stack trace"
+}
+
+detect_term
+while getopts "h?o:e:f:sr:" opt; do
+    case "$opt" in
+    h|\?)
+        usage
+	exit 0
+        ;;
+    e) executable=$OPTARG
+        ;;
+    o) options=$OPTARG
+        ;;
+    f)  trace_file=$OPTARG
+        ;;
+    s) supress=1
+        ;;
+    r)
+        reset_state="printing"
+        start_address=$OPTARG
+        ;; 
+    esac
+done
+
+shift $((OPTIND-1))
+
+if [ ! -z $1 ]; then
+    err_print "Extra Arguments detected $@"
+    usage
+    drain
+fi
+
+if [ -z ${executable} ]; then
+    err_print "No executable file given"
+    usage
+    drain
+fi
+
+state=${reset_state}
+
+#Options must begin with -
+if [[ ! $options =~ -.* ]]; then
+    options="-${options}"
+fi
+
+if [ -z ${trace_file} ]; then
+    parse_input
+else
+        parse_file "${trace_file}"
+fi

--- a/scripts/stack-trace-resolve.txt
+++ b/scripts/stack-trace-resolve.txt
@@ -1,0 +1,22 @@
+Usage:
+    1. Parse stack trace from stored output:
+           stack-trace-resolve [-o <opt>] [-s] -e <executable_path> -f <stack_trace_file>
+    2. Parse stack trace from output of an enclave over pipe:
+           <output_stream> | stack-trace-resolve [-o <opt>] [-s] -e <executable_path>
+    3. Paste stack trace prints from an output in raw mode.
+           stack-trace-resolve [-o <opt>] [-s] -e <executable_path> -r
+Note:
+    1. -o <opt>:
+       This option lets user customize the output format of the stack trace translation.
+       Here, opt indicates options passed to addr2line, default being [default: -Cfp].
+       Please refer to manpage of addr2line for further details about options.
+    2. -s:
+       This option suppresses the output that does not pertain to stack trace.
+       Without -s, lines of output before and after the stack trace would be echoed on the screen.
+    3. -r:
+       This option lets user run the script in raw mode and parses only stack trace prints.
+       Without -r option, only stack trace lines continuously following "stack backtrace:" are parsed.
+       User could start this script with -r option and copy-paste actual stack trace in stdin, until,
+       the script detects EOF (ctrl-d).
+       Alternatively, in raw mode, a file with a list of only stack trace prints (one on each line)
+       could be provided as an input with the -f option.


### PR DESCRIPTION
## The script allows following usages:

### Usage:
    1. Parse stack trace from stored output:
           stack-trace-resolve [-o <opt>] [-s] -e <executable_path> -f <stack_trace_file>
    2. Parse stack trace from output of an enclave over pipe:
           <output_stream> | stack-trace-resolve [-o <opt>] [-s] -e <executable_path>
    3. Paste stack trace prints from an output in raw mode.
           stack-trace-resolve [-o <opt>] [-s] -e <executable_path> -r
### Note:
    1. -o <opt>:
       This option lets user customize the output format of the stack trace translation.
       Here, opt indicates options passed to addr2line, default being [default: -Cfp].
       Please refer to manpage of addr2line for further details about options.
    2. -s:
       This option suppresses the output that does not pertain to stack trace.
       Without -s, lines of output before and after the stack trace would be echoed on the screen.
    3. -r:
       This option lets user run the script in raw mode and parses only stack trace prints.
       Without -r option, only stack trace lines continuously following "stack backtrace:" are parsed.
       User could start this script with -r option and copy-paste actual stack trace in stdin, until,
       the script detects EOF (ctrl-d).
       Alternatively, in raw mode, a file with a list of only stack trace prints (one on each line)
       could be provided as an input with the -f option.
