### PR TITLE
rs-libc: Fix build determinism

### DIFF
--- a/rs-libc/build.rs
+++ b/rs-libc/build.rs
@@ -34,14 +34,14 @@ fn main() {
     let mut build = cc::Build::new();
 
     #[cfg(unix)]
-    for path in read_dir(p_s).unwrap().filter_map(extension_filter("S")) {
+    for path in sorted(read_dir(p_s).unwrap().filter_map(extension_filter("S"))) {
         build.file(path);
     }
     #[cfg(windows)]
-    for path in read_dir(p_s).unwrap().filter_map(extension_filter("o")) {
+    for path in sorted(read_dir(p_s).unwrap().filter_map(extension_filter("o"))) {
         build.object(path);
     }
-    for path in read_dir(p_c).unwrap().filter_map(extension_filter("c")) {
+    for path in sorted(read_dir(p_c).unwrap().filter_map(extension_filter("c"))) {
         build.file(path);
     }
 
@@ -70,4 +70,10 @@ fn main() {
         }
 
     b.warnings(false).compile(name);
+}
+
+fn sorted<A: Ord, I: Iterator<Item=A>>(iterator: I) -> Vec<A> {
+    let mut items: Vec<_> = iterator.collect();
+    items.sort();
+    items
 }

--- a/rs-libc/build.rs
+++ b/rs-libc/build.rs
@@ -9,6 +9,7 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs::{read_dir, DirEntry};
 use std::path::PathBuf;
+use std::collections::BTreeSet;
 
 fn main() {
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();

--- a/rs-libc/build.rs
+++ b/rs-libc/build.rs
@@ -72,8 +72,6 @@ fn main() {
     b.warnings(false).compile(name);
 }
 
-fn sorted<A: Ord, I: Iterator<Item=A>>(iterator: I) -> Vec<A> {
-    let mut items: Vec<_> = iterator.collect();
-    items.sort();
-    items
+fn sorted<A: Ord, I: Iterator<Item=A>>(iterator: I) -> BTreeSet<A> {
+    iterator.collect()
 }


### PR DESCRIPTION
Currently the directory listing order in rs-libc's build.rs is non-deterministic, and this order is fed into the `cc` build directly, making the final binary artifact non-reproducible. This is because link-time relocation is dependent on the order in which inputs are specified.

In certain use-cases of SGX the attested measurement must be reproducible by third parties, otherwise a security audit of the enclave code cannot be tied to attestations.

The fix is to simply sort the listing.