### PR TITLE
Version bump `tokio` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
  "openssl",
  "sgx-isa",
  "sgxs",
- "tokio 0.2.22",
+ "tokio 1.14.0",
 ]
 
 [[package]]
@@ -1262,7 +1262,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1459,7 +1459,7 @@ checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
  "http 0.2.5",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa 0.4.6",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "socket2",
  "tokio 1.14.0",
  "tower-service",
@@ -1694,7 +1694,7 @@ dependencies = [
  "fortanix-sgx-abi",
  "futures 0.3.17",
  "static_assertions",
- "tokio 0.2.22",
+ "tokio 1.14.0",
 ]
 
 [[package]]
@@ -1985,29 +1985,6 @@ dependencies = [
  "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
-dependencies = [
- "log 0.4.14",
- "mio 0.6.22",
- "miow 0.3.7",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.22",
 ]
 
 [[package]]
@@ -2604,12 +2581,6 @@ dependencies = [
  "quote 1.0.10",
  "syn 1.0.81",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
 
 [[package]]
 name = "pin-project-lite"
@@ -3732,39 +3703,21 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "libc",
- "memchr",
- "mio 0.6.22",
- "mio-named-pipes",
- "mio-uds",
- "num_cpus",
- "pin-project-lite 0.1.10",
- "signal-hook-registry",
- "slab",
- "tokio-macros",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg 1.0.1",
+ "bytes 1.1.0",
  "libc",
+ "memchr",
  "mio 0.7.14",
  "num_cpus",
- "pin-project-lite 0.2.7",
+ "once_cell",
+ "parking_lot 0.11.2",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
@@ -3812,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
@@ -3942,7 +3895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "tracing-core",
 ]
 

--- a/examples/usercall-extension-bind/runner/Cargo.toml
+++ b/examples/usercall-extension-bind/runner/Cargo.toml
@@ -10,4 +10,5 @@ aesm-client = { version = "0.5.0", features = ["sgxs"], path="../../../intel-sgx
 enclave-runner = { version = "0.5.0", path="../../../intel-sgx/enclave-runner"}
 sgxs-loaders = { version = "0.3.0",   path="../../../intel-sgx/sgxs-loaders"}
 futures = "0.3"
-tokio = { version = "0.2", features = ["net", "io-util"] }
+tokio = { version = "1.20", features = ["net", "io-util"] }
+tokio-stream = { version = "0.1.9", features = ["net"] }

--- a/examples/usercall-extension-bind/runner/src/main.rs
+++ b/examples/usercall-extension-bind/runner/src/main.rs
@@ -17,6 +17,7 @@ use std::task::{Context, Poll};
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 use tokio::io::{self, AsyncRead, AsyncReadExt};
 use tokio::net::{TcpListener, TcpStream};
+use tokio_stream::wrappers::TcpListenerStream;
 
 use aesm_client::AesmClient;
 use enclave_runner::usercalls::{AsyncListener, AsyncStream, UsercallExtension};
@@ -210,7 +211,7 @@ impl ProxyProtocol {
                 Ok(local_address) => local_address.to_string(),
                 Err(_) => "error".to_string(),
             };
-            let listen_stream = listener.and_then(|mut stream| { async {
+            let listen_stream = TcpListenerStream::new(listener).and_then(|mut stream| { async {
                 let proxied_addrs = read_proxy_protocol_header(&mut stream).await?;
                 Ok((stream, proxied_addrs))
             }}).boxed();

--- a/examples/usercall-extension/runner/Cargo.toml
+++ b/examples/usercall-extension/runner/Cargo.toml
@@ -10,5 +10,5 @@ aesm-client = { version = "0.5.0", features = ["sgxs"], path="../../../intel-sgx
 enclave-runner = { version = "0.5.0", path="../../../intel-sgx/enclave-runner"}
 sgxs-loaders = { version = "0.3.0",   path="../../../intel-sgx/sgxs-loaders"}
 futures = "0.3"
-tokio = { version = "0.2", features = ["process"] }
+tokio = { version = "1.20", features = ["process"] }
 pin-utils = "0.1"

--- a/examples/usercall-extension/runner/src/main.rs
+++ b/examples/usercall-extension/runner/src/main.rs
@@ -11,7 +11,7 @@ use std::process::Stdio;
 use std::task::{Context, Poll};
 
 use futures::FutureExt;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::process::{ChildStdin, ChildStdout, Command};
 
 use aesm_client::AesmClient;
@@ -49,8 +49,8 @@ impl AsyncRead for CatService {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context,
-        buf: &mut [u8]
-    ) -> Poll<IoResult<usize>> {
+        buf: &mut ReadBuf,
+    ) -> Poll<IoResult<()>> {
         self.stdout().poll_read(cx, buf)
     }
 }

--- a/intel-sgx/enclave-runner/Cargo.toml
+++ b/intel-sgx/enclave-runner/Cargo.toml
@@ -35,8 +35,8 @@ nix = "0.13.0"                                  # MIT
 openssl = { version = "0.10", optional = true } # Apache-2.0
 crossbeam = "0.7.1"                             # MIT/Apache-2.0
 num_cpus = "1.10.0"                             # MIT/Apache-2.0
-tokio = { version = "0.2", features = ["full"] } # MIT
-futures = { version = "0.3", features = ["compat", "io-compat"] } # MIT/Apache-2.0
+tokio = { version = "1", features = ["full"] }  # MIT
+futures = "0.3"                                 # MIT/Apache-2.0
 
 [features]
 default = ["crypto-openssl"]

--- a/ipc-queue/Cargo.toml
+++ b/ipc-queue/Cargo.toml
@@ -21,7 +21,7 @@ static_assertions = "1.1.0"
 
 [target.'cfg(not(target_env = "sgx"))'.dev-dependencies]
 futures = { version = "0.3", features = ["compat", "io-compat"] }
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 
 [package.metadata.fortanix-sgx]
 # set number of threads so tests can run properly

--- a/ipc-queue/src/interface_async.rs
+++ b/ipc-queue/src/interface_async.rs
@@ -169,11 +169,11 @@ mod tests {
             }
         }
 
-        fn send(&self, val: T) -> Result<(), broadcast::SendError<T>> {
+        fn send(&self, val: T) -> Result<(), broadcast::error::SendError<T>> {
             self.tx.send(val).map(|_| ())
         }
 
-        async fn recv(&self) -> Result<T, broadcast::RecvError> {
+        async fn recv(&self) -> Result<T, broadcast::error::RecvError> {
             let mut rx = self.rx.lock().await;
             rx.recv().await
         }


### PR DESCRIPTION
I've tried to touch as little as possible since I saw that there's a bigger PR that touches the enclave-runner to add async support to enclave interface.