### PR TITLE
Clarify behavior around reading/writing zero-length buffers.

### DIFF
--- a/enclave-runner/src/usercalls/interface.rs
+++ b/enclave-runner/src/usercalls/interface.rs
@@ -260,7 +260,9 @@ impl ToSgxResult for IoResult<()> {
 }
 
 pub unsafe fn from_raw_parts_nonnull<'a, T>(p: *const T, len: usize) -> IoResult<&'a [T]> {
-    if p.is_null() {
+    if len == 0 {
+        Ok(&[])
+    } else if p.is_null() {
         Err(IoErrorKind::InvalidInput.into())
     } else {
         Ok(slice::from_raw_parts(p, len))
@@ -268,7 +270,9 @@ pub unsafe fn from_raw_parts_nonnull<'a, T>(p: *const T, len: usize) -> IoResult
 }
 
 pub unsafe fn from_raw_parts_mut_nonnull<'a, T>(p: *mut T, len: usize) -> IoResult<&'a mut [T]> {
-    if p.is_null() {
+    if len == 0 {
+        Ok(&mut [])
+    } else if p.is_null() {
         Err(IoErrorKind::InvalidInput.into())
     } else {
         Ok(slice::from_raw_parts_mut(p, len))

--- a/fortanix-sgx-abi/src/lib.rs
+++ b/fortanix-sgx-abi/src/lib.rs
@@ -303,7 +303,9 @@ impl Usercalls {
     /// `buf` must point to a buffer in userspace with a size of at least
     /// `len`. On a succesful return, the number of bytes written is returned.
     /// The enclave must check that the returned length is no more than `len`.
-    /// If `len` is `0` or end of stream is reached, `0` may be returned.
+    /// If `len` is `0`, this call should block until the stream is ready for
+    /// reading. If `len` is `0` or end of stream is reached, `0` may be
+    /// returned.
     ///
     /// The enclave may mix calls to [`read`](#method.read) and
     /// [`read_alloc`](#method.read_alloc).
@@ -330,7 +332,8 @@ impl Usercalls {
     /// `buf` must point to a buffer in userspace with a size of at least
     /// `len`. On a succesful return, the number of bytes written is returned.
     /// The enclave must check that the returned length is no more than `len`.
-    /// If `len` is `0` or the stream is closed, `0` may be returned.
+    /// If `len` is `0`, this call should block until the stream is ready for
+    /// writing. If `len` is `0` or the stream is closed, `0` may be returned.
     pub fn write(fd: Fd, buf: *const u8, len: usize) -> (Result, usize) { unimplemented!() }
 
     /// Flush stream `fd`, ensuring that all intermediately buffered contents


### PR DESCRIPTION
This matches Linux/Windows behavior