### PR TITLE
Allow users to redirect enclave standard input/output

### DIFF
--- a/intel-sgx/enclave-runner/src/command.rs
+++ b/intel-sgx/enclave-runner/src/command.rs
@@ -10,8 +10,7 @@ use failure::Error;
 use sgxs::loader::{Load, MappingInfo};
 
 use crate::loader::{EnclaveBuilder, ErasedTcs};
-use crate::usercalls::EnclaveState;
-use crate::usercalls::UsercallExtension;
+use crate::usercalls::{EnclaveState, EnclaveStdio, UsercallExtension};
 use std::os::raw::c_void;
 
 #[derive(Debug)]
@@ -21,6 +20,7 @@ pub struct Command {
     address: usize,
     size: usize,
     usercall_ext: Option<Box<dyn UsercallExtension>>,
+    stdio: EnclaveStdio,
     forward_panics: bool,
     cmd_args: Vec<Vec<u8>>,
 }
@@ -43,6 +43,7 @@ impl Command {
         address: *mut c_void,
         size: usize,
         usercall_ext: Option<Box<dyn UsercallExtension>>,
+        stdio: EnclaveStdio,
         forward_panics: bool,
         cmd_args: Vec<Vec<u8>>,
     ) -> Command {
@@ -53,6 +54,7 @@ impl Command {
             address: address as _,
             size,
             usercall_ext,
+            stdio,
             forward_panics,
             cmd_args,
         }
@@ -63,6 +65,13 @@ impl Command {
     }
 
     pub fn run(self) -> Result<(), Error> {
-        EnclaveState::main_entry(self.main, self.threads, self.usercall_ext, self.forward_panics, self.cmd_args)
+        EnclaveState::main_entry(
+            self.main,
+            self.threads,
+            self.usercall_ext,
+            self.stdio,
+            self.forward_panics,
+            self.cmd_args,
+        )
     }
 }

--- a/intel-sgx/enclave-runner/src/library.rs
+++ b/intel-sgx/enclave-runner/src/library.rs
@@ -11,8 +11,7 @@ use failure::Error;
 use sgxs::loader::{Load, MappingInfo};
 
 use crate::loader::{EnclaveBuilder, ErasedTcs};
-use crate::usercalls::EnclaveState;
-use crate::usercalls::UsercallExtension;
+use crate::usercalls::{EnclaveState, EnclaveStdio, UsercallExtension};
 use std::fmt;
 use std::os::raw::c_void;
 
