### PR TITLE
X509 OID for attestation transparency for sgx_pkix. HRST-33.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "sgx_pkix"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "byteorder 1.3.4",
  "lazy_static",

--- a/intel-sgx/sgx_pkix/Cargo.toml
+++ b/intel-sgx/sgx_pkix/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Unfortunately crates.io prevents us from changing the name to `sgx-pkix`
 name = "sgx_pkix"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"

--- a/intel-sgx/sgx_pkix/src/lib.rs
+++ b/intel-sgx/sgx_pkix/src/lib.rs
@@ -3,6 +3,8 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#![recursion_limit = "256"]
+
 #[macro_use]
 extern crate quick_error;
 #[macro_use]

--- a/intel-sgx/sgx_pkix/src/oid.rs
+++ b/intel-sgx/sgx_pkix/src/oid.rs
@@ -35,6 +35,9 @@ lazy_static!{
     pub static ref round5_5pke_0d: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 4, 2].into();
     pub static ref lms_15_10_sha256: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 4, 3].into();
 
+    // Fortanix attestation transparency identifiers
+    pub static ref transparencyProofSgx: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 5, 1].into();
+
     // Intel SGX OID namespaces:
     // https://download.01.org/intel-sgx/sgx-dcap/1.10/linux/docs/Intel_SGX_PCK_Certificate_CRL_Spec-1.4.pdf
     // https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/master/QuoteVerification/QVL/Src/AttestationParsers/src/ParserUtils.h#L57


### PR DESCRIPTION
This adds an X509 OID for attestation transparency. This change was previously made ont he sgx_pkix 0.1.x branch (for sgx_pkix version 0.1.4). This change adds the new OID on the master branch for sgx_pkix version 0.2.2, for when we migrate roche to the latest releases of the crates that belong to rust-sgx.