### PR TITLE
Closing `TcpListeners` in runner

### DIFF
--- a/fortanix-vme/ci-common.sh
+++ b/fortanix-vme/ci-common.sh
@@ -110,7 +110,7 @@ function cargo_test {
         fi
 	RUST_BACKTRACE=full ${elf} -- --nocapture > ${out} 2> ${err}
 
-        out=$(cat ${out} | grep -v "#" || true)
+        out=$(cat ${out} | grep -v "^#" || true)
         expected=$(cat ./out.expected)
 
         if [ "${out}" == "${expected}" ]; then

--- a/fortanix-vme/fortanix-vme-abi/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-abi/src/lib.rs
@@ -26,7 +26,10 @@ pub enum Request {
     Accept {
         /// The Vsock port the enclave is listening on
         enclave_port: u32,
-    }
+    },
+    Close {
+        enclave_port: u32,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -87,7 +90,8 @@ pub enum Response {
         /// The vsock port number the runner will connect to the enclave in order to forward the
         /// incoming connection
         proxy_port: u32,
-    }
+    },
+    Closed,
 }
 
 #[cfg(test)]

--- a/fortanix-vme/fortanix-vme-runner/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-runner/src/lib.rs
@@ -424,7 +424,7 @@ impl Server {
             // Close `TcpListener`
             drop(listener);
         } else {
-            // Info not found, possibly not a listener socket
+            println!("[warning] Can't close the connection as it can't be located.");
         }
         let response = Response::Closed;
         Self::log_communication(

--- a/fortanix-vme/tests/incoming_connection/out.expected
+++ b/fortanix-vme/tests/incoming_connection/out.expected
@@ -1,6 +1,15 @@
-Bind to socket to 3400
+Server run #1
+Bind TCP socket to port 3400
 Listening for incoming connections...
 Waiting for connection 1
 Connection 1: Connected
 Waiting for connection 2
 Connection 2: Connected
+Server run #2
+Bind TCP socket to port 3400
+Listening for incoming connections...
+Waiting for connection 1
+Connection 1: Connected
+Waiting for connection 2
+Connection 2: Connected
+Bye bye

--- a/fortanix-vme/tests/incoming_connection/src/main.rs
+++ b/fortanix-vme/tests/incoming_connection/src/main.rs
@@ -1,8 +1,8 @@
 use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener};
 use std::io::{Read, Write};
 
-fn main() {
-    println!("Bind to socket to 3400");
+fn server_run() {
+    println!("Bind TCP socket to port 3400");
     let listener = TcpListener::bind("127.0.0.1:3400").expect("Bind failed");
     assert_eq!(listener.local_addr().unwrap(), SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 3400));
 
@@ -27,4 +27,12 @@ fn main() {
             Err(e)              => println!("Connection {}: Accept failed: {:?}", id, e),
         }
     }
+}
+
+fn main() {
+    for run in 1..=2 {
+        println!("Server run #{}", run);
+        server_run()
+    }
+    println!("Bye bye");
 }

--- a/fortanix-vme/tests/incoming_connection/test_interaction.sh
+++ b/fortanix-vme/tests/incoming_connection/test_interaction.sh
@@ -4,5 +4,5 @@ while [ true ]
 do
   echo "Interacting with test"
   timeout 1s curl -k localhost:3400 || true
-  sleep 20s
+  sleep 5s
 done


### PR DESCRIPTION
When a Nitro enclave closes a `TcpListener`, sockets in the runner need to be cleaned up as well. This PR introduces the required changes to the ABI and runner.