### PR TITLE
Fixed TCS permissions for Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/doc/SGXS.md
+++ b/doc/SGXS.md
@@ -25,6 +25,7 @@ if:
 - the offset of every EADD blob does not have the lower 12 bits set,
 - the offset of every EADD blob is higher than that of any previous EADD blob,
 - the offset of every EEXTEND blob does not have the lower 8 bits set,
+- the page permissions bits of every EADD blob representing a TCS page are not set.
 - the upper 52 bits of offsets of all EEXTEND blobs are equal to those of the
   preceding EADD blob, and
 - the lower 12 bits of offsets of all consecutive EEXTEND blobs are unique.

--- a/sgxs-loaders/src/enclaveapi/mod.rs
+++ b/sgxs-loaders/src/enclaveapi/mod.rs
@@ -133,11 +133,9 @@ impl EnclaveLoad for WinInnerLibrary {
         match PageType::try_from(eadd.secinfo.flags.page_type()) {
             Ok(PageType::Reg) => {}
             Ok(PageType::Tcs) => {
-                if !eadd.secinfo.flags.contains(SecinfoFlags::R) {
-                    return Err(Error::Add(ErrorKind::InvalidInput.into()));
-                }
-                // NOTE: For some reason the windows API needs the Read flag set but then removes it while calling EADD
-                flags |= PAGE_ENCLAVE_THREAD_CONTROL | PAGE_READWRITE;
+                // NOTE: For some reason the windows API needs the PAGE_READWRITE set
+                // but the sgx EADD instruction removes it
+                flags = PAGE_ENCLAVE_THREAD_CONTROL | PAGE_READWRITE;
             }
             _ => return Err(Error::Add(ErrorKind::InvalidInput.into())),
         }

--- a/sgxs/src/sgxs.rs
+++ b/sgxs/src/sgxs.rs
@@ -268,6 +268,8 @@ impl<'a, R: SgxsRead + 'a> SgxsRead for CanonicalSgxsReader<'a, R> {
                 if !self.got_ecreate
                     || (header.offset & 0xfff) != 0
                     || self.last_offset.map_or(false, |lo| header.offset <= lo)
+                    || (header.secinfo.flags.page_type() == PageType::Tcs as u8
+                    && header.secinfo.flags.intersects(SecinfoFlags::R|SecinfoFlags::W|SecinfoFlags::X))
                 {
                     return Err(Error::StreamNotCanonical.into());
                 }


### PR DESCRIPTION
Removed the wrong check in the `add` function in enclaveapi sgxs-loader
Added a check in CanonicalSgxsReader to ensure that the TCS Page does not have any page permission flags set

Closes #146 