### PR TITLE
Make sized enclaves by default

### DIFF
--- a/fortanix-sgx-tools/src/bin/ftxsgx-runner-cargo.rs
+++ b/fortanix-sgx-tools/src/bin/ftxsgx-runner-cargo.rs
@@ -93,14 +93,8 @@ fn run() -> Result<(), Error> {
     }
     run_command(ftxsgx_elf2sgxs_command)?;
 
-    let bin_with_ext = args[1].clone() + ".sgxs";
-    let mut sgxs_append_command = Command::new("sgxs-append");
-    sgxs_append_command.arg("-i")
-        .arg(&bin_with_ext);
-    run_command(sgxs_append_command)?;
-
     let mut ftxsgx_runner_command = Command::new("ftxsgx-runner");
-    ftxsgx_runner_command.arg(&bin_with_ext)
+    ftxsgx_runner_command.arg(args[1].clone() + ".sgxs")
         .arg("--signature")
         .arg("dummy");
 


### PR DESCRIPTION
`elf2sgxs` used to generate unsized enclaves that would need to be appended using `sgxs-append`. This is a niche use case. Instead, generate sized enclaves by default so that appending is unnecessary. Add a command line option to `elf2sgxs` to generate an unsized enclave instead.