### PR TITLE
Switch to stable asm!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,36 +26,32 @@ matrix:
             - clang-11
             - musl-tools
       rust:
-        - nightly-2021-12-15
+        - stable
       env:
         - RUST_BACKTRACE=1
         - CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
         - CC_x86_64_fortanix_unknown_sgx=clang-11
       before_script:
         - rustup target add x86_64-fortanix-unknown-sgx x86_64-unknown-linux-musl
+        - rustup toolchain add nightly
+        - rustup target add x86_64-fortanix-unknown-sgx --toolchain nightly
       script:
         - cargo test --verbose --locked --all --exclude sgxs-loaders && [ "$(echo $(nm -D target/debug/sgx-detect|grep __vdso_sgx_enter_enclave))" = "w __vdso_sgx_enter_enclave" ]
-        - cargo test --verbose --locked -p sgx-isa --features sgxstd --target x86_64-fortanix-unknown-sgx --no-run
         - cargo test --verbose --locked -p sgxs-tools --features pe2sgxs --bin isgx-pe2sgx
         - cargo test --verbose --locked -p dcap-ql --features link
         - cargo test --verbose --locked -p dcap-ql --features verify
-        - cargo build --verbose --locked -p aesm-client --target=x86_64-fortanix-unknown-sgx
-        - cargo build --verbose --locked -p aesm-client --target=x86_64-fortanix-unknown-sgx --features sgx-isa/sgxstd
-        - cargo test --locked -p nitro-attestation-verify
+        # uses backtrace, which still requires nightly on SGX
+        - cargo +nightly build --verbose --locked -p aesm-client --target=x86_64-fortanix-unknown-sgx
+        # uses sgxstd feature
+        - cargo +nightly build --verbose --locked -p aesm-client --target=x86_64-fortanix-unknown-sgx --features sgx-isa/sgxstd
+        - cargo +nightly test --verbose --locked -p sgx-isa --features sgxstd --target x86_64-fortanix-unknown-sgx --no-run
         # Unfortunately running `faketime '2021-09-10 11:00:00 GMT' cargo test -p nitro-attestation-verify` causes a segmentation
         #  fault while compiling. We only execute `faketime` during the tests
-        - cargo test --locked -p nitro-attestation-verify --no-run && faketime '2021-09-08 11:00:00 GMT' $(find ./target/debug/deps -name "nitro_attestation_verify*" -executable)
-        - cargo test --locked -p nitro-attestation-verify --no-run && faketime '2021-09-10 11:00:00 GMT' $(find ./target/debug/deps -name "nitro_attestation_verify*" -executable)
+        #- cargo test --locked -p nitro-attestation-verify --no-run && faketime '2021-09-08 11:00:00 GMT' cargo test --locked -p nitro-attestation-verify --lib
+        - cargo test --locked -p nitro-attestation-verify --no-run && faketime '2021-09-10 11:00:00 GMT' cargo test --locked -p nitro-attestation-verify --lib
         # NOTE: linking glibc version of OpenSSL with musl binary.
         # Unlikely to produce a working binary, but at least the build succeeds.
         - mkdir -p /tmp/muslinclude && ln -sf /usr/include/x86_64-linux-gnu/openssl /tmp/muslinclude/openssl && PKG_CONFIG_ALLOW_CROSS=1 CFLAGS=-I/tmp/muslinclude cargo build --locked -p fortanix-sgx-tools --target x86_64-unknown-linux-musl
-        - cargo build --verbose --locked -p em-app --target=x86_64-fortanix-unknown-sgx
-        - cargo build --verbose --locked -p em-app --target=x86_64-unknown-linux-gnu
-        - cargo build --verbose --locked -p em-app --target=x86_64-unknown-linux-musl
-        - cargo build --verbose --locked -p get-certificate --target=x86_64-fortanix-unknown-sgx
-        - cargo build --verbose --locked -p get-certificate --target=x86_64-unknown-linux-gnu
-        - cargo build --verbose --locked -p get-certificate --target=x86_64-unknown-linux-musl
-        - cargo build --verbose --locked -p harmonize --target=x86_64-fortanix-unknown-sgx
-        - cargo build --verbose --locked -p harmonize --target=x86_64-unknown-linux-gnu
-        - cargo build --verbose --locked -p harmonize --target=x86_64-unknown-linux-musl
+        - cargo build --verbose --locked -p em-app -p get-certificate -p harmonize --target=x86_64-unknown-linux-musl
+        - cargo build --verbose --locked -p em-app -p get-certificate -p harmonize --target=x86_64-fortanix-unknown-sgx
         - ./doc/generate-api-docs.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
  "protobuf",
  "protoc-rust",
  "report-test",
