### PR TITLE
Enable `enclave_loader()` fallback to `libsgx_enclave_common.so.1`

### DIFF
--- a/intel-sgx/dcap-ql/src/bindings/mod.rs
+++ b/intel-sgx/dcap-ql/src/bindings/mod.rs
@@ -81,5 +81,7 @@ pub fn enclave_loader() -> Result<EnclaveCommonLibrary, Error> {
     // so we should be able to find it already loaded.
     // We can't use the library from `mod dl` if `not(feature = "link")`,
     // because that is not the right library.
-    Ok(EnclaveCommonLibrary::load(Some(Dl::this().into()))?.build())
+    let lib = EnclaveCommonLibrary::load(Some(Dl::this().into()))
+        .or(EnclaveCommonLibrary::load(None))?;
+    Ok(lib.build())
 }


### PR DESCRIPTION
The aesmd service depends on a dcap_quoteprov.so library (the DCAP provider) to aid in DCAP attestations. For it to work correctly, it may need to (recursively) request a DCAP attestation itself. For that a `dcap-ql::enclave_loader` call is required. Unfortunately, when this happens as part of the aesmd service, `Dl::this()` returns `/opt/intel/sgx-aesm-service/aesm/aesm_service`. This leads to an error as the expected symbols can't be located. This PR adds a fallback to the `libsgx_enclave_common.so.1` library (or `sgx_enclave_common.dll` on windows).

This commit has been merged already on a different branch as part of #432 