### PR TITLE
Change sgx_pkix crate version to 0.2.0. EDP-99.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "em-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "b64-ct",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "ias"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aesm-client",
  "base64 0.13.0",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "sgx_pkix"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "byteorder 1.3.4",
  "lazy_static",

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "em-app"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["fortanix.com"]
 license = "MPL-2.0"
 edition = "2018"
@@ -30,7 +30,7 @@ uuid_sdkms = { package = "uuid", version = "0.7.4", features = ["v4", "serde"] }
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
-sgx_pkix = { version = "0.1.0", path = "../intel-sgx/sgx_pkix" }
+sgx_pkix = { version = "0.2.0", path = "../intel-sgx/sgx_pkix" }
 sgx-isa = { version = "0.4", path = "../intel-sgx/sgx-isa", default-features = false }
 
 [target.x86_64-unknown-linux-musl.dependencies]

--- a/intel-sgx/ias/Cargo.toml
+++ b/intel-sgx/ias/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ias"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -24,7 +24,7 @@ mbedtls = { version = "0.8.0", features = ["std"], default-features = false, opt
 pkix = "0.1"
 
 sgx-isa = { version = "0.4", path = "../sgx-isa" }
-sgx_pkix = { version = "0.1", path = "../sgx_pkix" }
+sgx_pkix = { version = "0.2", path = "../sgx_pkix" }
 
 [target.'cfg(not(target_env="sgx"))'.dependencies]
 reqwest = { version = "0.11", features = ["json"], optional = true }

--- a/intel-sgx/sgx_pkix/Cargo.toml
+++ b/intel-sgx/sgx_pkix/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Unfortunately crates.io prevents us from changing the name to `sgx-pkix`
 name = "sgx_pkix"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"


### PR DESCRIPTION
sgx_pkix version 0.1.2 was incorrectly numbered. This version changed the version of sgx-isa used, which in turn changed the version of the mbedtls dependency. mbedtls 0.8.0 is not compatible with version 0.7.0, so version 0.1.2 is not compatible with code that was using 0.1.1. This release should have been numbered 0.2.0.

Two other crates directly depend on sgx_pkix: em-app and ias. I've updated their dependencies, and bumped the third digit in their versions. We will want to yank sgx_pkix version 0.1.2,  em-app version 3.0, and ias version 1.0 when the new versions are published.