### PR TITLE
Preparing crate publications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aesm-client"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "byteorder 1.3.4",
  "failure",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-ql"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "byteorder 1.3.4",
  "dcap-ql-sys",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-ql-sys"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "num-derive 0.2.5",
  "num-traits",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-retrieve-pckid"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aesm-client",
  "dcap-ql",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runner"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "crossbeam",
  "failure",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "fortanix-sgx-tools"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aesm-client",
  "clap",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "ipc-queue"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fortanix-sgx-abi",
  "futures 0.3.17",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "report-test"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "enclave-runner",
  "failure",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "sgx-isa"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bitflags 1.2.1",
  "mbedtls",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "sgx_pkix"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "byteorder 1.3.4",
  "lazy_static",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "byteorder 1.3.4",
  "crypto-hash",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs-loaders"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aesm-client",
  "bitflags 1.2.1",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs-tools"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "aesm-client",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,7 +1084,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fortanix-sgx-abi"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -31,7 +31,7 @@ yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 sgx_pkix = { version = "0.1.0", path = "../intel-sgx/sgx_pkix" }
-sgx-isa = { version = "0.3", path = "../intel-sgx/sgx-isa", default-features = false }
+sgx-isa = { version = "0.4", path = "../intel-sgx/sgx-isa", default-features = false }
 
 [target.x86_64-unknown-linux-musl.dependencies]
 aws-nitro-enclaves-nsm-api = "0.2.0"

--- a/intel-sgx/aesm-client/Cargo.toml
+++ b/intel-sgx/aesm-client/Cargo.toml
@@ -27,7 +27,7 @@ test-sgx = []
 [dependencies]
 # Project dependencies
 sgxs = { version = "0.7.0", path = "../sgxs", optional = true }
-sgx-isa = { version = "0.3.0", path = "../sgx-isa"}
+sgx-isa = { version = "0.4.0", path = "../sgx-isa"}
 
 # External dependencies
 byteorder = "1.0"          # Unlicense/MIT
@@ -53,6 +53,6 @@ libloading = "0.5.2"
 protoc-rust = "2.8.0" # MIT/Apache-2.0
 
 [dev-dependencies]
-sgx-isa = { version = "0.3.0", path = "../sgx-isa" }
+sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
 "report-test" = { version = "0.3.1", path = "../report-test" }
 "sgxs-loaders" = { version = "0.3.0", path = "../sgxs-loaders" }

--- a/intel-sgx/aesm-client/Cargo.toml
+++ b/intel-sgx/aesm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesm-client"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/dcap-ql-sys/Cargo.toml
+++ b/intel-sgx/dcap-ql-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-ql-sys"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Fortanix, Inc."]
 links = "sgx_dcap_ql"
 build = "build.rs"
@@ -24,7 +24,7 @@ link = []
 
 [dependencies]
 # Project dependencies
-"sgx-isa" = { version = "0.3.0", path = "../sgx-isa" }
+"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
 
 # External dependencies
 num-derive = "0.2" # MIT/Apache-2.0

--- a/intel-sgx/dcap-ql/Cargo.toml
+++ b/intel-sgx/dcap-ql/Cargo.toml
@@ -38,7 +38,7 @@ verify = ["mbedtls", "num", "yasna"]
 # Project dependencies
 "dcap-ql-sys" = { version = "0.2.0", path = "../dcap-ql-sys", optional = true }
 "sgxs-loaders" = { version = "0.3.0", path = "../sgxs-loaders", optional = true }
-"sgx-isa" = { version = "0.3.0", path = "../sgx-isa" }
+"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
 
 # External dependencies
 byteorder = "1.1.0" # Unlicense/MIT

--- a/intel-sgx/dcap-ql/Cargo.toml
+++ b/intel-sgx/dcap-ql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-ql"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/dcap-retrieve-pckid/Cargo.toml
+++ b/intel-sgx/dcap-retrieve-pckid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-retrieve-pckid"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -17,5 +17,5 @@ categories = ["command-line-utilities"]
 "aesm-client" = { version = "0.5.0", path = "../aesm-client", features = ["sgxs"] }
 "dcap-ql" = { version = "0.3.0", path = "../dcap-ql", default-features = false }
 "report-test" = { version = "0.3.1", path = "../report-test" }
-"sgx-isa" = { version = "0.3.0", path = "../sgx-isa" }
+"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
 "sgxs-loaders" = { version = "0.3.0", path = "../sgxs-loaders" }

--- a/intel-sgx/enclave-runner/Cargo.toml
+++ b/intel-sgx/enclave-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runner"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/enclave-runner/Cargo.toml
+++ b/intel-sgx/enclave-runner/Cargo.toml
@@ -22,7 +22,7 @@ exclude = ["fake-vdso/.gitignore", "fake-vdso/Makefile", "fake-vdso/main.S"]
 # Project dependencies
 sgxs = { version = "0.7.2", path = "../sgxs" }
 fortanix-sgx-abi = { version = "0.4.0", path = "../fortanix-sgx-abi" }
