### PR TITLE
Update documentation patch to new rust folder structure

### DIFF
--- a/doc/rust-std-edp-doc.patch
+++ b/doc/rust-std-edp-doc.patch
@@ -1,7 +1,7 @@
-diff --git a/src/liballoc/lib.rs b/src/liballoc/lib.rs
-index 5365c9d..14fef75 100644
---- a/src/liballoc/lib.rs
-+++ b/src/liballoc/lib.rs
+diff --git a/library/alloc/src/lib.rs b/library/alloc/src/lib.rs
+index 5dda7bfa37c..339f1a3036b 100644
+--- a/library/alloc/src/lib.rs
++++ b/library/alloc/src/lib.rs
 @@ -1,3 +1,9 @@
 +//! **You are viewing the documentation of the Rust core allocation and
 +//! collections library as a part of the Fortanix Rust EDP.** There are no
@@ -12,21 +12,20 @@ index 5365c9d..14fef75 100644
  //! # The Rust core allocation and collections library
  //!
  //! This library provides smart pointers and collections for managing
-@@ -59,7 +65,9 @@
+@@ -63,6 +69,9 @@
  #![allow(unused_attributes)]
  #![stable(feature = "alloc", since = "1.36.0")]
  #![doc(
--    html_root_url = "https://doc.rust-lang.org/nightly/",
 +    html_logo_url = "https://edp.fortanix.com/img/docs/edp-logo.svg",
 +    html_favicon_url = "https://edp.fortanix.com/favicon.ico",
 +    html_root_url = "https://edp.fortanix.com/docs/api/",
      html_playground_url = "https://play.rust-lang.org/",
      issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
      test(no_crate_inject, attr(allow(unused_variables), deny(warnings)))
-diff --git a/src/libcore/lib.rs b/src/libcore/lib.rs
-index 3b7929f..f3482a9 100644
---- a/src/libcore/lib.rs
-+++ b/src/libcore/lib.rs
+diff --git a/library/core/src/lib.rs b/library/core/src/lib.rs
+index 4b16a269f2d..3d0b4ae9ca5 100644
+--- a/library/core/src/lib.rs
++++ b/library/core/src/lib.rs
 @@ -1,3 +1,9 @@
 +//! **You are viewing the documentation of the Rust core library as a part of
 +//! the Fortanix Rust EDP.** There are no changes compared to the normal the
@@ -37,21 +36,20 @@ index 3b7929f..f3482a9 100644
  //! # The Rust Core Library
  //!
  //! The Rust Core Library is the dependency-free[^free] foundation of [The
-@@ -51,7 +57,9 @@
- #![cfg(not(test))]
+@@ -55,6 +61,9 @@
+ #![cfg(any(not(feature = "miri-test-libstd"), test, doctest))]
  #![stable(feature = "core", since = "1.6.0")]
  #![doc(
--    html_root_url = "https://doc.rust-lang.org/nightly/",
++    html_root_url = "https://edp.fortanix.com/docs/api/",
 +    html_logo_url = "https://edp.fortanix.com/img/docs/edp-logo.svg",
 +    html_favicon_url = "https://edp.fortanix.com/favicon.ico",
-+    html_root_url = "https://edp.fortanix.com/docs/api/",
      html_playground_url = "https://play.rust-lang.org/",
      issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
      test(no_crate_inject, attr(deny(warnings))),
-diff --git a/src/libstd/lib.rs b/src/libstd/lib.rs
-index ac07af5..f32927c 100644
---- a/src/libstd/lib.rs
-+++ b/src/libstd/lib.rs
+diff --git a/library/std/src/lib.rs b/library/std/src/lib.rs
+index c2243b25953..2af4966f0cd 100644
+--- a/library/std/src/lib.rs
++++ b/library/std/src/lib.rs
 @@ -1,3 +1,11 @@
 +//! **You are viewing the documentation of the Rust standard library as a part
 +//! of the Fortanix Rust EDP.** The only changes compared to the normal Rust
@@ -64,14 +62,13 @@ index ac07af5..f32927c 100644
  //! # The Rust Standard Library
  //!
  //! The Rust Standard Library is the foundation of portable Rust software, a
-@@ -199,7 +207,9 @@
- 
- #![stable(feature = "rust1", since = "1.0.0")]
+@@ -190,6 +198,9 @@
+ #![cfg_attr(not(feature = "restricted-std"), stable(feature = "rust1", since = "1.0.0"))]
+ #![cfg_attr(feature = "restricted-std", unstable(feature = "restricted_std", issue = "none"))]
  #![doc(
--    html_root_url = "https://doc.rust-lang.org/nightly/",
++    html_root_url = "https://edp.fortanix.com/docs/api/",
 +    html_logo_url = "https://edp.fortanix.com/img/docs/edp-logo.svg",
 +    html_favicon_url = "https://edp.fortanix.com/favicon.ico",
-+    html_root_url = "https://edp.fortanix.com/docs/api/",
      html_playground_url = "https://play.rust-lang.org/",
      issue_tracker_base_url = "https://github.com/rust-lang/rust/issues/",
      test(no_crate_inject, attr(deny(warnings))),


### PR DESCRIPTION
The directory structure of the rust compiler changed upstream. We apply a patch before generating documentation for the sgx target. This patch needs an update to reflect the new directory structure.