### PR TITLE
Add an OID for attestation transparency. HRST-32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ matrix:
             - clang-11
             - musl-tools
       rust:
-        - stable
+        # This need to change back to `nightly` after https://github.com/fortanix/rust-sgx/issues/433 is fixed
+        - nightly-2023-01-31
       env:
         - RUST_BACKTRACE=1
         - CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "sgx_pkix"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "byteorder",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
  "protobuf",
  "protoc-rust",
  "report-test",
- "sgx-isa",
+ "sgx-isa 0.3.3",
  "sgxs",
  "sgxs-loaders",
  "unix_socket2",
@@ -564,7 +564,7 @@ dependencies = [
  "report-test",
  "serde",
  "serde_json",
- "sgx-isa",
+ "sgx-isa 0.3.3",
  "sgxs",
  "sgxs-loaders",
  "yasna 0.3.2",
@@ -576,7 +576,7 @@ version = "0.2.0"
 dependencies = [
  "num-derive",
  "num-traits",
- "sgx-isa",
+ "sgx-isa 0.3.3",
 ]
 
 [[package]]
@@ -586,7 +586,7 @@ dependencies = [
  "aesm-client",
  "dcap-ql",
  "report-test",
- "sgx-isa",
+ "sgx-isa 0.3.3",
  "sgxs-loaders",
 ]
 
@@ -627,7 +627,7 @@ dependencies = [
  "nix 0.13.1",
  "num_cpus",
  "openssl",
- "sgx-isa",
+ "sgx-isa 0.3.3",
  "sgxs",
  "tokio 0.2.22",
 ]
@@ -779,7 +779,7 @@ dependencies = [
  "num_cpus",
  "serde",
  "serde_derive",
- "sgx-isa",
+ "sgx-isa 0.3.3",
  "sgxs",
  "sgxs-loaders",
  "toml",
@@ -2095,7 +2095,7 @@ version = "0.3.2"
 dependencies = [
  "enclave-runner",
  "failure",
- "sgx-isa",
+ "sgx-isa 0.3.3",
  "sgxs",
 ]
 
@@ -2324,6 +2324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sgx-isa"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55adf0940448a33eac98b3c84ab2e567c1fbc086750bcfd72702d6facc39bb77"
+dependencies = [
+ "bitflags 1.2.1",
+]
+
+[[package]]
 name = "sgx_pkix"
 version = "0.1.4"
 dependencies = [
@@ -2331,7 +2340,7 @@ dependencies = [
  "lazy_static",
  "pkix",
  "quick-error",
- "sgx-isa",
+ "sgx-isa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2345,7 +2354,7 @@ dependencies = [
  "foreign-types",
  "openssl",
  "openssl-sys",
- "sgx-isa",
+ "sgx-isa 0.3.3",
  "sha2",
  "time",
 ]
@@ -2362,7 +2371,7 @@ dependencies = [
  "libloading 0.5.2",
  "nix 0.15.0",
  "report-test",
- "sgx-isa",
+ "sgx-isa 0.3.3",
  "sgxs",
  "winapi 0.3.9",
 ]
@@ -2399,7 +2408,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_yaml",
- "sgx-isa",
+ "sgx-isa 0.3.3",
  "sgxs",
  "sgxs-loaders",
  "syn 0.15.44",

--- a/em-app/Cargo.lock
+++ b/em-app/Cargo.lock
@@ -637,13 +637,15 @@ dependencies = [
 [[package]]
 name = "sgx-isa"
 version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55adf0940448a33eac98b3c84ab2e567c1fbc086750bcfd72702d6facc39bb77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "sgx_pkix"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "byteorder",
  "lazy_static",

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -17,7 +17,7 @@ mbedtls = { version = "0.7", default-features = false, features = ["sgx"] }
 b64-ct = "0.1.0"
 serde_bytes = "0.10"
 serde_json = "1.0"
-sgx-isa = { version = "0.3", path = "../sgx-isa", default-features = false }
+sgx-isa = { version = "0.3.3", default-features = false, features = ["sgxstd"] }
 
 em-node-agent-client = "1.0.0"
 sgx_pkix = { version = "0.1.0", path ="../sgx-pkix" }

--- a/sgx-pkix/Cargo.toml
+++ b/sgx-pkix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgx_pkix"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"
@@ -12,6 +12,6 @@ categories = ["cryptography"]
 [dependencies]
 byteorder = "1.0"
 pkix = ">=0.1.1, <0.3.0"
-sgx-isa = { version = "0.3", path = "../sgx-isa" }
+sgx-isa = "0.3"
 quick-error = "1.1.0"
 lazy_static = "1"

--- a/sgx-pkix/src/lib.rs
+++ b/sgx-pkix/src/lib.rs
@@ -3,6 +3,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#![recursion_limit = "256"]
+
 #[macro_use]
 extern crate quick_error;
 #[macro_use]

--- a/sgx-pkix/src/oid.rs
+++ b/sgx-pkix/src/oid.rs
@@ -35,6 +35,9 @@ lazy_static!{
     pub static ref round5_5pke_0d: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 4, 2].into();
     pub static ref lms_15_10_sha256: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 4, 3].into();
 
+    // Fortanix attestation transparency identifiers
+    pub static ref transparencyProofSgx: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 5, 1].into();
+
     // Intel SGX OID namespaces:
     // https://download.01.org/intel-sgx/sgx-dcap/1.10/linux/docs/Intel_SGX_PCK_Certificate_CRL_Spec-1.4.pdf
     // https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/master/QuoteVerification/QVL/Src/AttestationParsers/src/ParserUtils.h#L57


### PR DESCRIPTION
Attestation transparency information will be added to the certificate used for joining the cluster, so we need an OID for that purpose.

This is being added on the 1.x branch because roche currently must be built with a 1.x version of sgx_pkix due to dependencies on dcap-ql version 3.3. dcap-ql can't be updated without updating mbedtls.