### PR TITLE
[PLAT-351]: Support an easy way to run Nitro enclaves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "cargo_toml"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363c7cfaa15f101415c4ac9e68706ca4a2277773932828b33f96e59d28c68e62"
+dependencies = [
+ "serde",
+ "serde_derive 1.0.132",
+ "toml 0.5.8",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,13 +676,17 @@ name = "eif-tools"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cargo_toml",
  "clap",
  "elf",
  "env_logger 0.9.0",
  "log 0.4.11",
  "nitro-cli",
+ "once_cell",
+ "serde",
  "sha2 0.9.8",
  "tempdir",
+ "thiserror",
 ]
 
 [[package]]
@@ -959,11 +974,11 @@ dependencies = [
  "nix 0.13.1",
  "num_cpus",
  "serde",
- "serde_derive 1.0.130 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.132",
  "sgx-isa 0.3.3",
  "sgxs",
  "sgxs-loaders",
- "toml",
+ "toml 0.4.10",
  "xmas-elf",
 ]
 
@@ -1685,7 +1700,7 @@ dependencies = [
  "mbedtls-sys-auto",
  "rs-libc 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
- "serde_derive 1.0.130 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.132",
  "yasna 0.2.2",
 ]
 
@@ -2101,9 +2116,9 @@ checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
@@ -2933,7 +2948,7 @@ dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
- "serde_derive 1.0.130 (git+https://github.com/fortanix/serde.git?branch=master)",
+ "serde_derive 1.0.130",
 ]
 
 [[package]]
@@ -2958,8 +2973,7 @@ dependencies = [
 [[package]]
 name = "serde_derive"
 version = "1.0.130"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+source = "git+https://github.com/fortanix/serde.git?branch=master#80449547025fc4a016a333e96c0cdaf7e4a96f67"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
@@ -2968,8 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
-source = "git+https://github.com/fortanix/serde.git?branch=master#80449547025fc4a016a333e96c0cdaf7e4a96f67"
+version = "1.0.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
@@ -3137,7 +3152,7 @@ dependencies = [
  "report-test",
  "reqwest",
  "serde",
- "serde_derive 1.0.130 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.132",
  "serde_yaml",
  "sgx-isa 0.3.3",
  "sgxs",
@@ -3377,18 +3392,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
@@ -3629,6 +3644,15 @@ name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]

--- a/fortanix-vme/eif-tools/Cargo.toml
+++ b/fortanix-vme/eif-tools/Cargo.toml
@@ -15,10 +15,14 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 anyhow = "1.0"
+cargo_toml = "0.10.3"
 clap = "2.33"
 elf = "0.0.10"
 env_logger = "0.9"
 log = "0.4"
 nitro-cli = { git = "https://github.com/fortanix/aws-nitro-enclaves-cli.git", branch = "main" }
+once_cell = "1.9.0"
+serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.9.5"
 tempdir = "0.3"
+thiserror = "1.0"

--- a/fortanix-vme/eif-tools/src/bin/ftxvme-runner-cargo.rs
+++ b/fortanix-vme/eif-tools/src/bin/ftxvme-runner-cargo.rs
@@ -194,7 +194,7 @@ impl FortanixVmeConfig {
                 package.metadata
                     .map(|metadata| metadata.fortanix_vme)
             })