@@ -47,10 +46,11 @@ impl Library {
         address: *mut c_void,
         size: usize,
         usercall_ext: Option<Box<dyn UsercallExtension>>,
+        stdio: EnclaveStdio,
         forward_panics: bool,
     ) -> Library {
         Library {
-            enclave: EnclaveState::library(tcss, usercall_ext, forward_panics),
+            enclave: EnclaveState::library(tcss, usercall_ext, stdio, forward_panics),
             address,
             size,
         }

--- a/intel-sgx/enclave-runner/src/loader.rs
+++ b/intel-sgx/enclave-runner/src/loader.rs
@@ -8,7 +8,7 @@ use std::fs::File;
 use std::io::{Error as IoError, ErrorKind, Read, Result as IoResult};
 use std::os::raw::c_void;
 use std::path::Path;
-use std::{arch, str};
+use std::{arch, mem, str};
 
 use failure::{format_err, Error, ResultExt};
 use failure_derive::Fail;
@@ -23,9 +23,10 @@ use sgx_isa::{Attributes, AttributesFlags, Miscselect, Sigstruct};
 use sgxs::crypto::{SgxHashOps, SgxRsaOps};
 use sgxs::loader::{Load, MappingInfo, Tcs};
 use sgxs::sigstruct::{self, EnclaveHash, Signer};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::tcs::DebugBuffer;
-use crate::usercalls::UsercallExtension;
+use crate::usercalls::{EnclaveStdio, ReadOnlyStream, UsercallExtension, WriteOnlyStream};
 use crate::{Command, Library};
 
 enum EnclaveSource<'a> {
@@ -65,6 +66,7 @@ pub struct EnclaveBuilder<'a> {
     attributes: Option<Attributes>,
     miscselect: Option<Miscselect>,
     usercall_ext: Option<Box<dyn UsercallExtension>>,
+    stdio: EnclaveStdio,
     load_and_sign: Option<Box<dyn FnOnce(Signer) -> Result<Sigstruct, Error>>>,
     hash_enclave: Option<Box<dyn FnOnce(&mut EnclaveSource<'_>) -> Result<EnclaveHash, Error>>>,
     forward_panics: bool,
@@ -142,6 +144,7 @@ impl<'a> EnclaveBuilder<'a> {
             miscselect: None,
             signature: None,
             usercall_ext: None,
+            stdio: EnclaveStdio::default(),
             load_and_sign: None,
             hash_enclave: None,
             forward_panics: false,
@@ -256,6 +259,24 @@ impl<'a> EnclaveBuilder<'a> {
         self.usercall_ext = Some(extension.into());
     }
 
+    /// Redirect the enclave's stdin. Defaults to the current process stdin.
+    pub fn stdin(&mut self, stream: impl AsyncRead + Send + Sync + 'static) -> &mut Self {
+        self.stdio.stdin = Some(ReadOnlyStream::new(stream));
+        self
+    }
+
+    /// Redirect the enclave's stdout. Defaults to the current process stdout.
+    pub fn stdout(&mut self, stream: impl AsyncWrite + Send + Sync + 'static) -> &mut Self {
+        self.stdio.stdout = Some(WriteOnlyStream::new(stream));
+        self
+    }
+
+    /// Redirect the enclave's stderr. Defaults to the current process stderr.
+    pub fn stderr(&mut self, stream: impl AsyncWrite + Send + Sync + 'static) -> &mut Self {
+        self.stdio.stderr = Some(WriteOnlyStream::new(stream));
+        self
+    }
+
     /// Whether to panic the runner if any enclave thread panics.
     /// Defaults to `false`.
     /// Note: If multiple enclaves are loaded, and an enclave with this set to
@@ -334,8 +355,9 @@ impl<'a> EnclaveBuilder<'a> {
     pub fn build<T: Load>(mut self, loader: &mut T) -> Result<Command, Error> {
         let args = self.cmd_args.take().unwrap_or_default();
         let c = self.usercall_ext.take();
+        let io = mem::take(&mut self.stdio);
         self.load(loader)
-            .map(|(t, a, s, fp)| Command::internal_new(t, a, s, c, fp, args))
+            .map(|(t, a, s, fp)| Command::internal_new(t, a, s, c, io, fp, args))
     }
 
     /// Panics if you have previously called [`arg`] or [`args`].
@@ -347,7 +369,8 @@ impl<'a> EnclaveBuilder<'a> {
             panic!("Command arguments do not apply to Library enclaves.");
         }
         let c = self.usercall_ext.take();
+        let io = mem::take(&mut self.stdio);
         self.load(loader)
-            .map(|(t, a, s, fp)| Library::internal_new(t, a, s, c, fp))
+            .map(|(t, a, s, fp)| Library::internal_new(t, a, s, c, io, fp))
     }
 }


### PR DESCRIPTION
Hi all! This PR adds `EnclaveBuilder::stdin`, `EnclaveBuilder::stdout`, and `EnclaveBuilder::stderr` methods for optionally redirecting each stdio stream. My main use-case for this change is to do backtrace symbolizing in the enclave runner itself, rather than an outside wrapper script like [intel-sgx/scripts/stack-trace-resolve](https://github.com/fortanix/rust-sgx/blob/master/intel-sgx/scripts/stack-trace-resolve). I found this to be cleaner; it keeps everything self-contained and the backtraces just come out exactly as you would expect.