### PR TITLE
more flexible get_quote in aesm-client (fixes #116 and #113)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "aesm-client"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "byteorder",
  "failure",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "fortanix-sgx-tools"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aesm-client",
  "clap",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs-tools"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aesm-client",
  "atty",

--- a/aesm-client/Cargo.toml
+++ b/aesm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesm-client"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/aesm-client/src/imp/unix.rs
+++ b/aesm-client/src/imp/unix.rs
@@ -115,13 +115,13 @@ impl AesmClient {
         spid: Vec<u8>,
         sig_rl: Vec<u8>,
         quote_type: QuoteType,
-        nonce: [u8; 16],
+        nonce: Vec<u8>,
     ) -> Result<QuoteResult> {
         let mut req = Request_GetQuoteRequest::new();
         req.set_report(report);
         req.set_quote_type(quote_type.into());
         req.set_spid(spid);
-        req.set_nonce(nonce.to_vec());
+        req.set_nonce(nonce);
         req.set_buf_size(session.quote_buffer_size(&sig_rl));
         if sig_rl.len() != 0 {
             req.set_sig_rl(sig_rl);

--- a/aesm-client/src/imp/unix.rs
+++ b/aesm-client/src/imp/unix.rs
@@ -114,12 +114,14 @@ impl AesmClient {
         report: Vec<u8>,
         spid: Vec<u8>,
         sig_rl: Vec<u8>,
+        quote_type: QuoteType,
+        nonce: [u8; 16],
     ) -> Result<QuoteResult> {
         let mut req = Request_GetQuoteRequest::new();
         req.set_report(report);
-        req.set_quote_type(QuoteType::Linkable.into());
+        req.set_quote_type(quote_type.into());
         req.set_spid(spid);
-        req.set_nonce(vec![0; 16]); // TODO: caller-supplied nonce
+        req.set_nonce(nonce.to_vec());
         req.set_buf_size(session.quote_buffer_size(&sig_rl));
         if sig_rl.len() != 0 {
             req.set_sig_rl(sig_rl);

--- a/aesm-client/src/imp/windows.rs
+++ b/aesm-client/src/imp/windows.rs
@@ -117,7 +117,7 @@ impl AesmClient {
         spid: Vec<u8>,
         sig_rl: Vec<u8>,
         quote_type: QuoteType,
-        nonce: [u8; 16],
+        nonce: Vec<u8>,
     ) -> Result<QuoteResult> {
         let quote_buffer_size = session.quote_buffer_size(&sig_rl);
         let mut qe_report: Vec<u8> = vec![0; Report::UNPADDED_SIZE];
@@ -134,7 +134,7 @@ impl AesmClient {
                     report.as_ptr() as _,
                     quote_type.into(),
                     spid.as_ptr() as _,
-                    nonce.as_ptr() as _,
+                    &nonce[0],
                     sig_rl_in,
                     sig_rl_size_in as _,
                     qe_report.as_mut_ptr() as _,

--- a/aesm-client/src/imp/windows.rs
+++ b/aesm-client/src/imp/windows.rs
@@ -116,8 +116,9 @@ impl AesmClient {
         report: Vec<u8>,
         spid: Vec<u8>,
         sig_rl: Vec<u8>,
+        quote_type: QuoteType,
+        nonce: [u8; 16],
     ) -> Result<QuoteResult> {
-        let nonce = [0u8; 64];
         let quote_buffer_size = session.quote_buffer_size(&sig_rl);
         let mut qe_report: Vec<u8> = vec![0; Report::UNPADDED_SIZE];
         let mut quote: Vec<u8> = vec![0; quote_buffer_size as usize];
@@ -131,7 +132,7 @@ impl AesmClient {
             assert_eq!(spid.len(), 16);
             let error = (&self.library.get_quote)(
                     report.as_ptr() as _,
-                    QuoteType::Linkable.into(),
+                    quote_type.into(),
                     spid.as_ptr() as _,
                     nonce.as_ptr() as _,
                     sig_rl_in,

--- a/aesm-client/src/imp/windows.rs
+++ b/aesm-client/src/imp/windows.rs
@@ -130,6 +130,7 @@ impl AesmClient {
             };
             assert_eq!(qe_report.len(), Report::UNPADDED_SIZE);
             assert_eq!(spid.len(), 16);
+            assert_eq!(nonce.len(), 16);
             let error = (&self.library.get_quote)(
                     report.as_ptr() as _,
                     quote_type.into(),

--- a/aesm-client/src/lib.rs
+++ b/aesm-client/src/lib.rs
@@ -180,7 +180,7 @@ impl AesmClient {
         spid: Vec<u8>,
         sig_rl: Vec<u8>,
         quote_type: QuoteType,
-        nonce: [u8; 16],
+        nonce: Vec<u8>,
     ) -> Result<QuoteResult> {
         self.inner.get_quote(
             session,
@@ -349,6 +349,7 @@ mod tests {
     use super::*;
 
     const SPID_SIZE: usize = 16;
+    const NONCE_SIZE: usize = 16;
 
     #[test]
     fn test_init_quote() {
@@ -376,7 +377,7 @@ mod tests {
                 vec![0u8; SPID_SIZE],
                 vec![],
                 QuoteType::Linkable,
-                [0; 16],
+                vec![0u8; NONCE_SIZE],
             )
             .unwrap_err();
 

--- a/aesm-client/src/lib.rs
+++ b/aesm-client/src/lib.rs
@@ -179,12 +179,16 @@ impl AesmClient {
         report: Vec<u8>,
         spid: Vec<u8>,
         sig_rl: Vec<u8>,
+        quote_type: QuoteType,
+        nonce: [u8; 16],
     ) -> Result<QuoteResult> {
         self.inner.get_quote(
             session,
             report,
             spid,
             sig_rl,
+            quote_type,
+            nonce,
         )
     }
 
@@ -371,6 +375,8 @@ mod tests {
                 vec![0u8; Report::UNPADDED_SIZE],
                 vec![0u8; SPID_SIZE],
                 vec![],
+                QuoteType::Linkable,
+                [0; 16],
             )
             .unwrap_err();
 

--- a/aesm-client/tests/live_quote.rs
+++ b/aesm-client/tests/live_quote.rs
@@ -37,7 +37,7 @@ fn live_quote() {
             DUMMY_SPID.to_vec(),
             vec![],
             QuoteType::Linkable,
-            [0; 16],
+            [0; 16].to_vec(),
         )
         .expect("quote result");
 }

--- a/aesm-client/tests/live_quote.rs
+++ b/aesm-client/tests/live_quote.rs
@@ -10,7 +10,7 @@ extern crate sgx_isa;
 extern crate sgxs;
 extern crate sgxs_loaders;
 
-use aesm_client::AesmClient;
+use aesm_client::{AesmClient, QuoteType};
 use sgx_isa::Targetinfo;
 #[cfg(unix)]
 use sgxs_loaders::isgx::Device as IsgxDevice;
@@ -36,6 +36,8 @@ fn live_quote() {
             report.as_ref().to_owned(),
             DUMMY_SPID.to_vec(),
             vec![],
+            QuoteType::Linkable,
+            [0; 16],
         )
         .expect("quote result");
 }

--- a/fortanix-sgx-tools/Cargo.toml
+++ b/fortanix-sgx-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortanix-sgx-tools"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -18,7 +18,7 @@ categories = ["development-tools::build-utils", "command-line-utilities"]
 
 [dependencies]
 # Project dependencies
-aesm-client = { version = "0.3.0", path = "../aesm-client", features = ["sgxs"] }
+aesm-client = { version = "0.4.0", path = "../aesm-client", features = ["sgxs"] }
 sgxs-loaders = { version = "0.2.0", path = "../sgxs-loaders" }
 enclave-runner = { version = "0.3.0", path = "../enclave-runner" }
 sgxs = { version = "0.7.0", path = "../sgxs" }

--- a/sgxs-tools/Cargo.toml
+++ b/sgxs-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-tools"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -31,7 +31,7 @@ path = "src/sgx_detect/main.rs"
 # Project dependencies
 "sgxs" = { version = "0.7.0", path = "../sgxs", features = ["crypto-openssl"] }
 "sgxs-loaders" = { version = "0.2.0", path = "../sgxs-loaders" }
-"aesm-client" = { version = "0.3.0", path = "../aesm-client", features = ["sgxs"] }
+"aesm-client" = { version = "0.4.0", path = "../aesm-client", features = ["sgxs"] }
 "sgx-isa" = { version = "0.3.0", path = "../sgx-isa" }
 "report-test" = { version = "0.3.0", path = "../report-test" }
 "enclave-runner" = { version = "0.3.0", path = "../enclave-runner" }


### PR DESCRIPTION
- extended the `get_quote` function with quote type and nonce
- bumped aesm-client version to 0.4 (as function params changed)
and *-tools patch version (as nothing changed in them,
except for using a new version of aesm-client)