### PR TITLE
Fix bors on em-app_v0.2.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 branches:
   only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
     # Branch for continued development of em-app v0.2.x
     - em-app_v0.2.x
 language: rust


### PR DESCRIPTION
Now that the `em-app_v0.2.x` branch has been marked as a protected branch, `bors` is enabled on it. The `.travis.yml` file on that branch doesn't have the `staging` or `trying` branches listed, which means CI won't be started for those branches and `bors` will time out on `bors r` and `bors try` commands. This PR attempts to fix that by adding those branches to the `.travis.yml` file.