### PR TITLE
Avoiding use of LLVM reserved register `rbx`

### DIFF
--- a/enclave-runner/src/tcs.rs
+++ b/enclave-runner/src/tcs.rs
@@ -184,10 +184,12 @@ pub(crate) fn coenter<T: Tcs>(
         } else {
             asm!("
                     lea 1f(%rip), %rcx // set SGX AEP
+                    xchg {0}, %rbx
 1:                  enclu
+                    xchg %rbx, {0}
                 ",
+                inout(reg) tcs.address() => _, // rbx is used internally by LLVM and cannot be used as an operand for inline asm (#84658)
                 inout("eax") Enclu::EEnter as u32 => sgx_result,
-                inout("rbx") tcs.address() => _,
                 out("rcx") _,
                 inout("rdx") p3,
                 inout("rdi") p1,


### PR DESCRIPTION
LLVM reserves register `rbx` in inline assembly (issue: #335). This PR avoids the use of this register until [rust-lang issue 85056](https://github.com/rust-lang/rust/issues/85056) is merged