### PR TITLE
rs-libc: resolve symlinks in build script

### DIFF
--- a/rs-libc/build.rs
+++ b/rs-libc/build.rs
@@ -21,12 +21,9 @@ fn main() {
 
     let extension_filter = |ext| {
         move |f: Result<DirEntry, _>| {
-            let f = f.unwrap();
-            if f.file_type().unwrap().is_file() {
-                let path = f.path();
-                if path.extension().and_then(OsStr::to_str) == Some(ext) {
-                    return Some(path);
-                }
+            let path = f.unwrap().path();
+            if path.is_file() && path.extension().and_then(OsStr::to_str) == Some(ext) {
+                return Some(path);
             }
             None
         }


### PR DESCRIPTION
Hello, for our build system we use `nix` specifically `naersk` (https://github.com/nmattia/naersk).
During the building process dependencies are linked into a build dir, not copied.
The `rs-libc` build script explicitly checks that the dir entries are files, so symlinks get ignored.
One possible solutions for our use case would be to remove this check.