- "sgx-isa 0.3.3",
+ "sgx-isa",
  "sgxs",
  "sgxs-loaders",
  "unix_socket2",
@@ -667,7 +667,7 @@ dependencies = [
  "report-test",
  "serde",
  "serde_json",
- "sgx-isa 0.3.3",
+ "sgx-isa",
  "sgxs",
  "sgxs-loaders",
  "yasna 0.3.2",
@@ -679,7 +679,7 @@ version = "0.2.0"
 dependencies = [
  "num-derive 0.2.5",
  "num-traits",
- "sgx-isa 0.3.3",
+ "sgx-isa",
 ]
 
 [[package]]
@@ -689,7 +689,7 @@ dependencies = [
  "aesm-client",
  "dcap-ql",
  "report-test",
- "sgx-isa 0.3.3",
+ "sgx-isa",
  "sgxs-loaders",
 ]
 
@@ -809,8 +809,8 @@ dependencies = [
  "serde_bytes",
  "serde_derive 1.0.132",
  "serde_json",
- "sgx-isa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_pkix 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx-isa",
+ "sgx_pkix",
  "url 1.7.2",
  "uuid 0.6.5",
  "uuid 0.7.4",
@@ -877,7 +877,7 @@ dependencies = [
  "nix 0.13.1",
  "num_cpus",
  "openssl",
- "sgx-isa 0.3.3",
+ "sgx-isa",
  "sgxs",
  "tokio 0.2.22",
 ]
@@ -1091,7 +1091,7 @@ dependencies = [
  "num_cpus",
  "serde",
  "serde_derive 1.0.132",
- "sgx-isa 0.3.3",
+ "sgx-isa",
  "sgxs",
  "sgxs-loaders",
  "toml 0.4.10",
@@ -3032,7 +3032,7 @@ version = "0.3.2"
 dependencies = [
  "enclave-runner",
  "failure",
- "sgx-isa 0.3.3",
+ "sgx-isa",
  "sgxs",
 ]
 
@@ -3358,15 +3358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sgx-isa"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55adf0940448a33eac98b3c84ab2e567c1fbc086750bcfd72702d6facc39bb77"
-dependencies = [
- "bitflags 1.2.1",
-]
-
-[[package]]
 name = "sgx_pkix"
 version = "0.1.1"
 dependencies = [
@@ -3374,20 +3365,7 @@ dependencies = [
  "lazy_static",
  "pkix",
  "quick-error",
- "sgx-isa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sgx_pkix"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf3793cb22f01be29fd8ac1f97df9b4685156ec6e9ddea6573b8b1819a7802b"
-dependencies = [
- "byteorder 1.3.4",
- "lazy_static",
- "pkix",
- "quick-error",
- "sgx-isa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx-isa",
 ]
 
 [[package]]
@@ -3401,7 +3379,7 @@ dependencies = [
  "foreign-types",
  "openssl",
  "openssl-sys",
- "sgx-isa 0.3.3",
+ "sgx-isa",
  "sha2 0.8.2",
  "time 0.1.44",
 ]
@@ -3418,7 +3396,7 @@ dependencies = [
  "libloading 0.5.2",
  "nix 0.15.0",
  "report-test",
- "sgx-isa 0.3.3",
+ "sgx-isa",
  "sgxs",
  "winapi 0.3.9",
 ]
@@ -3455,7 +3433,7 @@ dependencies = [
  "serde",
  "serde_derive 1.0.132",
  "serde_yaml",
- "sgx-isa 0.3.3",
+ "sgx-isa",
  "sgxs",
  "sgxs-loaders",
  "syn 0.15.44",

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -30,8 +30,8 @@ uuid_sdkms = { package = "uuid", version = "0.7.4", features = ["v4", "serde"] }
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
-sgx_pkix = { version = "0.1.0" }
-sgx-isa = { version="0.3", features=["sgxstd"], default-features=false }
+sgx_pkix = { version = "0.1.0", path = "../intel-sgx/sgx_pkix" }
+sgx-isa = { version = "0.3", path = "../intel-sgx/sgx-isa", default-features = false }
 
 [target.x86_64-unknown-linux-musl.dependencies]
 nsm-driver = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api", package = "nsm-driver", rev = "6745598d0e0e8af57e9b96ee2bf3d11b216fe649" }

--- a/fortanix-vme/tests/incoming_connection/src/main.rs
+++ b/fortanix-vme/tests/incoming_connection/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(io_error_uncategorized)]
 use std::io::{ErrorKind, Read, Write};
 use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::os::unix::io::{AsRawFd, FromRawFd};
@@ -31,7 +30,7 @@ fn server_run<A: ToSocketAddrs>(addr: A) {
                 assert_eq!(stream.local_addr().unwrap().port(), 3400);
 
                 let no_stream = unsafe { TcpStream::from_raw_fd(666.into()) };
-                assert_eq!(no_stream.peer_addr().unwrap_err().kind(), ErrorKind::Uncategorized);
+                no_stream.peer_addr().unwrap_err();
 
                 println!("Connection {}: Connected", id);
                 let mut buff_in = [0u8; 4192];

--- a/intel-sgx/enclave-runner/src/lib.rs
+++ b/intel-sgx/enclave-runner/src/lib.rs
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(warnings)]
-#![feature(asm)]
 #![doc(
     html_logo_url = "https://edp.fortanix.com/img/docs/edp-logo.svg",
     html_favicon_url = "https://edp.fortanix.com/favicon.ico",

--- a/intel-sgx/enclave-runner/src/tcs.rs
+++ b/intel-sgx/enclave-runner/src/tcs.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std;
+use std::arch::asm;
 use std::cell::RefCell;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;

--- a/intel-sgx/enclave-runner/src/usercalls/mod.rs
+++ b/intel-sgx/enclave-runner/src/usercalls/mod.rs
@@ -1226,7 +1226,7 @@ async fn trap_attached_debugger(tcs: usize, debug_buf: *const u8) {
     // Synchronized
     unsafe {
         let old = signal::sigaction(signal::SIGTRAP, &sig_action).unwrap();
-        asm!("
+        std::arch::asm!("
             xchg %rbx, {0}
             int3
             xchg {0}, %rbx

--- a/intel-sgx/sgx-isa/Cargo.toml
+++ b/intel-sgx/sgx-isa/Cargo.toml
@@ -27,4 +27,3 @@ serde = { version = "1.0.104", features = ["derive"], optional = true } # MIT/Ap
 [features]
 large_array_derive = []
 sgxstd = []
-nightly = []

--- a/intel-sgx/sgx_pkix/Cargo.toml
+++ b/intel-sgx/sgx_pkix/Cargo.toml
@@ -13,6 +13,6 @@ categories = ["cryptography"]
 [dependencies]
 byteorder = "1.0"
 pkix = "0.1.1"
-sgx-isa = "0.3"
+sgx-isa = { version = "0.3", path = "../sgx-isa" }
 quick-error = "1.1.0"
 lazy_static = "1"

--- a/intel-sgx/sgxs-tools/src/bin/sgxs-load.rs
+++ b/intel-sgx/sgxs-tools/src/bin/sgxs-load.rs
@@ -4,9 +4,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Will be fixed in https://github.com/fortanix/rust-sgx/pull/369
-#![allow(deprecated)]
-#![feature(llvm_asm)]
 extern crate aesm_client;
 extern crate clap;
 extern crate sgx_isa;
@@ -31,20 +28,24 @@ use sgxs_loaders::enclaveapi::Sgx as SgxDevice;
 fn enclu_eenter(tcs: &mut dyn Tcs) {
     let result: u32;
     unsafe {
-        llvm_asm!("
-        lea aep(%rip),%rcx
-        jmp enclu
-aep:
-        xor %eax,%eax
-        jmp post
-enclu:
-        enclu
-post:
-"       : "={eax}"(result)
-            : "{eax}"(Enclu::EEnter), "{rbx}"(tcs.address())
-            : "rcx"
-            : "volatile"
-        )
+        std::arch::asm!("
+            xchg %rbx, {0}
+            lea 1f(%rip),%rcx
+            jmp 2f
+1:
+            xor %eax,%eax
+            jmp 3f
+2:
+            enclu
+3:
+            xchg {0}, %rbx
+",
+            // rbx is used internally by LLVM and cannot be used as an operand for inline asm (#84658)
+            in(reg) tcs.address(),
+            inout("eax") Enclu::EEnter as u32 => result,
+            lateout("rcx") _,
+            options(nostack, att_syntax)
+        );
     };
 
     if result == 0 {


### PR DESCRIPTION
Once Rust 1.59 is released, this needs to be merged, minor versions need to be bumped where appropriate, and this should be released.

* [x] Wait for Rust 1.59
* [x] Switch CI to stable
* [x] Update documentation to stable