### PR TITLE
Augusta SGX loader: map contiguous similar pages at once

### DIFF
--- a/sgxs-loaders/src/enclaveapi/mod.rs
+++ b/sgxs-loaders/src/enclaveapi/mod.rs
@@ -63,6 +63,7 @@ impl EinittokenError for Error {
 
 impl EnclaveLoad for WinInnerLibrary {
     type Error = Error;
+    type MapData = ();
 
     fn new(
         device: Arc<WinInnerLibrary>,
@@ -96,6 +97,7 @@ impl EnclaveLoad for WinInnerLibrary {
         } else {
             Ok(Mapping {
                 device,
+                mapdata: (),
                 tcss: vec![],
                 base: base as _,
                 size: ecreate.size,
@@ -171,7 +173,7 @@ impl EnclaveLoad for WinInnerLibrary {
     }
 
     fn init(
-        mapping: &Mapping<Self>,
+        mapping: &mut Mapping<Self>,
         sigstruct: &Sigstruct,
         einittoken: Option<&Einittoken>,
     ) -> Result<(), Self::Error> {

--- a/sgxs-loaders/src/sgx_enclave_common/mod.rs
+++ b/sgxs-loaders/src/sgx_enclave_common/mod.rs
@@ -127,6 +127,7 @@ impl EinittokenError for Error {
 
 impl EnclaveLoad for InnerLibrary {
     type Error = Error;
+    type MapData = ();
 
     fn new(
         device: Arc<InnerLibrary>,
@@ -161,6 +162,7 @@ impl EnclaveLoad for InnerLibrary {
         } else {
             Ok(Mapping {
                 device,
+                mapdata: (),
                 tcss: vec![],
                 base: base as _,
                 size: ecreate.size,
@@ -220,7 +222,7 @@ impl EnclaveLoad for InnerLibrary {
     }
 
     fn init(
-        mapping: &Mapping<Self>,
+        mapping: &mut Mapping<Self>,
         sigstruct: &Sigstruct,
         einittoken: Option<&Einittoken>,
     ) -> Result<(), Self::Error> {


### PR DESCRIPTION
Avoid running into the `/proc/sys/vm/max_map_count` limit by creating fewer larger mappings instead of mapping every page.

This unfortunately requires delaying the last `mmap` call to `einit` time, which is not great UX. This is the same as what Intel does in their SDK though.