### PR TITLE
[PLAT-388] Bugfix `ftxvme-elf2eif`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
+name = "hello_world"
+version = "0.1.0"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "fortanix-vme/eif-tools",
     "fortanix-vme/fortanix-vme-abi",
     "fortanix-vme/fortanix-vme-runner",
+    "fortanix-vme/tests/hello_world",
     "fortanix-vme/tests/outgoing_connection",
     "fortanix-vme/tests/incoming_connection",
     "fortanix-vme/tests/iron",

--- a/fortanix-vme/eif-tools/src/bin/ftxvme-elf2eif.rs
+++ b/fortanix-vme/eif-tools/src/bin/ftxvme-elf2eif.rs
@@ -16,7 +16,7 @@ fn setup_docker_dir(elf_path: &str) -> Result<TempDir> {
     const DOCKERFILE: &str = "
         FROM scratch
         COPY enclave .
-        CMD ./enclave
+        CMD [\"./enclave\"]
     ";
     info!("Setting up docker directory");
     let docker_dir = TempDir::new("elf2eif_docker_dir")?;

--- a/fortanix-vme/eif-tools/src/bin/ftxvme-elf2eif.rs
+++ b/fortanix-vme/eif-tools/src/bin/ftxvme-elf2eif.rs
@@ -79,7 +79,7 @@ fn main() {
     let mut logger = env_logger::Builder::from_default_env();
     let logger = logger.format(|buf, record| writeln!(buf, "{}", record.args()));
     if verbose {
-        logger.filter_level(LevelFilter::Info).init();
+        logger.filter_level(LevelFilter::Debug).init();
     } else {
         logger.filter_level(LevelFilter::Error).init();
     }

--- a/fortanix-vme/tests/hello_world/Cargo.toml
+++ b/fortanix-vme/tests/hello_world/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "hello_world"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/fortanix-vme/tests/hello_world/src/main.rs
+++ b/fortanix-vme/tests/hello_world/src/main.rs
@@ -1,0 +1,10 @@
+use std::{thread, time};
+
+fn main() {
+    for i in 0..30 {
+        println!("{}: Hello, world!", i);
+        thread::sleep(time::Duration::from_secs(1));
+    }
+
+    println!("Byte bye!");
+}

--- a/fortanix-vme/tests/outgoing_connection/src/main.rs
+++ b/fortanix-vme/tests/outgoing_connection/src/main.rs
@@ -2,6 +2,7 @@ use std::net::{Ipv4Addr, TcpStream};
 use std::io::{Read, Write};
 
 fn main() {
+    println!("# Running outgoing connection test");
     let mut socket = TcpStream::connect(format!("google.com:80")).unwrap();
     // `socket.local_addr()` may return the actual local IP address, not 127.0.0.1
     assert!(socket.local_addr().unwrap().port() != 80);


### PR DESCRIPTION
The `ftxvme-elf2eif` used to generate eif files based on the `scratch` Docker image. That is causing problems for Nitro enclaves. Reverted back to the `alpine` image for now. CI has also been modified to facilitate easier testing in the future.