### PR TITLE
[PLAT-396] Refactor threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "vsock"
 version = "0.2.4"
-source = "git+https://github.com/fortanix/vsock-rs.git?branch=fortanixvme#8c0a6b75e9e0c8f2ce68ad4b7b6d6898852810e7"
+source = "git+https://github.com/fortanix/vsock-rs.git?branch=fortanixvme#95834efa8f54a3c9c07544de8a561c028bd4fbcb"
 dependencies = [
  "getrandom 0.2.3",
  "libc",

--- a/fortanix-vme/fortanix-vme-runner/src/main.rs
+++ b/fortanix-vme/fortanix-vme-runner/src/main.rs
@@ -4,7 +4,7 @@ use std::io::ErrorKind;
 
 fn main() {
     match Server::run(SERVER_PORT) {
-        Ok((server_thread, _port))                   => server_thread.join().expect("Server panicked"),
+        Ok(handle)                                   => { handle.join().unwrap(); },
         Err(e) if e.kind() == ErrorKind::AddrInUse   => println!("Server failed. Do you already have a runner running on vsock port {}? (Error: {:?})", SERVER_PORT, e),
         Err(e)                                       => println!("Server failed. Error: {:?}", e),
     }


### PR DESCRIPTION
This PR improves on two key areas:
- Information about TCP connections are stored in a hashmap, similar to how information about TCP server sockets is tracked. This will enable this information to be requested from the enclave in a subsequent PR
- The way how connections are proxied, is modified. Instead of starting another thread per TCP connection, a single proxy thread is started. It iterates over all TCP connections and exchanges message once for each connection. When no connections are currently available, the thread yields its CPU time.