### PR TITLE
[PLAT-345] Refactoring keeping track of `TcpListeners`

### DIFF
--- a/fortanix-vme/fortanix-vme-abi/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-abi/src/lib.rs
@@ -19,11 +19,13 @@ pub enum Request {
     Bind {
         /// The address the listen to in the parent VM
         addr: String,
-        /// The port the enclave is listening on to receive connections from the parent VM
+        /// The port the enclave is listening on to receive connections from the parent VM. This
+        /// port will also be used to reference the connection
         enclave_port: u32,
     },
     Accept {
-        fd: i32,
+        /// The Vsock port the enclave is listening on
+        enclave_port: u32,
     }
 }
 
@@ -76,9 +78,6 @@ pub enum Response {
     Bound {
         /// The local TCP address the parent VM is listening on
         local: Addr,
-        /// The id used to identify the listener. It can be used for subsequent calls (e.g., to
-        /// accept new incoming connections)
-        fd: i32,
     },
     IncomingConnection {
         /// The local address (as used by the runner)


### PR DESCRIPTION
`TcpListeners` are being stored by the stdlib in a list together with the file descriptor used for them in the runner. That is suboptimal. A recent change enabled storing additional data in the `Socket`. That enables to get rid of this linked list. However, for that to work we need to reference `TcpListeners` with the port they are bound to, not their file descriptor in the runner. This PR performs the required interface changes.