### PR TITLE
Add KSS detection to sgx-detect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "sgx-isa"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bitflags 1.2.1",
  "mbedtls 0.5.3",

--- a/sgx-isa/Cargo.toml
+++ b/sgx-isa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgx-isa"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/sgx-isa/src/lib.rs
+++ b/sgx-isa/src/lib.rs
@@ -394,6 +394,8 @@ bitflags! {
         const MODE64BIT     = 0b0000_0100;
         const PROVISIONKEY  = 0b0001_0000;
         const EINITTOKENKEY = 0b0010_0000;
+        const CET           = 0b0100_0000;
+        const KSS           = 0b1000_0000;
     }
 }
 


### PR DESCRIPTION
Adds support to `sgx-detect` to determine if the platform supports KSS (ref #200)