-        .flatten();
+            .flatten();
 
         let config = if let Some(fortanix_vme_metadata) = fortanix_vme_metadata {
 

--- a/fortanix-vme/eif-tools/src/bin/ftxvme-runner-cargo.rs
+++ b/fortanix-vme/eif-tools/src/bin/ftxvme-runner-cargo.rs
@@ -1,0 +1,302 @@
+use std::{io, path::{Path, PathBuf}, process::{ExitStatus, Command}};
+
+use anyhow::Context;
+use serde::{Serialize, Deserialize};
+use cargo_toml::Manifest;
+use thiserror::Error;
+use once_cell::sync::Lazy;
+
+/// Convenience macro to make command constructing containing
+/// optional args and flags readable.
+///
+/// ```ignore
+/// command! {
+///     "command_name" => args(
+///         "--opt1"  => ?is_some(value), // Where `value` is an Option<>.
+///                                       // `--opt1` is only passed if `value`
+///                                       // is Some()
+///
+///         "--opt2"  => ?is_true(flag),  // Where `flag` is an bool.
+///                                       // `--opt2` is only passed if
+///                                       // `flag` is true.
+///
+///         "--opt3"  => val,             // Where `val` is straight away
+///                                       // passed to command.arg()
+///
+///         "--opt4", "--opt5"            // args without values.
+///     )
+/// }
+/// ```
+macro_rules! command {
+    {
+        $name:expr $( => args(
+            $( $arg:expr
+                $( => ? is_true($flag:expr) )?
+                $( => ? is_some($optional:expr) )?
+                $( => $val:expr )?
+            ),+
+        ) )?
+    } => {{
+        let command = std::process::Command::new($name);
+
+        $(
+            let mut command = command;
+            $(
+                #[allow(unreachable_patterns)]
+                match () {
+                    // case if arg is determined by a flag
+                    $(
+                    () if $flag => {command.arg($arg);}
+                    () => {},
+                    )?
+
+                    // case if arg is determined by an optional val
+                    $(
+                    () if $optional.is_some() => {command.arg($arg).arg($optional.unwrap());}
+                    () => {},
+                    )?
+
+                    // case if value can be given to arg straight away
+                    $(
+                    () => {command.arg($arg).arg($val);}
+                    )?
+
+                    // simple arg
+                    () => {command.arg($arg);},
+                };
+            )+
+        )?
+
+        command
+    }};
+}
+
+static ARGS: Lazy<Vec<String>> = Lazy::new(|| {
+    std::env::args().collect::<Vec<_>>()
+});
+
+#[derive(Debug, Error)]
+enum CommandFail {
+    #[error("Failed to run {0}: {1}")]
+    Io(String, io::Error),
+    #[error("While running {0} got exit status {1}")]
+    Status(String, ExitStatus),
+}
+
+fn run_command(mut cmd: Command) -> Result<(), CommandFail> {
+    match cmd.status() {
+        Err(e) => Err(CommandFail::Io(format!("{:?}", cmd), e)),
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => Err(CommandFail::Status(format!("{:?}", cmd), status)),
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+struct CargoTomlMetadata {
+    fortanix_vme: FortanixVmeConfig,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "kebab-case", default)]
+#[rustfmt::skip] // contains long lines because of links and they may wrapped by mistake
+/// This config is mainly intended for args of ftxvme-elf2eif and nitro-cli run-enclave.
+/// See their args documentation for more info about these opts:
+/// https://docs.aws.amazon.com/enclaves/latest/user/cmd-nitro-run-enclave.html#cmd-nitro-run-enclave-options
+/// https://docs.aws.amazon.com/enclaves/latest/user/cmd-nitro-build-enclave.html#cmd-nitro-build-enclave-options
+struct FortanixVmeConfig {
+    /// Enables verbose mode of ftxvme-elf2eif.
+    verbose: bool,
+
+    /// Path to output eif file
+    eif_file_path: PathBuf,
+
+    /// Path to resources, default is `/usr/share/nitro_enclaves/blobs/`.
+    /// See blobs in: https://github.com/aws/aws-nitro-enclaves-cli#source-code-components
+    resource_path: Option<PathBuf>,
+
+    /// Path to signing certificate. If this is specified,
+    /// `private-key` needs to be specified too.
+    signing_certificate: Option<PathBuf>,
+
+    /// Path to private key. If this is specified,
+    /// `signing-certificate` needs to be specified too.
+    private_key: Option<PathBuf>,
+
+    /// A custom name given to the enclave. If not specified,
+    /// the name of the .eif file is used.
+    enclave_name: Option<String>,
+
+    /// Specifies the number of vCPUs to allocate to the enclave.
+    /// Shouldn't coexist with `cpu_ids`.
+    cpu_count: Option<isize>,
+
+    /// Specifies the IDs of the vCPUs to allocate to the enclave.
+    /// Shouldn't coexist with `cpu_count`.
+    cpu_ids: Option<String>,
+
+    /// Specifies the amount of memory (in MiB) to allocate to the enclave.
+    /// Should be at least 64 MiB.
+    memory: isize,
+
+    /// Basically this field represents the vsock address of
+    /// the enclave.
+    /// This field should always be greater than equal to 4.
+    ///
+    /// The CID of parent instance is always 3 as per:
+    /// https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave-concepts.html#term-socket
+    ///
+    /// Vsock CID is analogous to an IP address.
+    enclave_cid: Option<String>,
+
+    /// `true` by default. This enables debug mode of `nitro-cli run-enclave`.
+    debug_mode: bool,
+
+    /// The path to a .json configuration file that specifies the paramaters for the enclave
+    ///
+    /// If this is given, no other entry should be there in the table otherwise
+    /// this will error out.
+    nitro_cli_run_enclave_config: Option<PathBuf>,
+
+    /// fortanix-vme-runner starts a vsock proxy server and
+    /// is needed if your edp application makes any call to
+    /// functions like `TcpStream::connect()`.
+    /// If your application calls `TcpStream::connect("<url:port>")`,
+    /// this proxy server acts as a bridge for request and responses.
+    ///
+    /// If this is set to true, this runner won't try to
+    /// start fortanix-vme-runner.
+    disable_fortanix_vme_runner_start: bool,
+}
+
+impl FortanixVmeConfig {
+    const DEFAULT_CPU_COUNT: isize = 2;
+    const DEFAULT_MEMORY: isize = 512;
+    const DEFAULT_DEBUG_MODE: bool = true;
+
+    fn default_eif_path() -> PathBuf {
+        format!("{}.eif", ARGS[1]).into()
+    }
+
+
+    /// Tries to parse Cargo.toml for `package.metadata.fortanix-vme` and uses
+    /// it if found. If some required values are missing in the the metadata,
+    /// default ones are used.
+    /// If no metadata is specified, we construct the config only using the
+    /// default versions of required values.
+    fn get() -> anyhow::Result<FortanixVmeConfig> {
+        let manifest_path = Path::new(&std::env::var_os("CARGO_MANIFEST_DIR").context("CARGO_MANIFEST_DIR not set")?)
+            .join("Cargo.toml");
+
+        let fortanix_vme_metadata = Manifest::<CargoTomlMetadata>::from_path_with_metadata(&manifest_path)?
+            .package
+            .map(|package| {
+                package.metadata
+                    .map(|metadata| metadata.fortanix_vme)
+            })
+        .flatten();
+
+        let config = if let Some(fortanix_vme_metadata) = fortanix_vme_metadata {
+
+            // Use default cpu count if metadata doesn't specify cpu_ids or cpu_count.
+            // Also, specifying both cpu_count and cpu_ids is invalid but we don't handle it here
+            // because nitro-cli will anyway error out if that's the case.
+            let (cpu_ids, cpu_count) = match (fortanix_vme_metadata.cpu_ids, fortanix_vme_metadata.cpu_count) {
+                (None, None) => (None, Some(FortanixVmeConfig::DEFAULT_CPU_COUNT)),
+                val => val,
+            };
+
+            FortanixVmeConfig {
+                cpu_count,
+                cpu_ids,
+                .. fortanix_vme_metadata
+            }
+        } else {
+            Default::default()
+        };
+
+        Ok(config)
+    }
+
+}
+
+impl Default for FortanixVmeConfig {
+    fn default() -> Self {
+        Self {
+            cpu_count: Some(FortanixVmeConfig::DEFAULT_CPU_COUNT),
+            memory: FortanixVmeConfig::DEFAULT_MEMORY,
+            debug_mode: FortanixVmeConfig::DEFAULT_DEBUG_MODE,
+            enclave_name: None,
+            cpu_ids: None,
+            enclave_cid: None,
+            nitro_cli_run_enclave_config: None,
+            verbose: false,
+            eif_file_path: FortanixVmeConfig::default_eif_path(),
+            resource_path: None,
+            signing_certificate: None,
+            private_key: None,
+            disable_fortanix_vme_runner_start: false,
+        }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let fortanix_vme_config = FortanixVmeConfig::get()?;
+
+    let ftxvme_elf2eif = command! {
+        "ftxvme-elf2eif" => args(
+            "--input-file"     => &ARGS[1],
+            "--output-file"    => &fortanix_vme_config.eif_file_path,
+            "--verbose"        => ?is_true(fortanix_vme_config.verbose),
+            "--resource-path"  => ?is_some(fortanix_vme_config.resource_path)
+        )
+    };
+
+    run_command(ftxvme_elf2eif)?;
+
+    if !fortanix_vme_config.disable_fortanix_vme_runner_start {
+        // We just try to start fortanix-vme-runner and don't wait on it. So,
+        // we don't know if it errors out. I think this should be enough
+        // as purpose of the runner is to provide easy setup. If someone really wants to
+        // be sure, they can set `disable_fortanix_vme_runner_start` to true and start
+        // it manually.
+        //
+        // If required, other option can be to link fortanix-vme-runner as a library and spawn the
+        // proxy server in another thread. The thing here will be that if fortanix-vme-runner
+        // already running, it will error out will addr in use. To be sure, we could probably
+        // communicate with fortanix-vme-runner.
+        let mut fortanix_vme_runner = command!("fortanix-vme-runner");
+        fortanix_vme_runner.spawn().context("Failed to start fortanix-vme-runner")?;
+    }
+
+    // if config is specified, no other arg should be passed. Reference:
+    // https://docs.aws.amazon.com/enclaves/latest/user/cmd-nitro-run-enclave.html#cmd-nitro-run-enclave-options
+    let nitro_cli_run_enclave = match fortanix_vme_config.nitro_cli_run_enclave_config {
+        Some(nitro_cli_run_enclave_config) => {
+            command! {
+                "nitro-cli" => args(
+                    "run-enclave",
+                    "--config" => nitro_cli_run_enclave_config
+                )
+            }
+        },
+        None => {
+            command! {
+                "nitro-cli" => args(
+                    "run-enclave",
+                    "--enclave-name" => ?is_some(fortanix_vme_config.enclave_name),
+                    "--cpu-count"    => ?is_some(fortanix_vme_config.cpu_count.map(|c| c.to_string())),
+                    "--cpu-ids"      => ?is_some(fortanix_vme_config.cpu_ids),
+                    "--eif-path"     => &fortanix_vme_config.eif_file_path,
+                    "--memory"       => fortanix_vme_config.memory.to_string(),
+                    "--enclave-cid"  => ?is_some(fortanix_vme_config.enclave_cid),
+                    "--debug-mode"   => ?is_true(fortanix_vme_config.debug_mode)
+                )
+            }
+        },
+    };
+
+    run_command(nitro_cli_run_enclave)?;
+
+    Ok(())
+}

--- a/fortanix-vme/eif-tools/src/bin/ftxvme-runner-cargo.rs
+++ b/fortanix-vme/eif-tools/src/bin/ftxvme-runner-cargo.rs
@@ -98,7 +98,7 @@ struct CargoTomlMetadata {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "kebab-case", default)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 #[rustfmt::skip] // contains long lines because of links and they may wrapped by mistake
 /// This config is mainly intended for args of ftxvme-elf2eif and nitro-cli run-enclave.
 /// See their args documentation for more info about these opts:

--- a/fortanix-vme/eif-tools/src/bin/ftxvme-runner-cargo.rs
+++ b/fortanix-vme/eif-tools/src/bin/ftxvme-runner-cargo.rs
@@ -149,14 +149,13 @@ struct FortanixVmeConfig {
     /// Vsock CID is analogous to an IP address.
     enclave_cid: Option<String>,
 
-    /// `true` by default. This enables debug mode of `nitro-cli run-enclave`.
+    /// `false` by default. This enables debug mode of `nitro-cli run-enclave`.
     debug_mode: bool,
 }
 
 impl FortanixVmeConfig {
     const DEFAULT_CPU_COUNT: isize = 2;
     const DEFAULT_MEMORY: isize = 512;
-    const DEFAULT_DEBUG_MODE: bool = true;
 
     fn default_eif_path() -> PathBuf {
         format!("{}.eif", ARGS[1]).into()
@@ -207,7 +206,7 @@ impl Default for FortanixVmeConfig {
         Self {
             cpu_count: Some(FortanixVmeConfig::DEFAULT_CPU_COUNT),
             memory: FortanixVmeConfig::DEFAULT_MEMORY,
-            debug_mode: FortanixVmeConfig::DEFAULT_DEBUG_MODE,
+            debug_mode: false,
             enclave_name: None,
             cpu_ids: None,
             enclave_cid: None,


### PR DESCRIPTION
Currently, to spawn an enclave, one has to do the following 3 steps:
- Convert elf to eif
- (not always required) Start fortanix-vme-runner which is basically a vsock proxy
- nitro-cli run-enclave

This PR adds code for a [custom runner for target `x86_64-unknown-linux-fortanixvme`](https://doc.rust-lang.org/cargo/reference/config.html#targettriplerunner) which will automate the above steps. This is pretty much like `ftxsgx-runner-cargo`. Although, I haven't created a separate `ftxvme-runner` like `ftxsgx-runner` as we can use `nitro-cli` directly here.

This runner spawns `fortanix-vme-runner` (this can be disabled by options in metadata) but doesn't wait on it. So, it doesn't know its exit status. If `fortanix-vme-runner` has been spawned before, it will not cause issues for the runner as when it tries to spawn it again, the address will already be in use and nothing will happen (although, the error message is displayed).
I think doing this should be enough as `fortanix-vme-runner` is being started here just for convenience. If someone wants to be certain of the exit status, they can set `disable-fortanix-vme-runner-start` to true in metadata and start `fortanix-vme-runner` explicitly.

---

I have tested this by setting the following in `~/.cargo/config`:
```toml
[target.x86_64-unknown-linux-fortanixvme]
runner = "/path/to/bin/of/ftxvme-runner-cargo"
```
and then in a simple rust crate, ran:
```
CC=musl-gcc \
  RUSTFLAGS="-Clink-self-contained=yes"\
  cargo run --target ${VME_TARGET} -Zbuild-std
```
This runs the enclave and its output can be further monitored by `nitro-console`.