### PR TITLE
[PLAT-268] Test connecting to and binding on `localhost`

### DIFF
--- a/fortanix-vme/aws-nitro-enclaves/tests/incoming_connection/out.expected
+++ b/fortanix-vme/aws-nitro-enclaves/tests/incoming_connection/out.expected
@@ -1,11 +1,11 @@
-Server run #1
+Running server on 127.0.0.1:3400
 Bind TCP socket to port 3400
 Listening for incoming connections...
 Waiting for connection 1
 Connection 1: Connected
 Waiting for connection 2
 Connection 2: Connected
-Server run #2
+Running server on localhost:3400
 Bind TCP socket to port 3400
 Listening for incoming connections...
 Waiting for connection 1

--- a/fortanix-vme/aws-nitro-enclaves/tests/incoming_connection/src/main.rs
+++ b/fortanix-vme/aws-nitro-enclaves/tests/incoming_connection/src/main.rs
@@ -3,9 +3,13 @@ use std::io::{ErrorKind, Read, Write};
 use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 
-fn server_run() {
+fn server_run(run: u32) {
     println!("Bind TCP socket to port 3400");
-    let listener = TcpListener::bind("127.0.0.1:3400").expect("Bind failed");
+    let listener = if run == 1 {
+        TcpListener::bind("127.0.0.1:3400").expect("Bind failed")
+    } else {
+        TcpListener::bind("localhost:3400").expect("Bind failed")
+    };
     assert_eq!(listener.local_addr().unwrap(), SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 3400));
 
     let fd = listener.as_raw_fd();
@@ -49,7 +53,7 @@ fn server_run() {
 fn main() {
     for run in 1..=2 {
         println!("Server run #{}", run);
-        server_run()
+        server_run(run)
     }
     println!("Bye bye");
 }

--- a/fortanix-vme/aws-nitro-enclaves/tests/incoming_connection/src/main.rs
+++ b/fortanix-vme/aws-nitro-enclaves/tests/incoming_connection/src/main.rs
@@ -1,15 +1,11 @@
 #![feature(io_error_uncategorized)]
 use std::io::{ErrorKind, Read, Write};
-use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 
-fn server_run(run: u32) {
+fn server_run<A: ToSocketAddrs>(addr: A) {
     println!("Bind TCP socket to port 3400");
-    let listener = if run == 1 {
-        TcpListener::bind("127.0.0.1:3400").expect("Bind failed")
-    } else {
-        TcpListener::bind("localhost:3400").expect("Bind failed")
-    };
+    let listener = TcpListener::bind(addr).expect("Bind failed");
     assert_eq!(listener.local_addr().unwrap(), SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 3400));
 
     let fd = listener.as_raw_fd();
@@ -51,9 +47,9 @@ fn server_run(run: u32) {
 }
 
 fn main() {
-    for run in 1..=2 {
-        println!("Server run #{}", run);
-        server_run(run)
+    for addr in &["127.0.0.1:3400", "localhost:3400"] {
+        println!("Running server on {}", addr);
+        server_run(addr)
     }
     println!("Bye bye");
 }

--- a/fortanix-vme/aws-nitro-enclaves/tests/outgoing_connection/out.expected
+++ b/fortanix-vme/aws-nitro-enclaves/tests/outgoing_connection/out.expected
@@ -1,1 +1,3 @@
 Connected to Google successfully!
+Connected to Google successfully!
+Connected to Google successfully!

--- a/fortanix-vme/aws-nitro-enclaves/tests/outgoing_connection/src/main.rs
+++ b/fortanix-vme/aws-nitro-enclaves/tests/outgoing_connection/src/main.rs
@@ -1,13 +1,13 @@
-use std::net::{Ipv4Addr, TcpStream};
+use std::net::TcpStream;
 use std::io::{Read, Write};
 
-fn main() {
+fn connect(host: &str, port: u16) {
+    let remote = format!("{}:{}", host, port);
     println!("# Running outgoing connection test");
-    let mut socket = TcpStream::connect(format!("google.com:80")).unwrap();
+    let mut socket = TcpStream::connect(remote).unwrap();
     // `socket.local_addr()` may return the actual local IP address, not 127.0.0.1
     assert!(socket.local_addr().unwrap().port() != 80);
-    assert!(socket.peer_addr().unwrap().ip() != Ipv4Addr::new(127, 0, 0, 1));
-    assert_eq!(socket.peer_addr().unwrap().port(), 80);
+    assert_eq!(socket.peer_addr().unwrap().port(), port);
     socket.write(b"GET / HTTP/1.1\n\n").unwrap();
     socket.flush().unwrap();
     let mut page = [0; 4192];
@@ -19,4 +19,10 @@ fn main() {
     } else {
         println!("Failed to read from connection, got: {}", page);
     }
+}
+
+fn main() {
+    connect("www.google.com", 80);
+    connect("127.0.0.1", 3080);
+    connect("localhost", 3080);
 }

--- a/fortanix-vme/aws-nitro-enclaves/tests/outgoing_connection/test_interaction.sh
+++ b/fortanix-vme/aws-nitro-enclaves/tests/outgoing_connection/test_interaction.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+function cleanup {
+    killall socat
+}
+
+trap cleanup err
+trap cleanup exit
+
+socat -v TCP-LISTEN:3080,fork TCP:www.google.com:80

--- a/fortanix-vme/ci-common.sh
+++ b/fortanix-vme/ci-common.sh
@@ -126,7 +126,7 @@ function cargo_test {
     fi
 
     if [ -f ./test_interaction.sh ]; then
-        kill ${test_interaction}
+        kill ${test_interaction} || true
     fi
 
     popd


### PR DESCRIPTION
An enclave should be able to bind a TCP listener on `localhost`. Likewise, it should be able to establish a local connection to the parent VM. Before this PR both scenarios worked correctly, but CI tests were missing.