### PR TITLE
Reverting version bump em-app

### DIFF
--- a/em-app/Cargo.lock
+++ b/em-app/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "em-app"
-version = "0.2.1"
+version = "0.2.0"
 dependencies = [
  "b64-ct",
  "em-node-agent-client",

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "em-app"
-version = "0.2.1"
+version = "0.2.0"
 authors = ["fortanix.com"]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
Commit https://github.com/fortanix/rust-sgx/pull/312/commits/edc4444f39cc7f709f7c80ba508d1a09c163d0c7 inadvertently bumped the version of `em-app`. This PR reverts that change. 