### PR TITLE
sgxs crate changes to enable offline signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "byteorder 1.3.4",
  "crypto-hash",

--- a/intel-sgx/sgxs/CHANGELOG.md
+++ b/intel-sgx/sgxs/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Version 0.7.4 - 2022-12-21
+
+## New Features
+- Refactored the signing APIs to permit signatures to be generated separately (for example using an HSM).
+  The way to use this new functionality is to construct a Sigstruct as usual and call
+  `sigstruct.unsigned_hash()` to produce the hash that must be signed externally. Once the signature is
+  available, reconstruct the sigstruct and call `sigstruct.cat_sign()` with the signature to get the signed
+  and populated Sigstruct.
+- If you are using a custom key implementation, you will need to implement the new `SgxRsaPubOps()`
+  trait for your key. This trait must provide a `calculate_q1_q2()` method that calculates the q1 and q1
+  values for a given signature. The q1 and q2 calculation is the same as for the existing
+  `sign_sha256_pkcs1v1_5_with_q1_q2()` method, but the `calculate_q1_q2()` method takes the signature
+  as a parameter instead of creating the signature.
+
+

--- a/intel-sgx/sgxs/Cargo.toml
+++ b/intel-sgx/sgxs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/sgxs/src/crypto/mod.rs
+++ b/intel-sgx/sgxs/src/crypto/mod.rs
@@ -51,6 +51,9 @@ pub trait SgxRsaOps {
 
     /// Retrieve the modulus in little-endian format
     fn n(&self) -> Vec<u8>;
+
+    /// Calculate q1 and q2 for a signature
+    fn calculate_q1_q2(&self, s_slice: &[u8]) -> Result<(Vec<u8>, Vec<u8>), Self::Error>;
 }
 
 #[cfg(feature = "crypto-openssl")]
@@ -137,32 +140,7 @@ mod openssl {
                 }
             };
 
-            // Compute Q1 and Q2
-            let mut s_2 = BigNum::new()?;
-            let mut s_3 = BigNum::new()?;
-            let mut q1 = BigNum::new()?;
-            let mut tmp1 = BigNum::new()?;
-            let mut tmp2 = BigNum::new()?;
-            let mut tmp3 = BigNum::new()?;
-            let mut q2 = BigNum::new()?;
-
-            let mut ctx = BigNumContext::new()?;
-            let s = BigNum::from_slice(&s_vec)?;
-            let n = self.n();
-            s_2.sqr(&s, &mut ctx)?;
-            q1.checked_div(&s_2, &n, &mut ctx)?;
-
-            s_3.checked_mul(&s_2, &s, &mut ctx)?;
-            tmp1.checked_mul(&q1, &s, &mut ctx)?;
-            tmp2.checked_mul(&tmp1, &n, &mut ctx)?;
-            tmp3.checked_sub(&s_3, &tmp2)?;
-            q2.checked_div(&tmp3, &n, &mut ctx)?;
-            let mut q1 = q1.to_vec();
-            let mut q2 = q2.to_vec();
-
-            // Return in little-endian format
-            q1.reverse();
-            q2.reverse();
+            let (q1, q2) = self.calculate_q1_q2(&s_vec)?;
             s_vec.reverse();
             Ok((s_vec, q1, q2))
         }
@@ -206,6 +184,36 @@ mod openssl {
             let mut v = self.n().to_vec();
             v.reverse();
             v
+        }
+
+        fn calculate_q1_q2(&self, s_slice: &[u8]) -> Result<(Vec<u8>, Vec<u8>), Self::Error> {
+            // Compute Q1 and Q2
+            let mut s_2 = BigNum::new()?;
+            let mut s_3 = BigNum::new()?;
+            let mut q1 = BigNum::new()?;
+            let mut tmp1 = BigNum::new()?;
+            let mut tmp2 = BigNum::new()?;
+            let mut tmp3 = BigNum::new()?;
+            let mut q2 = BigNum::new()?;
+
+            let mut ctx = BigNumContext::new()?;
+            let s = BigNum::from_slice(s_slice)?;
+            let n = self.n();
+            s_2.sqr(&s, &mut ctx)?;
+            q1.checked_div(&s_2, &n, &mut ctx)?;
+
+            s_3.checked_mul(&s_2, &s, &mut ctx)?;
+            tmp1.checked_mul(&q1, &s, &mut ctx)?;
+            tmp2.checked_mul(&tmp1, &n, &mut ctx)?;
+            tmp3.checked_sub(&s_3, &tmp2)?;
+            q2.checked_div(&tmp3, &n, &mut ctx)?;
+            let mut q1 = q1.to_vec();
+            let mut q2 = q2.to_vec();
+
+            // Return in little-endian format
+            q1.reverse();
+            q2.reverse();
+            Ok((q1, q2))
         }
     }
 }

