### PR TITLE
Pass local addr of connections to the enclave

### DIFF
--- a/fortanix-vme/fortanix-vme-abi/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-abi/src/lib.rs
@@ -81,6 +81,8 @@ pub enum Response {
         fd: i32,
     },
     IncomingConnection {
+        /// The local address (as used by the runner)
+        local: Addr,
         /// The address of the remote party
         peer: Addr,
         /// The vsock port number the runner will connect to the enclave in order to forward the

--- a/fortanix-vme/fortanix-vme-abi/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-abi/src/lib.rs
@@ -103,6 +103,7 @@ mod test {
         if let Addr::IPv4 { port, ip } = sock_addr.into() {
             assert_eq!(IpAddr::from(ip), sock_addr.ip());   
             assert_eq!(port, sock_addr.port());
+            assert_eq!(port, 4567);
         } else {
             panic!("Not IPv4")
         }

--- a/fortanix-vme/fortanix-vme-abi/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-abi/src/lib.rs
@@ -68,6 +68,8 @@ pub enum Response {
     Connected {
         /// The vsock port the proxy is listening on for an incoming connection
         proxy_port: u32,
+        /// The local address (as used by the runner)
+        local: Addr,
         /// The address of the remote party
         peer: Addr,
     },

--- a/fortanix-vme/fortanix-vme-runner/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-runner/src/lib.rs
@@ -188,6 +188,7 @@ impl Server {
         // Notify the enclave on which port her proxy is listening on
         let response = Response::Connected {
             proxy_port: proxy_server_port,
+            local: remote_socket.local_addr()?.into(),
             peer: remote_socket.peer_addr()?.into(),
         };
         Self::log_communication(

--- a/fortanix-vme/fortanix-vme-runner/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-runner/src/lib.rs
@@ -270,6 +270,7 @@ impl Server {
             Ok((mut conn, peer)) => {
                 let vsock = Vsock::new::<Std>()?;
                 let response = Response::IncomingConnection{
+                    local: conn.local_addr()?.into(),
                     peer: peer.into(),
                     proxy_port: vsock.addr::<Std>()?.port(),
                 };

--- a/fortanix-vme/tests/incoming_connection/src/main.rs
+++ b/fortanix-vme/tests/incoming_connection/src/main.rs
@@ -13,6 +13,9 @@ fn main() {
             Ok((mut stream, addr)) => {
                 println!("# addr = {:?}", addr);
                 assert_eq!(stream.peer_addr().unwrap().ip(), Ipv4Addr::new(127, 0, 0, 1));
+                assert!(stream.peer_addr().unwrap().port() != 3400);
+                assert_eq!(stream.local_addr().unwrap().ip(), Ipv4Addr::new(127, 0, 0, 1));
+                assert_eq!(stream.local_addr().unwrap().port(), 3400);
                 println!("Connection {}: Connected", id);
                 let mut buff_in = [0u8; 4192];
                 let n = stream.read(&mut buff_in).unwrap();

--- a/fortanix-vme/tests/outgoing_connection/src/main.rs
+++ b/fortanix-vme/tests/outgoing_connection/src/main.rs
@@ -1,8 +1,12 @@
-use std::net::TcpStream;
+use std::net::{Ipv4Addr, TcpStream};
 use std::io::{Read, Write};
 
 fn main() {
     let mut socket = TcpStream::connect(format!("google.com:80")).unwrap();
+    // `socket.local_addr()` may return the actual local IP address, not 127.0.0.1
+    assert!(socket.local_addr().unwrap().port() != 80);
+    assert!(socket.peer_addr().unwrap().ip() != Ipv4Addr::new(127, 0, 0, 1));
+    assert_eq!(socket.peer_addr().unwrap().port(), 80);
     socket.write(b"GET / HTTP/1.1\n\n").unwrap();
     socket.flush().unwrap();
     let mut page = [0; 4192];


### PR DESCRIPTION
When handling incoming and outgoing connections, the local address of the TCP connection as used in the runner needs to be passed to the enclave so it can hide the fact from users that the connection is being proxied.