### PR TITLE
Bump dependents of sgxs-loaders

### DIFF
--- a/aesm-client/Cargo.toml
+++ b/aesm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesm-client"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/dcap-ql/Cargo.toml
+++ b/dcap-ql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-ql"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/dcap-retrieve-pckid/Cargo.toml
+++ b/dcap-retrieve-pckid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-retrieve-pckid"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/fortanix-sgx-tools/Cargo.toml
+++ b/fortanix-sgx-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortanix-sgx-tools"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/sgxs-tools/Cargo.toml
+++ b/sgxs-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-tools"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """


### PR DESCRIPTION
Based on this dependency graph generated with `cargo depgraph  --all-deps --focus sgxs-loaders | dot -Tpng > graph.png`:
![image](https://user-images.githubusercontent.com/20523291/94497803-2f54f900-01ad-11eb-8ba0-847805a952fc.png)
I have bumped the patch versions of all workspace members that directly depend on sgxs-loaders