### PR TITLE
Fix bors on sgx-pkix_v0.1.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 branches:
   only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
     # Branch for continued development of sgx-pkix v0.1.x
     - sgx-pkix_v0.1.x
 language: rust


### PR DESCRIPTION
Same as #427, but now for the `sgx-pkix_v0.1.x` branch.

Now that the `sgx-pkix_v0.1.x` branch has been marked as a protected branch, bors is enabled on it. The `.travis.yml` file on that branch doesn't have the `staging` or `trying` branches listed, which means CI won't be started for those branches and bors will time out on `bors r` and `bors try` commands. This PR attempts to fix that by adding those branches to the `.travis.yml` file.