-sgx-isa = { version = "0.3.0", path = "../sgx-isa" }
+sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
 ipc-queue = { version = "0.1.0", path = "../../ipc-queue" }
 
 # External dependencies

--- a/intel-sgx/fortanix-sgx-abi/Cargo.toml
+++ b/intel-sgx/fortanix-sgx-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortanix-sgx-abi"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/fortanix-sgx-tools/Cargo.toml
+++ b/intel-sgx/fortanix-sgx-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortanix-sgx-tools"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -23,7 +23,7 @@ aesm-client = { version = "0.5.0", path = "../aesm-client", features = ["sgxs"] 
 sgxs-loaders = { version = "0.3.0", path = "../sgxs-loaders" }
 enclave-runner = { version = "0.5.0", path = "../enclave-runner" }
 sgxs = { version = "0.7.0", path = "../sgxs" }
-sgx-isa = { version = "0.3.0", path = "../sgx-isa" }
+sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
 
 # External dependencies
 xmas-elf = "0.6.0"         # Apache-2.0/MIT

--- a/intel-sgx/report-test/Cargo.toml
+++ b/intel-sgx/report-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "report-test"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -18,7 +18,7 @@ categories = ["development-tools"]
 # Project dependencies
 "enclave-runner" = { version = "0.5.0", path = "../enclave-runner" }
 "sgxs" = { version = "0.7.0", path = "../sgxs" }
-"sgx-isa" = { version = "0.3.0", path = "../sgx-isa" }
+"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
 
 # External dependencies
 failure = "0.1.1"   # MIT/Apache-2.0

--- a/intel-sgx/sgx-isa/Cargo.toml
+++ b/intel-sgx/sgx-isa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgx-isa"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/sgx_pkix/Cargo.toml
+++ b/intel-sgx/sgx_pkix/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Unfortunately crates.io prevents us from changing the name to `sgx-pkix`
 name = "sgx_pkix"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"
@@ -13,6 +13,6 @@ categories = ["cryptography"]
 [dependencies]
 byteorder = "1.0"
 pkix = "0.1.1"
-sgx-isa = { version = "0.3", path = "../sgx-isa" }
+sgx-isa = { version = "0.4", path = "../sgx-isa" }
 quick-error = "1.1.0"
 lazy_static = "1"

--- a/intel-sgx/sgxs-loaders/Cargo.toml
+++ b/intel-sgx/sgxs-loaders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-loaders"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -26,7 +26,7 @@ no_sgx_enclave_common = []
 [dependencies]
 # Project dependencies
 "sgxs" = { version = "0.7.0", path = "../sgxs" }
-"sgx-isa" = { version = "0.3.0", path = "../sgx-isa" }
+"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
 
 # External dependencies
 bitflags = "1"           # MIT/Apache-2.0

--- a/intel-sgx/sgxs-tools/Cargo.toml
+++ b/intel-sgx/sgxs-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-tools"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/sgxs-tools/Cargo.toml
+++ b/intel-sgx/sgxs-tools/Cargo.toml
@@ -32,7 +32,7 @@ path = "src/sgx_detect/main.rs"
 "sgxs" = { version = "0.7.0", path = "../sgxs", features = ["crypto-openssl"] }
 "sgxs-loaders" = { version = "0.3.0", path = "../sgxs-loaders" }
 "aesm-client" = { version = "0.5.0", path = "../aesm-client", features = ["sgxs"] }
-"sgx-isa" = { version = "0.3.0", path = "../sgx-isa" }
+"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
 "report-test" = { version = "0.3.1", path = "../report-test" }
 "enclave-runner" = { version = "0.5.0", path = "../enclave-runner" }
 

--- a/intel-sgx/sgxs/Cargo.toml
+++ b/intel-sgx/sgxs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -14,7 +14,7 @@ categories = ["parsing", "encoding"]
 
 [dependencies]
 # Project dependencies
-sgx-isa = { version = "0.3.1", path = "../sgx-isa" }
+sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
 
 # External dependencies
 byteorder = "1.0"                                     # Unlicense/MIT

--- a/ipc-queue/Cargo.toml
+++ b/ipc-queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-queue"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
In order to publish crates, some crates' version numbers need to be bumped. The following crates can/should be published:
- em-app
- fortanix-sgx-abi
- aesm-client
- dcap-ql-sys
- dcap-ql
- dcap-retrieve-pckid
- enclave-runner
- fortanix-sgx-tools
- report-test
- sgx-pkix
- sgxs-loaders
- sgxs-tools
- sgxs
- ipc-queue