### PR TITLE
aesm-client: Add timeout values to send to quoting enclave for sgx

### DIFF
--- a/aesm-client/src/imp/aesm_protobuf/mod.rs
+++ b/aesm-client/src/imp/aesm_protobuf/mod.rs
@@ -10,10 +10,19 @@ use {
 };
 // FIXME: remove conditional compilation after resolving https://github.com/fortanix/rust-sgx/issues/31
 #[cfg(not(target_env = "sgx"))]
-use imp::{LOCAL_AESM_TIMEOUT_US, REMOTE_AESM_TIMEOUT_US};
-// FIXME: remove conditional compilation after resolving https://github.com/fortanix/rust-sgx/issues/31
-#[cfg(not(target_env = "sgx"))]
 use std::time::Duration;
+
+
+/// This timeout is an argument in AESM request protobufs.
+///
+/// This value should be used for requests that can be completed locally, i.e.
+/// without network interaction.
+pub(super) const LOCAL_AESM_TIMEOUT_US: u32 = 1_000_000;
+/// This timeout is an argument in AESM request protobufs.
+///
+/// This value should be used for requests that might need interaction with
+/// remote servers, such as provisioning EPID.
+pub(super) const REMOTE_AESM_TIMEOUT_US: u32 = 30_000_000;
 
 impl AesmClient {
     pub fn try_connect(&self) -> Result<()> {
@@ -47,10 +56,7 @@ impl AesmClient {
 
     /// Obtain target info from QE.
     pub fn init_quote(&self) -> Result<QuoteInfo> {
-        #[allow(unused_mut)]
         let mut req = Request_InitQuoteRequest::new();
-        // FIXME: remove conditional compilation after resolving https://github.com/fortanix/rust-sgx/issues/31
-        #[cfg(not(target_env = "sgx"))]
         req.set_timeout(LOCAL_AESM_TIMEOUT_US);
         let mut res = self.transact(req)?;
 
@@ -83,8 +89,6 @@ impl AesmClient {
         }
         req.set_qe_report(true);
 
-        // FIXME: remove conditional compilation after resolving https://github.com/fortanix/rust-sgx/issues/31
-        #[cfg(not(target_env = "sgx"))]
         req.set_timeout(REMOTE_AESM_TIMEOUT_US);
 
         let mut res = self.transact(req)?;

--- a/aesm-client/src/imp/unix.rs
+++ b/aesm-client/src/imp/unix.rs
@@ -11,19 +11,6 @@ pub use error::{AesmError, Error, Result};
 
 mod aesm_protobuf;
 
-
-/// This timeout is an argument in AESM request protobufs.
-///
-/// This value should be used for requests that can be completed locally, i.e.
-/// without network interaction.
-const LOCAL_AESM_TIMEOUT_US: u32 = 1_000_000;
-/// This timeout is an argument in AESM request protobufs.
-///
-/// This value should be used for requests that might need interaction with
-/// remote servers, such as provisioning EPID.
-const REMOTE_AESM_TIMEOUT_US: u32 = 30_000_000;
-
-
 #[cfg(feature = "sgxs")]
 use Request_GetLaunchTokenRequest;
 
@@ -64,8 +51,8 @@ impl AesmClient {
             &**AESM_SOCKET_ABSTRACT_PATH
         };
 
-        let sock = UnixStream::connect_timeout(path, Duration::from_micros(LOCAL_AESM_TIMEOUT_US as _))?;
-        let _ = sock.set_write_timeout(Some(Duration::from_micros(LOCAL_AESM_TIMEOUT_US as _)))?;
+        let sock = UnixStream::connect_timeout(path, Duration::from_micros(aesm_protobuf::LOCAL_AESM_TIMEOUT_US as _))?;
+        let _ = sock.set_write_timeout(Some(Duration::from_micros(aesm_protobuf::LOCAL_AESM_TIMEOUT_US as _)))?;
         Ok(sock)
     }
 
@@ -81,7 +68,7 @@ impl AesmClient {
         // The field in the request protobuf is called mr_signer, but it wants the modulus.
         req.set_mr_signer(sigstruct.modulus.to_vec());
         req.set_se_attributes(attributes.as_ref().to_vec());
-        req.set_timeout(REMOTE_AESM_TIMEOUT_US);
+        req.set_timeout(aesm_protobuf::REMOTE_AESM_TIMEOUT_US);
 
         let mut res = self.transact(req)?;
 

--- a/aesm-client/src/lib.rs
+++ b/aesm-client/src/lib.rs
@@ -14,7 +14,7 @@
 #![deny(warnings)]
 
 extern crate byteorder;
-extern crate failure;
+pub extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 #[macro_use]


### PR DESCRIPTION
Fixes bug where calls to aesm from sgx module hangs indefinitely

Also make imported failure crate public