### PR TITLE
Bump up versions for async runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "aesm-client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "byteorder",
  "failure",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-provider"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "byteorder",
  "dcap-ql",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-ql"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "byteorder",
  "dcap-ql-sys",
@@ -506,7 +506,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "enclave-runner"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "crossbeam",
  "failure",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "fortanix-sgx-tools"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aesm-client",
  "clap",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "report-test"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "enclave-runner",
  "failure",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs-tools"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aesm-client",
  "atty",

--- a/aesm-client/Cargo.toml
+++ b/aesm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesm-client"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -54,5 +54,5 @@ protoc-rust = "2.8.0" # MIT/Apache-2.0
 
 [dev-dependencies]
 sgx-isa = { version = "0.3.0", path = "../sgx-isa" }
-"report-test" = { version = "0.2.0", path = "../report-test" }
+"report-test" = { version = "0.3.0", path = "../report-test" }
 "sgxs-loaders" = { version = "0.2.0", path = "../sgxs-loaders" }

--- a/dcap-provider/Cargo.toml
+++ b/dcap-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-provider"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"
@@ -35,7 +35,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # Project dependencies
 "dcap-ql" = { version = "0.2.0", path = "../dcap-ql", features = ["link"] }
-"report-test" = { version = "0.2.0", path = "../report-test" }
+"report-test" = { version = "0.3.0", path = "../report-test" }
 
 # External dependencies
 byteorder = "1.1.0"        # Unlicense/MIT

--- a/dcap-ql/Cargo.toml
+++ b/dcap-ql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-ql"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -44,5 +44,5 @@ num-traits = "0.2"  # MIT/Apache-2.0
 serde = { version = "1.0.104", features = ["derive"], optional = true } # MIT/Apache-2.0
 
 [dev-dependencies]
-"report-test" = { version = "0.2.0", path = "../report-test" }
+"report-test" = { version = "0.3.0", path = "../report-test" }
 "sgxs" = { version = "0.7.0", path = "../sgxs" }

--- a/enclave-runner/Cargo.toml
+++ b/enclave-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runner"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/fortanix-sgx-tools/Cargo.toml
+++ b/fortanix-sgx-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortanix-sgx-tools"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -20,7 +20,7 @@ categories = ["development-tools::build-utils", "command-line-utilities"]
 # Project dependencies
 aesm-client = { version = "0.3.0", path = "../aesm-client", features = ["sgxs"] }
 sgxs-loaders = { version = "0.2.0", path = "../sgxs-loaders" }
-enclave-runner = { version = "0.2.0", path = "../enclave-runner" }
+enclave-runner = { version = "0.3.0", path = "../enclave-runner" }
 sgxs = { version = "0.7.0", path = "../sgxs" }
 sgx-isa = { version = "0.3.0", path = "../sgx-isa" }
 

--- a/report-test/Cargo.toml
+++ b/report-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "report-test"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -16,7 +16,7 @@ categories = ["development-tools"]
 
 [dependencies]
 # Project dependencies
-"enclave-runner" = { version = "0.2.0", path = "../enclave-runner" }
+"enclave-runner" = { version = "0.3.0", path = "../enclave-runner" }
 "sgxs" = { version = "0.7.0", path = "../sgxs" }
 "sgx-isa" = { version = "0.3.0", path = "../sgx-isa" }
 

--- a/sgxs-tools/Cargo.toml
+++ b/sgxs-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-tools"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -33,8 +33,8 @@ path = "src/sgx_detect/main.rs"
 "sgxs-loaders" = { version = "0.2.0", path = "../sgxs-loaders" }
 "aesm-client" = { version = "0.3.0", path = "../aesm-client", features = ["sgxs"] }
 "sgx-isa" = { version = "0.3.0", path = "../sgx-isa" }
-"report-test" = { version = "0.2.0", path = "../report-test" }
-"enclave-runner" = { version = "0.2.0", path = "../enclave-runner" }
+"report-test" = { version = "0.3.0", path = "../report-test" }
+"enclave-runner" = { version = "0.3.0", path = "../enclave-runner" }
 
 # External dependencies
 lazy_static = "1"                                # MIT/Apache-2.0


### PR DESCRIPTION
Here's the order for publishing on crates.io:

1. minor bumps:
    - `enclave-runner`
2. minor bumps:
    - `fortanix-sgx-tools`
    - `report-test`
3. minor bumps:
    - `sgxs-tools`
4. minor bumps:
    - `dcap-provider`
5. patch bumps:
    - `aesm-client`
    - `dcap-ql`