--- a/intel-sgx/sgxs/src/sigstruct.rs
+++ b/intel-sgx/sgxs/src/sigstruct.rs
@@ -105,13 +105,13 @@ impl Signer {
         hasher.finish()
     }
 
-    pub fn unsigned_hash<H: SgxHashOps>(self) -> Hash {
+    pub fn unsigned_hash<H: SgxHashOps>(&self) -> Hash {
         let sig = Self::unsigned_sig(self);
 
         Self::sighash::<H>(&sig)
     }
 
-    pub fn unsigned_sig(self) -> Sigstruct {
+    pub fn unsigned_sig(&self) -> Sigstruct {
         let sig = Sigstruct {
             header: SIGSTRUCT_HEADER1,
             vendor: 0,
@@ -145,7 +145,7 @@ impl Signer {
     pub fn sign<K: SgxRsaOps, H: SgxHashOps>(self, key: &K) -> Result<Sigstruct, K::Error> {
         Self::check_key(key);
 
-        let mut sig = Self::unsigned_sig(self);
+        let mut sig = Self::unsigned_sig(&self);
 
         let (s, q1, q2) = key.sign_sha256_pkcs1v1_5_with_q1_q2(Self::sighash::<H>(&sig))?;
         let n = key.n();
@@ -162,13 +162,13 @@ impl Signer {
     /// Adds a signature from raw bytes. This is used to add a signature
     /// generated in an out-of-band process outside of sgxs-tools.
     pub fn cat_sign<K: SgxRsaOps>(
-        self,
+        &self,
         key: &K,
         mut s_vec: Vec<u8>,
     ) -> Result<Sigstruct, K::Error> {
         Self::check_key(key);
 
-        let mut sig = Self::unsigned_sig(self);
+        let mut sig = Self::unsigned_sig(&self);
         let (q1, q2) = key.calculate_q1_q2(&s_vec)?;
 
         // The signature is read in as big-endian. It must be little-endian for

--- a/intel-sgx/sgxs/src/sigstruct.rs
+++ b/intel-sgx/sgxs/src/sigstruct.rs
@@ -11,7 +11,7 @@ use time;
 
 use abi::{self, SIGSTRUCT_HEADER1, SIGSTRUCT_HEADER2};
 pub use abi::{Attributes, AttributesFlags, Miscselect, Sigstruct};
-use crypto::{Hash, SgxHashOps, SgxRsaOps};
+use crypto::{Hash, SgxHashOps, SgxRsaOps, SgxRsaPubOps};
 use sgxs::{copy_measured, SgxsRead};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -161,11 +161,11 @@ impl Signer {
 
     /// Adds a signature from raw bytes. This is used to add a signature
     /// generated in an out-of-band process outside of sgxs-tools.
-    pub fn cat_sign<K: SgxRsaOps>(
+    pub fn cat_sign<K: SgxRsaPubOps + SgxRsaOps>(
         &self,
         key: &K,
         mut s_vec: Vec<u8>,
-    ) -> Result<Sigstruct, K::Error> {
+    ) -> Result<Sigstruct, <K as SgxRsaPubOps>::Error> {
         Self::check_key(key);
 
         let mut sig = Self::unsigned_sig(&self);

--- a/intel-sgx/sgxs/src/sigstruct.rs
+++ b/intel-sgx/sgxs/src/sigstruct.rs
@@ -24,6 +24,10 @@ impl EnclaveHash {
         EnclaveHash { hash }
     }
 
+    pub fn hash(&self) -> Hash {
+        self.hash
+    }
+
     pub fn from_stream<R: SgxsRead, H: SgxHashOps>(stream: &mut R) -> Result<Self, Error> {
         struct WriteToHasher<H> {
             hasher: H,


### PR DESCRIPTION
This change adds new interfaces to the `sgxs` crate to make it possible to sign enclaves separately from creating the sigstructs. This is useful, for example, for performing signing via an HSM.

The first two commits in this sequence come from this pull request from ravenac95: https://github.com/fortanix/rust-sgx/pull/327. I did not include the changes to the command-line sgx-sign tool from that pull request. I think we can have a separate discussion about whether we want to support that model. The library changes should be less controversial.

I also included a change to expose the hash bytes from an EnclaveHash object. That comes from https://github.com/fortanix/rust-sgx/pull/341 from trevor-crypto.

This change should be backward-compatible with old code using this crate. New code that wants to use the new `cat_sign()` method and is using a custom key implementation will need to provide the new `SgxRsaPubOps()` trait for calculating the Q1 and Q2 values from a signature, instead of doing this during signing.