### PR TITLE
fix pe error by removing `isgx-pe2sgx` in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ matrix:
         - rustup target add x86_64-fortanix-unknown-sgx --toolchain nightly
       script:
         - cargo test --verbose --locked --all --exclude sgxs-loaders && [ "$(echo $(nm -D target/debug/sgx-detect|grep __vdso_sgx_enter_enclave))" = "w __vdso_sgx_enter_enclave" ]
-        - cargo test --verbose --locked -p sgxs-tools --features pe2sgxs --bin isgx-pe2sgx
         - cargo test --verbose --locked -p dcap-ql --features link
         - cargo test --verbose --locked -p dcap-ql --features verify
         - cargo test --verbose --locked -p ias --features mbedtls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "clap",
@@ -208,12 +208,6 @@ name = "bit-vec"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
-
-[[package]]
-name = "bitflags"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 
 [[package]]
 name = "bitflags"
@@ -250,12 +244,6 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "broadcast"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb214f702da3cc6aa1666520f40ea66f506644db5e1065be4bbc972f7ec3750b"
 
 [[package]]
 name = "bstr"
@@ -393,7 +381,7 @@ checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags 1.2.1",
+ "bitflags",
  "strsim 0.8.0",
  "textwrap",
  "unicode-width",
@@ -406,7 +394,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -845,7 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0bd923300728ad79f8c36f689f96d928d224524a2120a204fa2bb7801991e7c"
 dependencies = [
  "base64 0.10.1",
- "bitflags 1.2.1",
+ "bitflags",
  "chrono",
  "futures 0.1.30",
  "hyper 0.10.16",
@@ -1171,7 +1159,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "fuchsia-zircon-sys",
 ]
 
