### PR TITLE
Backport get_certificate() function from em-app 0.3 to em-app 0.2.

### DIFF
--- a/em-app/Cargo.lock
+++ b/em-app/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "em-app"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "b64-ct",
  "em-node-agent-client",

--- a/em-app/Cargo.lock
+++ b/em-app/Cargo.lock
@@ -262,6 +262,7 @@ version = "0.2.1"
 dependencies = [
  "b64-ct",
  "em-node-agent-client",
+ "hex",
  "hyper",
  "mbedtls",
  "pkix",
@@ -331,6 +332,12 @@ checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "httparse"

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "em-app"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["fortanix.com"]
 license = "MPL-2.0"
 edition = "2018"

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -15,6 +15,7 @@ keywords = [ "sgx" ]
 hyper = { version = "0.10", default-features = false }
 mbedtls = { version = "0.7", default-features = false, features = ["sgx"] }
 b64-ct = "0.1.0"
+hex = ">=0.3, <0.5"
 serde_bytes = "0.10"
 serde_json = "1.0"
 sgx-isa = { version="0.3", features=["sgxstd"], default-features=false }


### PR DESCRIPTION
This PR adds the `get_certificate()` function that is available in `em-app 0.3` to `em-app 0.2` in a backwards-compatible way.