### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/sgxs/src/sgxs.rs
+++ b/sgxs/src/sgxs.rs
@@ -467,7 +467,7 @@ impl<W: Write> SgxsWrite for W {
 
         let MeasuredData { chunks, reader } = data.into();
         let mut reader = reader.map(|r| r.chain(io::repeat(0)));
-        for (i, chunk) in chunks.into_iter().enumerate() {
+        for (i, chunk) in chunks.iter().enumerate() {
             let eext = MeasEExtend {
                 offset: offset + (i as u64 * 256),
             };


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.