@@ -1667,7 +1655,7 @@ version = "0.1.1"
 dependencies = [
  "aesm-client",
  "base64 0.13.0",
- "bitflags 1.2.1",
+ "bitflags",
  "byteorder 1.3.4",
  "clap",
  "env_logger 0.9.0",
@@ -1738,7 +1726,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "futures-core",
  "inotify-sys",
  "libc",
@@ -1957,7 +1945,7 @@ name = "mbedtls"
 version = "0.8.2"
 source = "git+https://github.com/fortanix/rust-mbedtls?branch=master#aa500d0e6e0a28117e9e62d932ed6d0341acab06"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "byteorder 1.3.4",
  "cc",
  "cfg-if 1.0.0",
@@ -2227,7 +2215,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "cc",
  "cfg-if 0.1.10",
  "libc",
@@ -2240,7 +2228,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "cc",
  "cfg-if 0.1.10",
  "libc",
@@ -2252,7 +2240,7 @@ name = "nix"
 version = "0.20.2"
 source = "git+https://github.com/fortanix/nix.git?branch=raoul/fortanixvme_r0.20.2#6803aa84923d024a6106840acf2d12edb78825c0"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "cc",
  "cfg-if 1.0.0",
  "libc",
@@ -2265,7 +2253,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3bb9a13fa32bc5aeb64150cd3f32d6cf4c748f8f8a417cce5d2eb976a8370ba"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "cc",
  "cfg-if 1.0.0",
  "libc",
@@ -2482,7 +2470,7 @@ version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -2587,15 +2575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec13ba9a0eec5c10a89f6ec1b6e9e2ef7d29b810d771355abbd1c43cae003ed6"
 dependencies = [
  "err-derive",
-]
-
-[[package]]
-name = "pe"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de31e953ee9f97fce65decc96536d4df6a9ac7e51e13e2b635aae46e507b9048"
-dependencies = [
- "bitflags 0.4.0",
 ]
 
 [[package]]
@@ -3078,7 +3057,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3293,7 +3272,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c843377a2ed87d63e487c7b41b1a82446ab7dc836addd66d63010ea05b14aaf7"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "chrono",
  "hyper 0.10.16",
  "log 0.4.14",
@@ -3311,7 +3290,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3499,7 +3478,7 @@ dependencies = [
 name = "sgx-isa"
 version = "0.4.0"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "mbedtls",
  "serde",
 ]
@@ -3536,7 +3515,7 @@ name = "sgxs-loaders"
 version = "0.3.3"
 dependencies = [
  "aesm-client",
- "bitflags 1.2.1",
+ "bitflags",
  "failure",
  "failure_derive",
  "libloading 0.5.2",
@@ -3553,7 +3532,6 @@ version = "0.8.6"
 dependencies = [
  "aesm-client",
  "atty",
- "broadcast",
  "byteorder 1.3.4",
  "clap",
  "crypto-hash",
@@ -3568,7 +3546,6 @@ dependencies = [
  "mopa",
  "num",
  "openssl",
- "pe",
  "petgraph",
  "proc-macro2 0.4.30",
  "proc-mounts",
@@ -4360,7 +4337,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cf11afbc4ebc0d5c7a7748a77d19e2042677fc15faa2f4ccccb27c18a60605"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags",
  "libc",
 ]
 

--- a/intel-sgx/sgxs-tools/Cargo.toml
+++ b/intel-sgx/sgxs-tools/Cargo.toml
@@ -20,10 +20,6 @@ proc-macro = true
 path = "src/sgx_detect/proc_macro.rs"
 
 [[bin]]
-name = "isgx-pe2sgx"
-required-features = ["pe2sgxs"]
-
-[[bin]]
 name = "sgx-detect"
 path = "src/sgx_detect/main.rs"
 
@@ -47,7 +43,6 @@ openssl = "0.10"                                 # Apache-2.0
 failure = "0.1.1"                                # MIT/Apache-2.0
 failure_derive = "0.1.1"                         # MIT/Apache-2.0
 crypto-hash = "0.3"                              # MIT
-broadcast = { version = "0.1", optional = true } # MIT
 log = "0.4"                                      # MIT/Apache-2.0
 env_logger = "0.6"                               # MIT/Apache-2.0
 yansi = "0.5"                                    # MIT/Apache-2.0
@@ -62,7 +57,6 @@ proc-mounts = "0.2.4"                            # MIT
 serde = "1.0.84"                                 # MIT/Apache-2.0
 serde_derive = "1.0.84"                          # MIT/Apache-2.0
 serde_yaml = "0.8.8"                             # MIT/Apache-2.0
-pe = { version = "0.1", optional = true }        # GPL
 
 [target.'cfg(unix)'.dependencies]
 "dcap-ql" = { version = "0.3.0", path = "../dcap-ql" }
@@ -71,7 +65,6 @@ pe = { version = "0.1", optional = true }        # GPL
 winapi = { version = "0.3.7", features = ["winbase"] }
 
 [features]
-pe2sgxs = ["pe", "broadcast"]
 docs = []
 
 [package.metadata.docs.rs]

--- a/intel-sgx/sgxs-tools/README.md
+++ b/intel-sgx/sgxs-tools/README.md
@@ -2,11 +2,15 @@
 
 Compiles with Rust nightly.
 
-## pe2sgxs
+## pe2sgxs (deprecated since v0.8.7)
 
 `pe2sgxs` converts enclaves in Intel's PE format to SGXS format, optionally
 extracting the signature. You can then use the SGXS file with the other SGXS
 utilities.
+
+This is deprecated since v0.8.7 because the code of its dependency `pe` is
+incompatible with rust compiler since `nightly-2023-01-31`. The source code has
+been moved to `src/deprecated`.
 
 ## sgx-debug-read
 

--- a/intel-sgx/sgxs-tools/src/deprecated/isgx-pe2sgx.rs
+++ b/intel-sgx/sgxs-tools/src/deprecated/isgx-pe2sgx.rs
@@ -4,6 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+//! This code is deprecated since v0.8.7 because its dependency `pe`
+//! is incompatible with rust compiler since `nightly-2023-01-31`.
+
 #[macro_use]
 extern crate lazy_static;
 extern crate broadcast;
@@ -614,6 +617,9 @@ sgx-utils@jbeekman.nl with as much data as you can provide about the enclave."
     )
 }
 
+#[deprecated(since = "0.8.7")]
+/// The dependency `pe` of this part of code is incompatible with rust compiler
+/// since `nightly-2023-01-31`."
 fn main() {
     let mut args = std::env::args_os();
     let _name = args.next();


### PR DESCRIPTION
Fix #433 by removing `isgx-pe2sgx` in CI

If it's not used, maybe we could also remove the code.

Please correct me if it's actively used somewhere