### PR TITLE
Add strrchr to rs-libc

### DIFF
--- a/rs-libc/LICENSE
+++ b/rs-libc/LICENSE
@@ -12,9 +12,11 @@ Adapted from musl-libc (license below):
     src/c/intscan.c
     src/c/intscan.h
     src/c/memchr.c
+    src/c/memrchr.c
     src/c/stpcpy.c
     src/c/stpncpy.c
     src/c/strchr.c
+    src/c/strrchr.c
     src/c/strchrnul.c
     src/c/strcmp.c
     src/c/strcpy.c

--- a/rs-libc/src/c/memrchr.c
+++ b/rs-libc/src/c/memrchr.c
@@ -1,0 +1,11 @@
+#include <string.h>
+
+void *__memrchr(const void *m, int c, size_t n)
+{
+	const unsigned char *s = m;
+	c = (unsigned char)c;
+	while (n--) if (s[n]==c) return (void *)(s+n);
+	return 0;
+}
+
+weak_alias(__memrchr, memrchr);

--- a/rs-libc/src/c/strrchr.c
+++ b/rs-libc/src/c/strrchr.c
@@ -1,0 +1,9 @@
+#include <string.h>
+
+char *__memrchr(const char *, int, int);
+
+char *strrchr(const char *s, int c)
+{
+	return __memrchr(s, c, strlen(s) + 1);
+}
+


### PR DESCRIPTION
This is useful for compiling sqlite3. The functions were swiped from [musl](https://git.musl-libc.org/cgit/musl/tree/src/string/memrchr.c), like the rest of them.