### PR TITLE
Fix CI breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,14 @@ matrix:
         - CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
         - CC_x86_64_fortanix_unknown_sgx=clang-11
       before_script:
+        # Travis-CI supplies clang version 16 by itself, in /usr/local
+        # However, our current build fails if llvm-16 is also available in the system. This is likely a bug,
+        # created and reported here: https://github.com/fortanix/rust-sgx/issues/465
+        # Once this bug is solved, please feel free to remove this workaround.
+        #
+        # Note that this clang-16 is some Travis-CI magic and not a standard Debian/Ubuntu Apt package.
+        # We're thus forced to force-remove the underlying directory in /usr/local
+        - sudo rm -rf /usr/local/*clang*
         - rustup target add x86_64-fortanix-unknown-sgx x86_64-unknown-linux-musl
         - rustup toolchain add nightly
         - rustup target add x86_64-fortanix-unknown-sgx --toolchain nightly


### PR DESCRIPTION
Fixes https://github.com/fortanix/rust-sgx/issues/458

Learnings from fixing the issue:
- Travis Ubuntu "patch" upgrade (20.04.5 -> 20.04.6) can cause a major upgrade of certain libraries, such as clang version 7 -> clang version 16. After a lot of tinkering and local tests, we were able to identify this as the root cause
- TravisCI seems to install its binaries (such as clang) not as an Apt package but directly in `/usr/local`. One should be aware that there's no simple package to uninstall this way, and the very dirty solution of `rm -rf /usr/local/clang-16` might be needed.
- clang can work perfectly... even when `clang --version` fails
- We've discovered an underlying issue with our build that caused breakage from simply the *presence* of a newer clang, even if the desired clang-11 is both installed and specified as an environment and CLI variables. An issue for that has been filled here: https://github.com/fortanix/rust-sgx/issues/465