### PR TITLE
[PLAT-66] Nitro nsm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,14 +1844,12 @@ name = "mbedtls"
 version = "0.8.2"
 source = "git+https://github.com/fortanix/rust-mbedtls?branch=master#aa500d0e6e0a28117e9e62d932ed6d0341acab06"
 dependencies = [
- "bit-vec 0.5.1",
  "bitflags 1.2.1",
  "byteorder 1.3.4",
  "cc",
  "cfg-if 1.0.0",
  "chrono",
  "mbedtls-sys-auto",
- "num-bigint 0.2.6",
  "rs-libc 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_derive 1.0.132",
@@ -2316,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg 1.0.1",
  "num-traits",
@@ -2349,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,8 +800,8 @@ dependencies = [
  "em-node-agent-client",
  "hyper 0.10.16",
  "mbedtls",
- "nsm-driver",
- "nsm-io",
+ "nsm-driver 0.1.0 (git+https://github.com/aws/aws-nitro-enclaves-nsm-api?rev=6745598d0e0e8af57e9b96ee2bf3d11b216fe649)",
+ "nsm-io 0.1.0 (git+https://github.com/aws/aws-nitro-enclaves-nsm-api?rev=6745598d0e0e8af57e9b96ee2bf3d11b216fe649)",
  "pkix",
  "rustc-serialize",
  "sdkms",
@@ -2138,6 +2138,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.20.2"
+source = "git+https://github.com/fortanix/nix.git?branch=raoul/fortanixvme_r0.20.2#6803aa84923d024a6106840acf2d12edb78825c0"
+dependencies = [
+ "bitflags 1.2.1",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset 0.6.4",
+]
+
+[[package]]
+name = "nix"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3bb9a13fa32bc5aeb64150cd3f32d6cf4c748f8f8a417cce5d2eb976a8370ba"
@@ -2160,6 +2172,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nsm"
+version = "0.1.0"
+dependencies = [
+ "nitro-attestation-verify",
+ "nsm-driver 0.1.0 (git+https://github.com/aws/aws-nitro-enclaves-nsm-api)",
+ "nsm-io 0.1.0 (git+https://github.com/aws/aws-nitro-enclaves-nsm-api)",
+ "serde_bytes",
+]
+
+[[package]]
 name = "nsm-driver"
 version = "0.1.0"
 source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api?rev=6745598d0e0e8af57e9b96ee2bf3d11b216fe649#6745598d0e0e8af57e9b96ee2bf3d11b216fe649"
@@ -2167,7 +2189,19 @@ dependencies = [
  "libc",
  "log 0.4.14",
  "nix 0.15.0",
- "nsm-io",
+ "nsm-io 0.1.0 (git+https://github.com/aws/aws-nitro-enclaves-nsm-api?rev=6745598d0e0e8af57e9b96ee2bf3d11b216fe649)",
+ "serde_cbor",
+]
+
+[[package]]
+name = "nsm-driver"
+version = "0.1.0"
+source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api#9ddb589875baf345d085a980aa96cf3a4e480ea8"
+dependencies = [
+ "libc",
+ "log 0.4.14",
+ "nix 0.20.2",
+ "nsm-io 0.1.0 (git+https://github.com/aws/aws-nitro-enclaves-nsm-api)",
  "serde_cbor",
 ]
 
@@ -2182,6 +2216,25 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
+]
+
+[[package]]
+name = "nsm-io"
+version = "0.1.0"
+source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api#9ddb589875baf345d085a980aa96cf3a4e480ea8"
+dependencies = [
+ "log 0.4.14",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+]
+
+[[package]]
+name = "nsm-test"
+version = "0.1.0"
+dependencies = [
+ "nsm",
+ "pkix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,13 @@ members = [
     "fortanix-vme/eif-tools",
     "fortanix-vme/fortanix-vme-abi",
     "fortanix-vme/fortanix-vme-runner",
+    "fortanix-vme/nsm",
     "fortanix-vme/nitro-attestation-verify",
     "fortanix-vme/tests/hello_world",
     "fortanix-vme/tests/outgoing_connection",
     "fortanix-vme/tests/incoming_connection",
     "fortanix-vme/tests/iron",
+    "fortanix-vme/tests/nsm-test",
     "intel-sgx/aesm-client",
     "intel-sgx/dcap-provider",
     "intel-sgx/dcap-ql-sys",
@@ -34,6 +36,7 @@ exclude = ["examples"]
 [patch.crates-io]
 libc  = { git = "https://github.com/fortanix/libc.git", branch = "fortanixvme" }
 mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", branch = "master" }
+nix   = { git = "https://github.com/fortanix/nix.git", branch = "raoul/fortanixvme_r0.20.2" }
 serde = { git = "https://github.com/fortanix/serde.git", branch = "master" }
 vsock = { git = "https://github.com/fortanix/vsock-rs.git", branch = "fortanixvme" }
 rustc-serialize = { git = "https://github.com/jethrogb/rustc-serialize.git", branch = "portability" }

--- a/fortanix-vme/ci-common.sh
+++ b/fortanix-vme/ci-common.sh
@@ -108,18 +108,20 @@ function cargo_test {
                 scp ./test_interaction.sh ubuntu@${AWS_VM}:/home/ubuntu/ci-fortanixvme/${name}/
             fi
         fi
-	RUST_BACKTRACE=full ${elf} -- --nocapture > ${out} 2> ${err}
+	if [ ! -f ./skip_on_dev_platform ]; then
+            RUST_BACKTRACE=full ${elf} -- --nocapture > ${out} 2> ${err}
 
-        out=$(cat ${out} | grep -v "^#" || true)
-        expected=$(cat ./out.expected)
+            out=$(cat ${out} | grep -v "^#" || true)
+            expected=$(cat ./out.expected)
 
-        if [ "${out}" == "${expected}" ]; then
-            echo "Test ${name}: Success"
-        else
-            echo "Test ${name}: Failed"
-	    echo "Got: ${out}"
-            echo "Expected: ${expected}"
-            exit -1
+            if [ "${out}" == "${expected}" ]; then
+                echo "Test ${name}: Success"
+            else
+                echo "Test ${name}: Failed"
+	        echo "Got: ${out}"
+                echo "Expected: ${expected}"
+                exit -1
+            fi
         fi
     fi
 

--- a/fortanix-vme/ci-fortanixvme.sh
+++ b/fortanix-vme/ci-fortanixvme.sh
@@ -70,7 +70,8 @@ run_tests\
     hello_world \
     outgoing_connection \
     incoming_connection \
-    iron
+    iron \
+    nsm-test
 
 echo "********************************"
 echo "**    All tests succeeded!    **"

--- a/fortanix-vme/nitro-attestation-verify/Cargo.toml
+++ b/fortanix-vme/nitro-attestation-verify/Cargo.toml
@@ -10,7 +10,7 @@ serde_cbor = "0.11"
 # Required until PR36 is accepted
 # https://github.com/awslabs/aws-nitro-enclaves-cose/pull/36
 aws-nitro-enclaves-cose = { version = "0.5.0", git = "https://github.com/fortanix/aws-nitro-enclaves-cose.git", branch = "raoul/crypto_abstraction_pinned", default-features = false }
-mbedtls = { version = "0.8.2", features = ["rdrand", "std", "dsa", "time"], default-features = false, optional = true }
+mbedtls = { version = "0.8.2", features = ["rdrand", "std", "time"], default-features = false, optional = true }
 num-bigint = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/fortanix-vme/nitro-attestation-verify/src/lib.rs
+++ b/fortanix-vme/nitro-attestation-verify/src/lib.rs
@@ -22,7 +22,7 @@ use ::mbedtls::{alloc::List as MbedtlsList, x509::{Certificate, VerifyError}};
 mod mbedtls;
 
 #[cfg(feature = "mbedtls")]
-use crate::mbedtls::Mbedtls;
+pub use crate::mbedtls::Mbedtls;
 
 pub trait VerificationType {}
 

--- a/fortanix-vme/nitro-attestation-verify/src/mbedtls.rs
+++ b/fortanix-vme/nitro-attestation-verify/src/mbedtls.rs
@@ -13,7 +13,7 @@ use num_bigint::BigUint;
 use std::sync::Mutex;
 use std::ops::Deref;
 
-pub(crate) struct Mbedtls;
+pub struct Mbedtls;
 
 struct MdType(hash::Type);
 

--- a/fortanix-vme/nsm/Cargo.toml
+++ b/fortanix-vme/nsm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "nsm"
 version = "0.1.0"
+authors = ["Raoul Strackx <raoul.strackx@fortanix.com>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/fortanix-vme/nsm/Cargo.toml
+++ b/fortanix-vme/nsm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "nsm"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+nitro-attestation-verify = { path = "../nitro-attestation-verify" }
+nsm-driver = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api" }
+nsm-io = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api" }
+serde_bytes = "0.11"

--- a/fortanix-vme/nsm/src/lib.rs
+++ b/fortanix-vme/nsm/src/lib.rs
@@ -214,6 +214,14 @@ impl Nsm {
     pub fn describe(&self) -> Result<Description, Error> {
         nsm_driver::nsm_process_request(self.0, Request::DescribeNSM).try_into()
     }
+
+    pub fn get_random(&self) -> Result<Vec<u8>, Error> {
+        match nsm_driver::nsm_process_request(self.0, Request::GetRandom) {
+            Response::GetRandom{ random }    => Ok(random),
+            Response::Error(code)            => Err(code.into()),
+            _                                => Err(Error::InvalidResponse),
+        }
+    }
 }
 
 impl Drop for Nsm {

--- a/fortanix-vme/nsm/src/lib.rs
+++ b/fortanix-vme/nsm/src/lib.rs
@@ -1,0 +1,106 @@
+pub use nitro_attestation_verify::{AttestationDocument, Unverified, NitroError as AttestationError};
+use nsm_io::{ErrorCode, Response, Request};
+pub use serde_bytes::ByteBuf;
+
+pub struct Nsm(i32);
+
+#[derive(Debug)]
+pub enum Error {
+    AttestationError(AttestationError),
+    BufferTooSmall,
+    CannotOpenDriver,
+    InputTooLarge,
+    InternalError,
+    InvalidArgument,
+    InvalidOperation,
+    InvalidPcrIndex,
+    InvalidResponse,
+    ReadOnlyPcrIndex,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::AttestationError(ref msg) => write!(fmt, "Attestation error: {}", msg),
+            Error::BufferTooSmall => write!(fmt, "Buffer too small"),
+            Error::CannotOpenDriver => write!(fmt, "CannotOpenDriver"),
+            Error::InputTooLarge => write!(fmt, "InputTooLarge"),
+            Error::InternalError => write!(fmt, "InternalError"),
+            Error::InvalidArgument => write!(fmt, "InvalidArgument"),
+            Error::InvalidOperation => write!(fmt, "InvalidOperation"),
+            Error::InvalidPcrIndex => write!(fmt, "InvalidPcrIndex"),
+            Error::InvalidResponse => write!(fmt, "InvalidResponse"),
+            Error::ReadOnlyPcrIndex => write!(fmt, "ReadOnlyPcrIndex"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        match self {
+            Error::AttestationError(_e) => "Attestation error",
+            Error::BufferTooSmall => "Provided output buffer too small",
+            Error::CannotOpenDriver => "Failed to open driver",
+            Error::InputTooLarge => "User-provided input is too large",
+            Error::InternalError => "NitroSecureModule cannot fulfill request due to internal error",
+            Error::InvalidArgument => "Invalid input argument",
+            Error::InvalidOperation => "Request cannot be fulfilled due to missing capabilities",
+            Error::InvalidPcrIndex => "Platform Configuration Register index out of bounds",
+            Error::InvalidResponse => "The received response does not correspond to the earlier request",
+            Error::ReadOnlyPcrIndex => "Platform Configuration Register is in read-only mode and the operation attempted to modify it",
+        }
+    }
+}
+
+impl From<AttestationError> for Error {
+    fn from(e: AttestationError) -> Self {
+        Error::AttestationError(e)
+    }
+}
+
+impl From<ErrorCode> for Error {
+    fn from(e: ErrorCode) -> Self {
+        match e {
+            ErrorCode::InvalidArgument => Error::InvalidArgument,
+            ErrorCode::InvalidIndex => Error::InvalidPcrIndex,
+            ErrorCode::InvalidResponse => Error::InvalidResponse,
+            ErrorCode::ReadOnlyIndex => Error::ReadOnlyPcrIndex,
+            ErrorCode::InvalidOperation => Error::InvalidOperation,
+            ErrorCode::BufferTooSmall => Error::BufferTooSmall,
+            ErrorCode::InputTooLarge => Error::InputTooLarge,
+            ErrorCode::InternalError => Error::InternalError,
+            ErrorCode::Success => Error::InvalidResponse,
+        }
+    }
+}
+
+impl Nsm {
+    pub fn new() -> Result<Self, Error> {
+        let fd = nsm_driver::nsm_init();
+
+        if fd < 0 {
+            Err(Error::CannotOpenDriver)
+        } else {
+            Ok(Nsm(fd))
+        }
+    }
+
+    pub fn attest(&mut self, user_data: Option<ByteBuf>, nonce: Option<ByteBuf>, public_key: Option<ByteBuf>) -> Result<AttestationDocument<Unverified>, Error> {
+        let req = Request::Attestation {
+            user_data,
+            nonce,
+            public_key,
+        };
+        match nsm_driver::nsm_process_request(self.0, req) {
+            Response::Attestation { document } => Ok(AttestationDocument::from_slice(document.as_slice())?),
+            Response::Error(code) => Err(code.into()),
+            _ => Err(Error::InvalidResponse),
+        }
+    }
+}
+
+impl Drop for Nsm {
+    fn drop(&mut self) {
+        nsm_driver::nsm_exit(self.0);
+    }
+}

--- a/fortanix-vme/nsm/src/lib.rs
+++ b/fortanix-vme/nsm/src/lib.rs
@@ -132,6 +132,14 @@ impl Nsm {
         };
         nsm_driver::nsm_process_request(self.0, req).try_into()
     }
+
+    pub fn extend_pcr(&mut self, idx_pcr: u16, data: Vec<u8>) -> Result<Pcr, Error> {
+        let req = Request::ExtendPCR {
+            index: idx_pcr,
+            data,
+        };
+        nsm_driver::nsm_process_request(self.0, req).try_into()
+    }
 }
 
 impl Drop for Nsm {

--- a/fortanix-vme/nsm/src/lib.rs
+++ b/fortanix-vme/nsm/src/lib.rs
@@ -140,6 +140,17 @@ impl Nsm {
         };
         nsm_driver::nsm_process_request(self.0, req).try_into()
     }
+
+    pub fn lock_pcr(&mut self, idx_pcr: u16) -> Result<(), Error> {
+        let req = Request::LockPCR {
+            index: idx_pcr,
+        };
+        match nsm_driver::nsm_process_request(self.0, req) {
+            Response::LockPCR     => Ok(()),
+            Response::Error(code) => Err(code.into()),
+            _                     => Err(Error::InvalidResponse),
+        }
+    }
 }
 
 impl Drop for Nsm {

--- a/fortanix-vme/tests/nsm-test/Cargo.toml
+++ b/fortanix-vme/tests/nsm-test/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "nsm-test"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+nsm = { path = "../../nsm" }
+pkix = { version = "0.1" }

--- a/fortanix-vme/tests/nsm-test/out.expected
+++ b/fortanix-vme/tests/nsm-test/out.expected
@@ -1,0 +1,1 @@
+Hello, world!

--- a/fortanix-vme/tests/nsm-test/skip_on_dev_platform
+++ b/fortanix-vme/tests/nsm-test/skip_on_dev_platform
@@ -1,0 +1,1 @@
+Yes, this test only makes sense running as an AWS Nitro enclave

--- a/fortanix-vme/tests/nsm-test/src/main.rs
+++ b/fortanix-vme/tests/nsm-test/src/main.rs
@@ -38,4 +38,10 @@ fn main() {
     nsm.lock_pcr(16).unwrap();
     println!("pcr16 = {:?}", nsm.describe_pcr(10));
     assert_eq!(nsm.describe_pcr(16).unwrap().locked, true);
+
+    nsm.lock_pcrs(18).unwrap();
+    for pcr in 0..=18 {
+        println!("#pcr{} = {:?}", pcr, nsm.describe_pcr(pcr));
+        assert_eq!(nsm.describe_pcr(pcr).map(|val| val.locked), Ok(pcr < 18));
+    }
 }

--- a/fortanix-vme/tests/nsm-test/src/main.rs
+++ b/fortanix-vme/tests/nsm-test/src/main.rs
@@ -21,4 +21,10 @@ fn main() {
     assert_eq!(doc.user_data.unwrap(), user_data);
     println!("nonce: {:?}", doc.nonce);
     assert_eq!(doc.nonce.unwrap(), nonce);
+
+    for idx in 0..32 {
+        let pcr = nsm.describe_pcr(idx).unwrap();
+        println!("# pcr{} = {:?}", idx, pcr);
+        assert_eq!(pcr.locked, idx <= 15);
+    }
 }

--- a/fortanix-vme/tests/nsm-test/src/main.rs
+++ b/fortanix-vme/tests/nsm-test/src/main.rs
@@ -1,4 +1,4 @@
-use nsm::{ByteBuf, Nsm};
+use nsm::{ByteBuf, Digest, Nsm};
 
 fn main() {
     let mut nsm = Nsm::new().unwrap();
@@ -44,4 +44,13 @@ fn main() {
         println!("#pcr{} = {:?}", pcr, nsm.describe_pcr(pcr));
         assert_eq!(nsm.describe_pcr(pcr).map(|val| val.locked), Ok(pcr < 18));
     }
+
+    println!("# nsm description: {:#?}", nsm.describe().unwrap());
+    let description = nsm.describe().unwrap();
+    assert_eq!(description.version_major, 1);
+    assert_eq!(description.version_minor, 0);
+    assert_eq!(description.version_patch, 0);
+    assert_eq!(description.max_pcrs, 32);
+    assert_eq!(description.locked_pcrs.iter().count(), 18);
+    assert_eq!(description.digest, Digest::SHA384);
 }

--- a/fortanix-vme/tests/nsm-test/src/main.rs
+++ b/fortanix-vme/tests/nsm-test/src/main.rs
@@ -27,4 +27,11 @@ fn main() {
         println!("# pcr{} = {:?}", idx, pcr);
         assert_eq!(pcr.locked, idx <= 15);
     }
+
+    let pcr16 = nsm.extend_pcr(16, vec![41, 41, 41]);
+    println!("pcr16 = {:?}", pcr16);
+    let pcr16 = nsm.extend_pcr(16, vec![42, 42, 42]);
+    println!("pcr16 = {:?}", pcr16);
+    println!("pcr16 = {:?}", nsm.describe_pcr(16));
+    assert_eq!(nsm.describe_pcr(16).unwrap().locked, false);
 }

--- a/fortanix-vme/tests/nsm-test/src/main.rs
+++ b/fortanix-vme/tests/nsm-test/src/main.rs
@@ -1,0 +1,24 @@
+use nsm::{ByteBuf, Nsm};
+
+fn main() {
+    let mut nsm = Nsm::new().unwrap();
+    let user_data = ByteBuf::from(vec![0, 1, 2]);
+    let nonce = ByteBuf::from(vec![3, 4, 5]);
+    let pub_key = ByteBuf::from(vec![6, 7, 8]);
+    let doc = nsm.attest(Some(user_data.clone()), Some(nonce.clone()), Some(pub_key.clone())).unwrap();
+    println!("#module_id: {}", doc.module_id);
+    println!("#timestamp: {}", doc.timestamp);
+    println!("digest: {}", doc.digest);
+    assert_eq!(doc.digest, "SHA384");
+    for (idx, val) in doc.pcrs.iter() {
+        println!("# pcr{} = {:?}", idx, val);
+    }
+    println!("#certificate: {}", pkix::pem::der_to_pem(&doc.certificate, pkix::pem::PEM_CERTIFICATE));
+    println!("#cabundle: {:?}", doc.cabundle.iter().map(|cert| pkix::pem::der_to_pem(cert, pkix::pem::PEM_CERTIFICATE)).collect::<Vec::<String>>());
+    println!("public_key: {:?}", pkix::pem::der_to_pem(doc.public_key.as_ref().unwrap(), pkix::pem::PEM_CERTIFICATE));
+    assert_eq!(doc.public_key.unwrap(), pub_key);
+    println!("user_data: {:?}", doc.user_data);
+    assert_eq!(doc.user_data.unwrap(), user_data);
+    println!("nonce: {:?}", doc.nonce);
+    assert_eq!(doc.nonce.unwrap(), nonce);
+}

--- a/fortanix-vme/tests/nsm-test/src/main.rs
+++ b/fortanix-vme/tests/nsm-test/src/main.rs
@@ -53,4 +53,5 @@ fn main() {
     assert_eq!(description.max_pcrs, 32);
     assert_eq!(description.locked_pcrs.iter().count(), 18);
     assert_eq!(description.digest, Digest::SHA384);
+    assert!(nsm.get_random().is_ok());
 }

--- a/fortanix-vme/tests/nsm-test/src/main.rs
+++ b/fortanix-vme/tests/nsm-test/src/main.rs
@@ -34,4 +34,8 @@ fn main() {
     println!("pcr16 = {:?}", pcr16);
     println!("pcr16 = {:?}", nsm.describe_pcr(16));
     assert_eq!(nsm.describe_pcr(16).unwrap().locked, false);
+
+    nsm.lock_pcr(16).unwrap();
+    println!("pcr16 = {:?}", nsm.describe_pcr(10));
+    assert_eq!(nsm.describe_pcr(16).unwrap().locked, true);
 }

--- a/fortanix-vme/tests/nsm-test/src/main.rs
+++ b/fortanix-vme/tests/nsm-test/src/main.rs
@@ -6,26 +6,26 @@ fn main() {
     let nonce = ByteBuf::from(vec![3, 4, 5]);
     let pub_key = ByteBuf::from(vec![6, 7, 8]);
     let doc = nsm.attest(Some(user_data.clone()), Some(nonce.clone()), Some(pub_key.clone())).unwrap();
-    println!("#module_id: {}", doc.module_id);
-    println!("#timestamp: {}", doc.timestamp);
-    println!("digest: {}", doc.digest);
-    assert_eq!(doc.digest, "SHA384");
-    for (idx, val) in doc.pcrs.iter() {
+    println!("#module_id: {}", doc.module_id());
+    println!("#timestamp: {}", doc.timestamp());
+    println!("digest: {}", doc.digest());
+    assert_eq!(doc.digest(), "SHA384");
+    for (idx, val) in doc.pcrs().iter() {
         println!("# pcr{} = {:?}", idx, val);
     }
-    println!("#certificate: {}", pkix::pem::der_to_pem(&doc.certificate, pkix::pem::PEM_CERTIFICATE));
-    println!("#cabundle: {:?}", doc.cabundle.iter().map(|cert| pkix::pem::der_to_pem(cert, pkix::pem::PEM_CERTIFICATE)).collect::<Vec::<String>>());
-    println!("public_key: {:?}", pkix::pem::der_to_pem(doc.public_key.as_ref().unwrap(), pkix::pem::PEM_CERTIFICATE));
-    assert_eq!(doc.public_key.unwrap(), pub_key);
-    println!("user_data: {:?}", doc.user_data);
-    assert_eq!(doc.user_data.unwrap(), user_data);
-    println!("nonce: {:?}", doc.nonce);
-    assert_eq!(doc.nonce.unwrap(), nonce);
+    println!("#certificate: {}", pkix::pem::der_to_pem(&doc.certificate(), pkix::pem::PEM_CERTIFICATE));
+    println!("#cabundle: {:?}", doc.cabundle().iter().map(|cert| pkix::pem::der_to_pem(cert, pkix::pem::PEM_CERTIFICATE)).collect::<Vec::<String>>());
+    println!("public_key: {:?}", pkix::pem::der_to_pem(doc.public_key().as_ref().unwrap(), pkix::pem::PEM_CERTIFICATE));
+    assert_eq!(*doc.public_key().unwrap(), pub_key);
+    println!("user_data: {:?}", doc.user_data());
+    assert_eq!(*doc.user_data().unwrap(), user_data);
+    println!("nonce: {:?}", doc.nonce());
+    assert_eq!(*doc.nonce().unwrap(), nonce);
 
     for idx in 0..32 {
         let pcr = nsm.describe_pcr(idx).unwrap();
         println!("# pcr{} = {:?}", idx, pcr);
-        assert_eq!(pcr.locked, idx <= 15);
+        assert_eq!(pcr.locked(), idx <= 15);
     }
 
     let pcr16 = nsm.extend_pcr(16, vec![41, 41, 41]);
@@ -33,16 +33,16 @@ fn main() {
     let pcr16 = nsm.extend_pcr(16, vec![42, 42, 42]);
     println!("pcr16 = {:?}", pcr16);
     println!("pcr16 = {:?}", nsm.describe_pcr(16));
-    assert_eq!(nsm.describe_pcr(16).unwrap().locked, false);
+    assert_eq!(nsm.describe_pcr(16).unwrap().locked(), false);
 
     nsm.lock_pcr(16).unwrap();
     println!("pcr16 = {:?}", nsm.describe_pcr(10));
-    assert_eq!(nsm.describe_pcr(16).unwrap().locked, true);
+    assert_eq!(nsm.describe_pcr(16).unwrap().locked(), true);
 
     nsm.lock_pcrs(18).unwrap();
     for pcr in 0..=18 {
         println!("#pcr{} = {:?}", pcr, nsm.describe_pcr(pcr));
-        assert_eq!(nsm.describe_pcr(pcr).map(|val| val.locked), Ok(pcr < 18));
+        assert_eq!(nsm.describe_pcr(pcr).map(|val| val.locked()), Ok(pcr < 18));
     }
 
     println!("# nsm description: {:#?}", nsm.describe().unwrap());
@@ -51,7 +51,7 @@ fn main() {
     assert_eq!(description.version_minor, 0);
     assert_eq!(description.version_patch, 0);
     assert_eq!(description.max_pcrs, 32);
-    assert_eq!(description.locked_pcrs.iter().count(), 18);
+    assert_eq!(description.locked_pcrs().iter().count(), 18);
     assert_eq!(description.digest, Digest::SHA384);
     assert!(nsm.get_random().is_ok());
 }


### PR DESCRIPTION
The AWS `nsm-driver` and `nsm-io` crates provide an interface to the AWS Nitro Security Module (NSM), but this is not Rust friendly. This new `nsm` crate avoids having the same conversion everywhere.