### PR TITLE
refactor dcap-retrieve-pckid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-retrieve-pckid"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aesm-client",
  "dcap-ql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,7 @@ version = "0.1.3"
 dependencies = [
  "aesm-client",
  "dcap-ql",
+ "failure",
  "report-test",
  "sgx-isa",
  "sgxs-loaders",

--- a/intel-sgx/dcap-retrieve-pckid/Cargo.toml
+++ b/intel-sgx/dcap-retrieve-pckid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-retrieve-pckid"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/dcap-retrieve-pckid/Cargo.toml
+++ b/intel-sgx/dcap-retrieve-pckid/Cargo.toml
@@ -19,3 +19,6 @@ categories = ["command-line-utilities"]
 "report-test" = { version = "0.3.1", path = "../report-test" }
 "sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
 "sgxs-loaders" = { version = "0.3.0", path = "../sgxs-loaders" }
+
+# External dependencies
+failure = "0.1.1"   # MIT/Apache-2.0

--- a/intel-sgx/dcap-retrieve-pckid/src/lib.rs
+++ b/intel-sgx/dcap-retrieve-pckid/src/lib.rs
@@ -35,12 +35,12 @@ impl<'a> fmt::Display for PrintHex<'a> {
     }
 }
 
-pub struct PckCertId {
+pub struct PckId {
     pub cd_ppid: Qe3CertDataPpid<'static>,
     pub qe_id: [u8; 16],
 }
 
-impl ToString for PckCertId {
+impl ToString for PckId {
     fn to_string(&self) -> String {
         format!(
             "{ppid},{pceid},{cpusvn},{pcesvn},{qe3id}",
@@ -53,7 +53,7 @@ impl ToString for PckCertId {
     }
 }
 
-pub fn retrieve_pckid_str() -> Result<PckCertId, &'static str> {
+pub fn retrieve_pckid_str() -> Result<PckId, &'static str> {
     const SGX_QL_ALG_ECDSA_P256: u32 = 2;
 
     let mut device = IsgxDevice::new()
@@ -92,7 +92,7 @@ pub fn retrieve_pckid_str() -> Result<PckCertId, &'static str> {
         .certification_data::<Qe3CertDataPpid>()
         .map_err(|_| "Certification data is already available for the current platform")?;
 
-    Ok(PckCertId {
+    Ok(PckId {
         cd_ppid: cd_ppid.clone_owned(),
         qe_id: user_data[0..16].try_into().unwrap(),
     })

--- a/intel-sgx/dcap-retrieve-pckid/src/lib.rs
+++ b/intel-sgx/dcap-retrieve-pckid/src/lib.rs
@@ -1,0 +1,84 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![deny(warnings)]
+use std::fmt;
+
+use aesm_client::AesmClient;
+use dcap_ql::quote::{Qe3CertDataPpid, Quote, Quote3SignatureEcdsaP256, QuoteHeader};
+use sgx_isa::Targetinfo;
+#[cfg(windows)]
+use sgxs_loaders::enclaveapi::Sgx as IsgxDevice;
+#[cfg(unix)]
+use sgxs_loaders::isgx::Device as IsgxDevice;
+
+fn get_algorithm_id(key_id: &Vec<u8>) -> u32 {
+    const ALGORITHM_OFFSET: usize = 154;
+
+    let mut bytes: [u8; 4] = Default::default();
+    bytes.copy_from_slice(&key_id[ALGORITHM_OFFSET..ALGORITHM_OFFSET + 4]);
+    u32::from_le_bytes(bytes)
+}
+
+struct PrintHex<'a>(&'a [u8]);
+
+impl<'a> fmt::Display for PrintHex<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+pub fn retrieve_pckid_str() -> Result<String, &'static str> {
+    const SGX_QL_ALG_ECDSA_P256: u32 = 2;
+
+    let mut device = IsgxDevice::new()
+        .map_err(|_| "Error opening SGX device")?
+        .einittoken_provider(AesmClient::new())
+        .build();
+
+    let client = AesmClient::new();
+
+    let key_ids = client
+        .get_supported_att_key_ids()
+        .map_err(|_| "AESM communication error getting attestation key ID")?;
+
+    let ecdsa_key_id = key_ids
+        .into_iter()
+        .find(|id| SGX_QL_ALG_ECDSA_P256 == get_algorithm_id(id))
+        .ok_or("No appropriate attestation key ID")?;
+
+    let quote_info = client
+        .init_quote_ex(ecdsa_key_id.clone())
+        .map_err(|_| "Error during quote initialization")?;
+
+    let ti = Targetinfo::try_copy_from(quote_info.target_info()).unwrap();
+    let report = report_test::report(&ti, &mut device).unwrap();
+
+    let res = client
+        .get_quote_ex(ecdsa_key_id, report.as_ref().to_owned(), None, vec![0; 16])
+        .map_err(|_| "Error obtaining quote")?;
+
+    let quote = Quote::parse(res.quote()).map_err(|_| "Error parsing quote")?;
+    let QuoteHeader::V3 { user_data, .. } = quote.header();
+    let sig = quote
+        .signature::<Quote3SignatureEcdsaP256>()
+        .map_err(|_| "Error parsing requested signature type")?;
+    let cd_ppid = sig
+        .certification_data::<Qe3CertDataPpid>()
+        .map_err(|_| "Certification data is already available for the current platform")?;
+
+    Ok(format!(
+        "{ppid},{pceid},{cpusvn},{pcesvn},{qe3id}",
+        ppid = PrintHex(&cd_ppid.ppid),
+        pceid = PrintHex(&cd_ppid.pceid.to_le_bytes()),
+        cpusvn = PrintHex(&cd_ppid.cpusvn),
+        pcesvn = PrintHex(&cd_ppid.pcesvn.to_le_bytes()),
+        qe3id = PrintHex(&user_data[0..16]),
+    ))
+}

--- a/intel-sgx/dcap-retrieve-pckid/src/main.rs
+++ b/intel-sgx/dcap-retrieve-pckid/src/main.rs
@@ -5,90 +5,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(warnings)]
-
-use std::fmt;
-
-use aesm_client::AesmClient;
-use dcap_ql::quote::{Qe3CertDataPpid, Quote, Quote3SignatureEcdsaP256, QuoteHeader};
-use sgx_isa::Targetinfo;
-#[cfg(windows)]
-use sgxs_loaders::enclaveapi::Sgx as IsgxDevice;
-#[cfg(unix)]
-use sgxs_loaders::isgx::Device as IsgxDevice;
-
-fn get_algorithm_id(key_id: &Vec<u8>) -> u32 {
-    const ALGORITHM_OFFSET: usize = 154;
-
-    let mut bytes: [u8; 4] = Default::default();
-    bytes.copy_from_slice(&key_id[ALGORITHM_OFFSET..ALGORITHM_OFFSET + 4]);
-    u32::from_le_bytes(bytes)
-}
-
-struct PrintHex<'a>(&'a [u8]);
-
-impl<'a> fmt::Display for PrintHex<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for b in self.0 {
-            write!(f, "{:02x}", b)?;
-        }
-        Ok(())
-    }
-}
-
-fn go() -> Result<(), &'static str> {
-    const SGX_QL_ALG_ECDSA_P256: u32 = 2;
-
-    let mut device = IsgxDevice::new()
-        .map_err(|_| "Error opening SGX device")?
-        .einittoken_provider(AesmClient::new())
-        .build();
-
-    let client = AesmClient::new();
-
-    let key_ids = client
-        .get_supported_att_key_ids()
-        .map_err(|_| "AESM communication error getting attestation key ID")?;
-
-    let ecdsa_key_id = key_ids
-        .into_iter()
-        .find(|id| SGX_QL_ALG_ECDSA_P256 == get_algorithm_id(id))
-        .ok_or("No appropriate attestation key ID")?;
-
-    let quote_info = client
-        .init_quote_ex(ecdsa_key_id.clone())
-        .map_err(|_| "Error during quote initialization")?;
-
-    let ti = Targetinfo::try_copy_from(quote_info.target_info()).unwrap();
-    let report = report_test::report(&ti, &mut device).unwrap();
-
-    let res = client
-        .get_quote_ex(ecdsa_key_id, report.as_ref().to_owned(), None, vec![0; 16])
-        .map_err(|_| "Error obtaining quote")?;
-
-    let quote = Quote::parse(res.quote()).map_err(|_| "Error parsing quote")?;
-    let QuoteHeader::V3 { user_data, .. } = quote.header();
-    let sig = quote
-        .signature::<Quote3SignatureEcdsaP256>()
-        .map_err(|_| "Error parsing requested signature type")?;
-    let cd_ppid = sig
-        .certification_data::<Qe3CertDataPpid>()
-        .map_err(|_| "Certification data is already available for the current platform")?;
-
-    println!(
-        "{ppid},{pceid},{cpusvn},{pcesvn},{qe3id}",
-        ppid = PrintHex(&cd_ppid.ppid),
-        pceid = PrintHex(&cd_ppid.pceid.to_le_bytes()),
-        cpusvn = PrintHex(&cd_ppid.cpusvn),
-        pcesvn = PrintHex(&cd_ppid.pcesvn.to_le_bytes()),
-        qe3id = PrintHex(&user_data[0..16]),
-    );
-
-    Ok(())
-}
+use dcap_retrieve_pckid::retrieve_pckid_str;
 
 fn main() {
-    if let Err(e) = go() {
-        eprintln!("ERROR retrieving PCK ID: {}", e);
-        std::process::exit(1);
+    match retrieve_pckid_str() {
+        Err(e) => {
+            eprintln!("ERROR retrieving PCK ID: {}", e);
+            std::process::exit(1);
+        }
+        Ok(pckid_str) => println!("{}", pckid_str),
     }
 }

--- a/intel-sgx/dcap-retrieve-pckid/src/main.rs
+++ b/intel-sgx/dcap-retrieve-pckid/src/main.rs
@@ -13,6 +13,6 @@ fn main() {
             eprintln!("ERROR retrieving PCK ID: {}", e);
             std::process::exit(1);
         }
-        Ok(pckid_str) => println!("{}", pckid_str),
+        Ok(pckid) => println!("{}", pckid.to_string()),
     }
 }


### PR DESCRIPTION
Split the origin code in `dcap-retrieve-pckid` into `lib.rs` and `main.rs`

So that this code could be easy reuse elsewhere.