### PR TITLE
Remove em-client patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,8 @@ dependencies = [
 [[package]]
 name = "em-client"
 version = "3.0.0"
-source = "git+https://github.com/fortanix/em-client-rust?rev=3117ec9404a9657fd0409f07a2d54211c526f77e#3117ec9404a9657fd0409f07a2d54211c526f77e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0bd923300728ad79f8c36f689f96d928d224524a2120a204fa2bb7801991e7c"
 dependencies = [
  "base64 0.10.1",
  "bitflags 1.2.1",
@@ -2704,7 +2705,7 @@ version = "2.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6653d384a260fedff0a466e894e05c5b8d75e261a14e9f93e81e43ef86cad23"
 dependencies = [
- "log 0.3.9",
+ "log 0.4.14",
  "which 4.0.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,3 @@ mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", branch = "master" 
 serde = { git = "https://github.com/fortanix/serde.git", branch = "master" }
 vsock = { git = "https://github.com/fortanix/vsock-rs.git", branch = "fortanixvme" }
 rustc-serialize = { git = "https://github.com/jethrogb/rustc-serialize.git", branch = "portability" }
-em-client = { git = "https://github.com/fortanix/em-client-rust", rev = "3117ec9404a9657fd0409f07a2d54211c526f77e" }


### PR DESCRIPTION
remove em-client patch since we now have a released version on crates.io