### PR TITLE
Storing peer address

### DIFF
--- a/fortanix-vme/fortanix-vme-abi/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-abi/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![no_std]
 extern crate alloc;
 #[cfg(feature="std")]

--- a/fortanix-vme/fortanix-vme-abi/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-abi/src/lib.rs
@@ -72,8 +72,8 @@ pub enum Response {
         peer: Addr,
     },
     Bound {
-        /// The TCP port the parent VM is listening on
-        port: u16,
+        /// The local TCP address the parent VM is listening on
+        local: Addr,
         /// The id used to identify the listener. It can be used for subsequent calls (e.g., to
         /// accept new incoming connections)
         fd: i32,

--- a/fortanix-vme/fortanix-vme-abi/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-abi/src/lib.rs
@@ -68,6 +68,8 @@ pub enum Response {
     Connected {
         /// The vsock port the proxy is listening on for an incoming connection
         proxy_port: u32,
+        /// The address of the remote party
+        peer: Addr,
     },
     Bound {
         /// The TCP port the parent VM is listening on

--- a/fortanix-vme/fortanix-vme-runner/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-runner/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use fnv::FnvHashMap;
 use nix::sys::select::{select, FdSet};
 use serde_cbor;

--- a/fortanix-vme/fortanix-vme-runner/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-runner/src/lib.rs
@@ -188,6 +188,7 @@ impl Server {
         // Notify the enclave on which port her proxy is listening on
         let response = Response::Connected {
             proxy_port: proxy_server_port,
+            peer: remote_socket.peer_addr()?.into(),
         };
         Self::log_communication(
             "runner",

--- a/fortanix-vme/fortanix-vme-runner/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-runner/src/lib.rs
@@ -245,9 +245,9 @@ impl Server {
     fn handle_request_bind(&self, addr: &String, enclave_port: u32, enclave: &mut VsockStream) -> Result<(), IoError> {
         let cid: u32 = enclave.peer().unwrap().parse().unwrap_or(vsock::VMADDR_CID_HYPERVISOR);
         let listener = TcpListener::bind(addr)?;
-        let port = listener.local_addr().map(|addr| addr.port())?;
+        let local = listener.local_addr()?.into();
         let fd = self.add_listener_info(ListenerInfo{ listener, enclave_cid: cid, enclave_port });
-        let response = Response::Bound{ port, fd };
+        let response = Response::Bound{ local, fd };
         Self::log_communication(
             "runner",
             enclave.local_port().unwrap_or_default(),

--- a/fortanix-vme/tests/incoming_connection/src/main.rs
+++ b/fortanix-vme/tests/incoming_connection/src/main.rs
@@ -1,10 +1,10 @@
-use std::net::{Shutdown, TcpListener};
+use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener};
 use std::io::{Read, Write};
 
 fn main() {
     println!("Bind to socket to 3400");
     let listener = TcpListener::bind("127.0.0.1:3400").expect("Bind failed");
-//    println!("# Listening on: {}", listener.local_addr().unwrap().port());
+    assert_eq!(listener.local_addr().unwrap(), SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 3400));
 
     println!("Listening for incoming connections...");
     for id in 1..3 {
@@ -12,6 +12,7 @@ fn main() {
         match listener.accept() {
             Ok((mut stream, addr)) => {
                 println!("# addr = {:?}", addr);
+                assert_eq!(stream.peer_addr().unwrap().ip(), Ipv4Addr::new(127, 0, 0, 1));
                 println!("Connection {}: Connected", id);
                 let mut buff_in = [0u8; 4192];
                 let n = stream.read(&mut buff_in).unwrap();


### PR DESCRIPTION
`TcpStream`s and `TcpListener`s need to be able to return the address of the remote party. This PR:
* Makes the runner return the peer address when a new connection is established
* Returns the full address (not just the port) when a `Bound` response is send to the enclave
* Adds a test for this functionality
* Adds a statement ensuring warnings are treated as errors