### PR TITLE
Fix IAS crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "ias"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "aesm-client",
  "base64 0.13.0",

--- a/intel-sgx/ias/Cargo.toml
+++ b/intel-sgx/ias/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ias"
-version = "0.2.0"
+version = "0.1.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
We never released any version. So it should be 0.1.0.