### PR TITLE
[PLAT-367] Connection info

### DIFF
--- a/fortanix-vme/fortanix-vme-abi/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-abi/src/lib.rs
@@ -30,6 +30,10 @@ pub enum Request {
     Close {
         enclave_port: u32,
     },
+    Info {
+        enclave_port: u32,
+        runner_port: Option<u32>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -92,6 +96,18 @@ pub enum Response {
         proxy_port: u32,
     },
     Closed,
+    Info {
+        /// The local address (as used by the runner)
+        local: Addr,
+        /// The address of the remote party for open connection, None for server sockets
+        peer: Option<Addr>,
+    },
+    Failed(Error),
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Error {
+    ConnectionNotFound,
 }
 
 #[cfg(test)]

--- a/fortanix-vme/fortanix-vme-runner/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-runner/src/lib.rs
@@ -9,7 +9,7 @@ use std::io::{self, Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::os::unix::io::AsRawFd;
 use std::sync::{Arc, Mutex, RwLock};
-use fortanix_vme_abi::{self, Addr, Response, Request};
+use fortanix_vme_abi::{self, Addr, Error as VmeError, Response, Request};
 use vsock::{self, SockAddr as VsockAddr, Std, Vsock, VsockListener, VsockStream};
 
 const PROXY_BUFF_SIZE: usize = 4192;
@@ -98,6 +98,10 @@ struct Connection {
 
 #[derive(Clone, Debug)]
 struct ConnectionInfo {
+    /// The local address (as used by the runner)
+    local: Addr,
+    /// The address of the remote party for open connection, None for server sockets
+    peer: Addr,
 }
 
 impl Connection {
@@ -110,7 +114,10 @@ impl Connection {
     }
 
     pub fn info(&self) -> ConnectionInfo {
-        ConnectionInfo{}
+        ConnectionInfo {
+            local: self.tcp_stream.local_addr().unwrap().into(),
+            peer: self.tcp_stream.peer_addr().unwrap().into(),
+        }
     }
 
     /// Exchanges messages between the remote server and enclave. Returns on error, or when one of
@@ -439,11 +446,55 @@ impl Server {
         Ok(())
     }
 
+    fn handle_request_info(self: Arc<Self>, enclave_port: u32, runner_port: Option<u32>, enclave: &mut VsockStream) -> Result<(), IoError> {
+        let enclave_cid: u32 = enclave.peer().unwrap().parse().unwrap_or(vsock::VMADDR_CID_HYPERVISOR);
+        let enclave_addr = VsockAddr::new(enclave_cid, enclave_port);
+        let response = if let Some(runner_port) = runner_port {
+            // We're looking for a Connection
+            let runner_cid: u32 = enclave.local().unwrap().parse().unwrap_or(vsock::VMADDR_CID_HYPERVISOR);
+            let runner_addr = VsockAddr::new(runner_cid, runner_port);
+            if let Some(connection) = self.connection(enclave_addr, runner_addr) {
+                Response::Info {
+                    local: connection.local.clone(),
+                    peer: Some(connection.peer.clone()),
+                }
+            } else {
+                // Connection not found
+                Response::Failed(VmeError::ConnectionNotFound)
+            }
+        } else {
+            // We're looking for a Listener
+            if let Some(listener) = self.listener(&enclave_addr) {
+                let listener = listener.lock().unwrap();
+                Response::Info {
+                    local: listener.listener.local_addr()?.into(),
+                    peer: None,
+                }
+            } else {
+                // Listener not found
+                Response::Failed(VmeError::ConnectionNotFound)
+            }
+        };
+        Self::log_communication(
+            "runner",
+            enclave.local_port().unwrap_or_default(),
+            "enclave",
+            enclave.peer_port().unwrap_or_default(),
+            &format!("{:?}", &response),
+            Direction::Right,
+            "vsock");
+        enclave.write(&serde_cbor::ser::to_vec(&response).unwrap())?;
+        Ok(())
+    }
+
     fn handle_client(self: Arc<Self>, stream: &mut VsockStream) -> Result<(), IoError> {
         match Self::read_request(stream) {
             Ok(Request::Connect{ addr })             => self.handle_request_connect(&addr, stream)?,
             Ok(Request::Bind{ addr, enclave_port })  => self.handle_request_bind(&addr, enclave_port, stream)?,
             Ok(Request::Accept{ enclave_port })      => self.handle_request_accept(enclave_port, stream)?,
+            Ok(Request::Info{
+                enclave_port,
+                runner_port })                       => self.handle_request_info(enclave_port, runner_port, stream)?,
             Ok(Request::Close{ enclave_port })       => self.handle_request_close(enclave_port, stream)?,
             Err(_e)                                  => return Err(IoError::new(IoErrorKind::InvalidData, "Failed to read request")),
         };

--- a/fortanix-vme/fortanix-vme-runner/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-runner/src/lib.rs
@@ -324,7 +324,7 @@ impl Server {
         self.listeners.write().unwrap().remove(&addr)
     }
 
-    fn connection(&self, enclave: VsockAddr, runner_port: u32) -> Option<ConnectionInfo> {
+    fn connection_info(&self, enclave: VsockAddr, runner_port: u32) -> Option<ConnectionInfo> {
         // There's an interesting vsock bug. When a new connection is created to the enclave in
         // the `handle_request_accept` function (from `ConnectionKey::from_vsock_stream`), the
         // local cid is different from the cid received when inspecting `enclave: VsockStream`.
@@ -457,10 +457,10 @@ impl Server {
         let enclave_addr = VsockAddr::new(enclave_cid, enclave_port);
         let response = if let Some(runner_port) = runner_port {
             // We're looking for a Connection
-            if let Some(connection) = self.connection(enclave_addr, runner_port) {
+            if let Some(ConnectionInfo{ local, peer }) = self.connection_info(enclave_addr, runner_port) {
                 Response::Info {
-                    local: connection.local.clone(),
-                    peer: Some(connection.peer.clone()),
+                    local,
+                    peer: Some(peer),
                 }
             } else {
                 // Connection not found

--- a/fortanix-vme/tests/incoming_connection/src/main.rs
+++ b/fortanix-vme/tests/incoming_connection/src/main.rs
@@ -1,10 +1,15 @@
-use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener};
 use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener};
+use std::os::unix::io::{AsRawFd, FromRawFd};
 
 fn server_run() {
     println!("Bind TCP socket to port 3400");
     let listener = TcpListener::bind("127.0.0.1:3400").expect("Bind failed");
     assert_eq!(listener.local_addr().unwrap(), SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 3400));
+
+    let fd = listener.as_raw_fd();
+    let listener1 = unsafe { TcpListener::from_raw_fd(fd) };
+    assert_eq!(listener1.local_addr().unwrap(), SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 3400));
 
     println!("Listening for incoming connections...");
     for id in 1..3 {

--- a/fortanix-vme/tests/incoming_connection/src/main.rs
+++ b/fortanix-vme/tests/incoming_connection/src/main.rs
@@ -1,5 +1,6 @@
-use std::io::{Read, Write};
-use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener};
+#![feature(io_error_uncategorized)]
+use std::io::{ErrorKind, Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 
 fn server_run() {
@@ -15,12 +16,23 @@ fn server_run() {
     for id in 1..3 {
         println!("Waiting for connection {}", id);
         match listener.accept() {
-            Ok((mut stream, addr)) => {
+            Ok((stream, addr)) => {
                 println!("# addr = {:?}", addr);
                 assert_eq!(stream.peer_addr().unwrap().ip(), Ipv4Addr::new(127, 0, 0, 1));
                 assert!(stream.peer_addr().unwrap().port() != 3400);
                 assert_eq!(stream.local_addr().unwrap().ip(), Ipv4Addr::new(127, 0, 0, 1));
                 assert_eq!(stream.local_addr().unwrap().port(), 3400);
+
+                let fd = stream.as_raw_fd();
+                let mut stream = unsafe { TcpStream::from_raw_fd(fd) };
+                assert_eq!(stream.peer_addr().unwrap().ip(), Ipv4Addr::new(127, 0, 0, 1));
+                assert!(stream.peer_addr().unwrap().port() != 3400);
+                assert_eq!(stream.local_addr().unwrap().ip(), Ipv4Addr::new(127, 0, 0, 1));
+                assert_eq!(stream.local_addr().unwrap().port(), 3400);
+
+                let no_stream = unsafe { TcpStream::from_raw_fd(666.into()) };
+                assert_eq!(no_stream.peer_addr().unwrap_err().kind(), ErrorKind::Uncategorized);
+
                 println!("Connection {}: Connected", id);
                 let mut buff_in = [0u8; 4192];
                 let n = stream.read(&mut buff_in).unwrap();


### PR DESCRIPTION
When `TcpListener`s or `TcpStream`s are created from a `RawFd`, they lack information about local and/or peer ports used in the runner. When this information is requested, it needs to be fetched from the runner.