### PR TITLE
Fix doc generation

### DIFF
--- a/doc/rust-std-edp-doc.patch
+++ b/doc/rust-std-edp-doc.patch
@@ -1,5 +1,5 @@
 diff --git a/src/liballoc/lib.rs b/src/liballoc/lib.rs
-index 63b3fbb..977ef16 100644
+index 5365c9d..14fef75 100644
 --- a/src/liballoc/lib.rs
 +++ b/src/liballoc/lib.rs
 @@ -1,3 +1,9 @@
@@ -12,19 +12,19 @@ index 63b3fbb..977ef16 100644
  //! # The Rust core allocation and collections library
  //!
  //! This library provides smart pointers and collections for managing
-@@ -52,7 +58,9 @@
-
+@@ -59,7 +65,9 @@
  #![allow(unused_attributes)]
  #![stable(feature = "alloc", since = "1.36.0")]
--#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
-+#![doc(html_logo_url = "https://edp.fortanix.com/img/docs/edp-logo.svg",
-+       html_favicon_url = "https://edp.fortanix.com/favicon.ico",
-+       html_root_url = "https://edp.fortanix.com/docs/api/",
-        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
-        test(no_crate_inject, attr(allow(unused_variables), deny(warnings))))]
- #![no_std]
+ #![doc(
+-    html_root_url = "https://doc.rust-lang.org/nightly/",
++    html_logo_url = "https://edp.fortanix.com/img/docs/edp-logo.svg",
++    html_favicon_url = "https://edp.fortanix.com/favicon.ico",
++    html_root_url = "https://edp.fortanix.com/docs/api/",
+     html_playground_url = "https://play.rust-lang.org/",
+     issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
+     test(no_crate_inject, attr(allow(unused_variables), deny(warnings)))
 diff --git a/src/libcore/lib.rs b/src/libcore/lib.rs
-index 63688e7..881e8f1 100644
+index 3b7929f..f3482a9 100644
 --- a/src/libcore/lib.rs
 +++ b/src/libcore/lib.rs
 @@ -1,3 +1,9 @@
@@ -39,17 +39,17 @@ index 63688e7..881e8f1 100644
  //! The Rust Core Library is the dependency-free[^free] foundation of [The
 @@ -51,7 +57,9 @@
  #![cfg(not(test))]
-
  #![stable(feature = "core", since = "1.6.0")]
--#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
-+#![doc(html_logo_url = "https://edp.fortanix.com/img/docs/edp-logo.svg",
-+       html_favicon_url = "https://edp.fortanix.com/favicon.ico",
-+       html_root_url = "https://edp.fortanix.com/docs/api/",
-        html_playground_url = "https://play.rust-lang.org/",
-        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
-        test(no_crate_inject, attr(deny(warnings))),
+ #![doc(
+-    html_root_url = "https://doc.rust-lang.org/nightly/",
++    html_logo_url = "https://edp.fortanix.com/img/docs/edp-logo.svg",
++    html_favicon_url = "https://edp.fortanix.com/favicon.ico",
++    html_root_url = "https://edp.fortanix.com/docs/api/",
+     html_playground_url = "https://play.rust-lang.org/",
+     issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
+     test(no_crate_inject, attr(deny(warnings))),
 diff --git a/src/libstd/lib.rs b/src/libstd/lib.rs
-index d11dee8..12d82d0 100644
+index ac07af5..f32927c 100644
 --- a/src/libstd/lib.rs
 +++ b/src/libstd/lib.rs
 @@ -1,3 +1,11 @@
@@ -64,14 +64,14 @@ index d11dee8..12d82d0 100644
  //! # The Rust Standard Library
  //!
  //! The Rust Standard Library is the foundation of portable Rust software, a
-@@ -196,7 +204,9 @@
- //! [primitive types]: ../book/ch03-02-data-types.html
-
+@@ -199,7 +207,9 @@
+ 
  #![stable(feature = "rust1", since = "1.0.0")]
--#![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
-+#![doc(html_logo_url = "https://edp.fortanix.com/img/docs/edp-logo.svg",
-+       html_favicon_url = "https://edp.fortanix.com/favicon.ico",
-+       html_root_url = "https://edp.fortanix.com/docs/api/",
-        html_playground_url = "https://play.rust-lang.org/",
-        issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
-        test(no_crate_inject, attr(deny(warnings))),
+ #![doc(
+-    html_root_url = "https://doc.rust-lang.org/nightly/",
++    html_logo_url = "https://edp.fortanix.com/img/docs/edp-logo.svg",
++    html_favicon_url = "https://edp.fortanix.com/favicon.ico",
++    html_root_url = "https://edp.fortanix.com/docs/api/",
+     html_playground_url = "https://play.rust-lang.org/",
+     issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
+     test(no_crate_inject, attr(deny(warnings))),

--- a/sgxs-tools/src/bin/isgx-pe2sgx.rs
+++ b/sgxs-tools/src/bin/isgx-pe2sgx.rs
@@ -419,7 +419,7 @@ impl<'a> LayoutInfo<'a> {
                     let secinfo = SecinfoTruncated {
                         flags: section_to_secinfo_flags(header) | PageType::Reg.into(),
                     };
-                    let mut splice = self.tls_splice(&mut data);
+                    let splice = self.tls_splice(&mut data);
                     self.write_pe_section(
                         &mut writer,
                         &mut splice[..].chain(&mut data),
@@ -572,7 +572,7 @@ impl<'data> PeHeader<'data> {
         })
     }
 
-    fn splice<'a>(&'a mut self) -> Box<Read + 'a> {
+    fn splice<'a>(&'a mut self) -> Box<dyn Read + 'a> {
         let data_ptr = &self.data[0] as *const _ as usize;
         let checksum_offset = (self.checksum as *const _ as usize)
             .checked_sub(data_ptr)


### PR DESCRIPTION
replaced rust-std-edp-doc.patch with a newer version

The doc generation failed because the patch could not be applied.