### PR TITLE
Use remote instead of local timeout for init_quote() in aesm-client

### DIFF
--- a/aesm-client/Cargo.toml
+++ b/aesm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesm-client"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/aesm-client/src/imp/aesm_protobuf/mod.rs
+++ b/aesm-client/src/imp/aesm_protobuf/mod.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 ///
 /// This value should be used for requests that can be completed locally, i.e.
 /// without network interaction.
+#[allow(unused)]
 pub(super) const LOCAL_AESM_TIMEOUT_US: u32 = 1_000_000;
 /// This timeout is an argument in AESM request protobufs.
 ///
@@ -56,7 +57,7 @@ impl AesmClient {
 
     pub fn init_quote(&self) -> Result<QuoteInfo> {
         let mut req = Request_InitQuoteRequest::new();
-        req.set_timeout(LOCAL_AESM_TIMEOUT_US);
+        req.set_timeout(REMOTE_AESM_TIMEOUT_US);
         let mut res = self.transact(req)?;
 
         let (target_info, gid) = (res.take_targetInfo(), res.take_gid());

--- a/aesm-client/src/imp/aesm_protobuf/mod.rs
+++ b/aesm-client/src/imp/aesm_protobuf/mod.rs
@@ -15,14 +15,17 @@ use std::time::Duration;
 
 /// This timeout is an argument in AESM request protobufs.
 ///
-/// This value should be used for requests that can be completed locally, i.e.
-/// without network interaction.
+/// This value should be used for operations that can be completed locally, i.e.
+/// without network interaction. Only the `try_connect()` operation falls into this
+/// category.
 #[allow(unused)]
 pub(super) const LOCAL_AESM_TIMEOUT_US: u32 = 1_000_000;
 /// This timeout is an argument in AESM request protobufs.
 ///
-/// This value should be used for requests that might need interaction with
-/// remote servers, such as provisioning EPID.
+/// This value should be used for operations that might need interaction with
+/// remote servers. All AESM requests fall into this category, because they either
+/// always require interaction with a remote server or can trigger an initialization
+/// step that involves communication with a remote server.
 pub(super) const REMOTE_AESM_TIMEOUT_US: u32 = 30_000_000;
 
 impl AesmClient {

--- a/aesm-client/src/lib.rs
+++ b/aesm-client/src/lib.rs
@@ -144,7 +144,7 @@ fn quote_buffer_size(sig_rl: &[u8]) -> u32 {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct QuoteResult {
-    /// For Intel attestatations, the EPID signature from Intel QE.
+    /// For Intel attestations, the EPID signature from Intel QE.
     quote: Vec<u8>,
 
     /// SGX report (EREPORT) from the Intel quoting enclave for the quote.


### PR DESCRIPTION
This should fix #179.

Quoting from that issue:
> When aesmd is still unprovisioned, AesmClient::init_quote() triggers EPID provisioning, and in this case the client returns an AesmCommunication error.