### PR TITLE
add a CsrSigner trait to em-app

### DIFF
--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -13,7 +13,7 @@ keywords = [ "sgx" ]
 
 [dependencies]
 hyper = { version = "0.10", default-features = false }
-mbedtls = {version="0.5", default-features = false, features = ["sgx"]}
+mbedtls = { version="0.6", default-features = false, features = ["sgx"] }
 b64-ct = "0.1.0"
 serde_bytes = "0.10"
 serde_json = "1.0"

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "em-app"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["fortanix.com"]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
the CsrSigner trait is similar to ExternalKey, but instead of allowing signing of arbitrary messages, only signs CSRs.

a default implementation of CsrSigner is provided for anything that implements ExternalKey