### PR TITLE
 Indicate that sgx_pkix is compatible with pkix v0.1.x and v0.2.x.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "sgx_pkix"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "byteorder 1.3.4",
  "lazy_static",

--- a/intel-sgx/sgx_pkix/Cargo.toml
+++ b/intel-sgx/sgx_pkix/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Unfortunately crates.io prevents us from changing the name to `sgx-pkix`
 name = "sgx_pkix"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"

--- a/intel-sgx/sgx_pkix/Cargo.toml
+++ b/intel-sgx/sgx_pkix/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography"]
 
 [dependencies]
 byteorder = "1.0"
-pkix = "0.1.1"
+pkix = ">=0.1.1, <0.3.0"
 sgx-isa = { version = "0.4", path = "../sgx-isa" }
 quick-error = "1.1.0"
 lazy_static = "1"


### PR DESCRIPTION
Similar to #420, but now for the master branch (0.2.x) of `sgx_pkix`.