### PR TITLE
Upgrade dcap-ql to accept mbedtls 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.146",
  "winapi 0.3.9",
 ]
 
@@ -115,7 +115,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9138ac237191fcb830a6c5fb45b93573ee670956bef2b2dd1ee8609daa59a4a"
 dependencies = [
- "libc",
+ "libc 0.2.146",
  "log 0.4.14",
  "nix 0.20.2",
  "serde",
@@ -137,7 +137,7 @@ checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
- "libc",
+ "libc 0.2.146",
  "miniz_oxide",
  "object",
  "rustc-demangle",
@@ -354,7 +354,7 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "libc",
+ "libc 0.2.146",
  "num-integer",
  "num-traits",
  "serde",
@@ -369,7 +369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
 dependencies = [
  "glob",
- "libc",
+ "libc 0.2.146",
  "libloading 0.7.2",
 ]
 
@@ -421,7 +421,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 dependencies = [
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -468,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -661,14 +661,14 @@ dependencies = [
 
 [[package]]
 name = "dcap-ql"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "byteorder 1.3.4",
  "dcap-ql-sys",
  "failure",
  "lazy_static",
- "libc",
- "mbedtls",
+ "libc 0.2.146",
+ "mbedtls 0.9.1",
  "num",
  "num-derive 0.2.5",
  "num-traits",
@@ -763,7 +763,7 @@ version = "0.1.0"
 source = "git+https://github.com/fortanix/aws-nitro-enclaves-cli.git?branch=main#93193b1317c544ff07dd3ddcc6e126f847449cbb"
 dependencies = [
  "eif_defs",
- "libc",
+ "libc 0.2.146",
  "nix 0.15.0",
  "vsock 0.1.5",
 ]
@@ -809,7 +809,7 @@ dependencies = [
  "em-client",
  "em-node-agent-client",
  "hyper 0.10.16",
- "mbedtls",
+ "mbedtls 0.8.3",
  "pkix",
  "rustc-serialize",
  "sdkms",
@@ -881,7 +881,7 @@ dependencies = [
  "futures 0.3.17",
  "ipc-queue",
  "lazy_static",
- "libc",
+ "libc 0.2.146",
  "nix 0.13.1",
  "num_cpus",
  "openssl",
@@ -1017,7 +1017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if 1.0.0",
- "libc",
+ "libc 0.2.146",
  "redox_syscall 0.2.10",
  "winapi 0.3.9",
 ]
@@ -1036,7 +1036,7 @@ checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
 dependencies = [
  "cfg-if 0.1.10",
  "crc32fast",
- "libc",
+ "libc 0.2.146",
  "miniz_oxide",
 ]
 
@@ -1110,7 +1110,7 @@ dependencies = [
  "enclave-runner",
  "failure",
  "failure_derive",
- "libc",
+ "libc 0.2.146",
  "nix 0.13.1",
  "num_cpus",
  "serde",
@@ -1317,7 +1317,7 @@ name = "get-certificate"
 version = "0.1.0"
 dependencies = [
  "em-app",
- "mbedtls",
+ "mbedtls 0.8.3",
  "serde_json",
 ]
 
@@ -1328,7 +1328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.146",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
@@ -1338,7 +1338,7 @@ version = "0.2.3"
 source = "git+https://github.com/fortanix/getrandom.git?branch=fortanixvme#cf4c6875ca03932aca760eb3a1fcfc4d4f9b47cd"
 dependencies = [
  "cfg-if 1.0.0",
- "libc",
+ "libc 0.2.138",
  "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
@@ -1405,7 +1405,7 @@ dependencies = [
  "csv",
  "em-app",
  "hyper 0.10.16",
- "mbedtls",
+ "mbedtls 0.8.3",
  "pkix",
  "rustc-serialize",
  "sdkms",
@@ -1432,7 +1432,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -1661,7 +1661,7 @@ dependencies = [
  "env_logger 0.9.0",
  "lazy_static",
  "log 0.4.14",
- "mbedtls",
+ "mbedtls 0.8.3",
  "percent-encoding 2.1.0",
  "pkix",
  "report-test",
@@ -1729,7 +1729,7 @@ dependencies = [
  "bitflags",
  "futures-core",
  "inotify-sys",
- "libc",
+ "libc 0.2.146",
  "tokio 1.14.0",
 ]
 
@@ -1739,7 +1739,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -1757,7 +1757,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -1851,11 +1851,17 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.104"
-source = "git+https://github.com/fortanix/libc.git?branch=fortanixvme#92233130f38b15b6217cab2669355129400fdcb7"
+version = "0.2.138"
+source = "git+https://github.com/fortanix/libc.git?branch=fortanixvme#c62c6451c40a47c8bd25a857450a4c2a249b38f4"
 dependencies = [
  "rustc-std-workspace-core",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.146"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libloading"
@@ -1942,14 +1948,34 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "mbedtls"
-version = "0.8.2"
-source = "git+https://github.com/fortanix/rust-mbedtls?branch=master#aa500d0e6e0a28117e9e62d932ed6d0341acab06"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4cdd74b4f7c633899ce071acfd307b053ccab39b7ca1ffac6900ed39a050e85"
 dependencies = [
  "bitflags",
  "byteorder 1.3.4",
  "cc",
  "cfg-if 1.0.0",
- "chrono",
+ "mbedtls-platform-support",
+ "mbedtls-sys-auto",
+ "rs-libc 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version",
+ "serde",
+ "serde_derive 1.0.132",
+ "yasna 0.2.2",
+]
+
+[[package]]
+name = "mbedtls"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f2c88dbe2fcc6fddc0dc33eb2694471fef46f48b2081996335adb2f8085c53"
+dependencies = [
+ "bitflags",
+ "byteorder 1.3.4",
+ "cc",
+ "cfg-if 1.0.0",
+ "mbedtls-platform-support",
  "mbedtls-sys-auto",
  "rs-libc 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
@@ -1958,16 +1984,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "mbedtls-platform-support"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85be113c8c2dc54cc6a5fba20130c7128f78dcb3ed0bb6797427333fa8cdb54d"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "chrono",
+ "mbedtls-sys-auto",
+]
+
+[[package]]
 name = "mbedtls-sys-auto"
-version = "2.26.1"
-source = "git+https://github.com/fortanix/rust-mbedtls?branch=master#aa500d0e6e0a28117e9e62d932ed6d0341acab06"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2231108271d9a10052178d940926baf24b57a2eb1703732faae387592dd6ac3"
 dependencies = [
  "bindgen",
  "cc",
  "cfg-if 1.0.0",
  "cmake",
  "lazy_static",
- "libc",
+ "libc 0.2.146",
  "quote 1.0.10",
  "syn 1.0.81",
 ]
@@ -2054,7 +2093,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc",
+ "libc 0.2.146",
  "log 0.4.14",
  "miow 0.2.1",
  "net2",
@@ -2068,7 +2107,7 @@ version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
- "libc",
+ "libc 0.2.146",
  "log 0.4.14",
  "miow 0.3.7",
  "ntapi",
@@ -2094,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
- "libc",
+ "libc 0.2.146",
  "mio 0.6.22",
 ]
 
@@ -2138,7 +2177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
- "libc",
+ "libc 0.2.146",
  "log 0.4.14",
  "openssl",
  "openssl-probe",
@@ -2156,7 +2195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.146",
  "winapi 0.3.9",
 ]
 
@@ -2167,7 +2206,7 @@ dependencies = [
  "aws-nitro-enclaves-cose 0.5.0",
  "chrono",
  "lazy_static",
- "mbedtls",
+ "mbedtls 0.8.3",
  "num-bigint 0.4.3",
  "pkix",
  "serde",
@@ -2193,7 +2232,7 @@ dependencies = [
  "hex 0.3.2",
  "inotify",
  "lazy_static",
- "libc",
+ "libc 0.2.146",
  "log 0.4.14",
  "nix 0.15.0",
  "once_cell",
@@ -2218,7 +2257,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.146",
  "void",
 ]
 
@@ -2231,7 +2270,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.146",
  "void",
 ]
 
@@ -2243,7 +2282,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 1.0.0",
- "libc",
+ "libc 0.2.146",
  "memoffset 0.6.4",
 ]
 
@@ -2256,7 +2295,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 1.0.0",
- "libc",
+ "libc 0.2.146",
  "memoffset 0.6.4",
 ]
 
@@ -2285,7 +2324,7 @@ name = "nsm-driver"
 version = "0.1.0"
 source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api#9ddb589875baf345d085a980aa96cf3a4e480ea8"
 dependencies = [
- "libc",
+ "libc 0.2.146",
  "log 0.4.14",
  "nix 0.20.2",
  "nsm-io",
@@ -2437,7 +2476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -2473,7 +2512,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
- "libc",
+ "libc 0.2.146",
  "once_cell",
  "openssl-sys",
 ]
@@ -2492,7 +2531,7 @@ checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
- "libc",
+ "libc 0.2.146",
  "pkg-config",
  "vcpkg",
 ]
@@ -2513,7 +2552,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 dependencies = [
- "libc",
+ "libc 0.2.146",
  "winapi 0.3.9",
 ]
 
@@ -2547,7 +2586,7 @@ checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if 0.1.10",
  "cloudabi",
- "libc",
+ "libc 0.2.146",
  "redox_syscall 0.1.57",
  "rustc_version",
  "smallvec 0.6.13",
@@ -2562,7 +2601,7 @@ checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
- "libc",
+ "libc 0.2.146",
  "redox_syscall 0.2.10",
  "smallvec 1.7.0",
  "winapi 0.3.9",
@@ -2823,7 +2862,7 @@ version = "2.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6653d384a260fedff0a466e894e05c5b8d75e261a14e9f93e81e43ef86cad23"
 dependencies = [
- "log 0.4.14",
+ "log 0.3.9",
  "which 4.0.2",
 ]
 
@@ -2883,7 +2922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc",
+ "libc 0.2.146",
  "rand_core 0.3.1",
  "rdrand",
  "winapi 0.3.9",
@@ -2896,7 +2935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
  "autocfg 0.1.7",
- "libc",
+ "libc 0.2.146",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
  "rand_hc 0.1.0",
@@ -2915,7 +2954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.15",
- "libc",
+ "libc 0.2.146",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
@@ -2998,7 +3037,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
- "libc",
+ "libc 0.2.146",
  "rand_core 0.4.2",
  "winapi 0.3.9",
 ]
@@ -3011,7 +3050,7 @@ checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
  "cloudabi",
  "fuchsia-cprng",
- "libc",
+ "libc 0.2.146",
  "rand_core 0.4.2",
  "rdrand",
  "winapi 0.3.9",
@@ -3293,7 +3332,7 @@ dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
- "libc",
+ "libc 0.2.146",
  "security-framework-sys",
 ]
 
@@ -3304,7 +3343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -3479,7 +3518,7 @@ name = "sgx-isa"
 version = "0.4.0"
 dependencies = [
  "bitflags",
- "mbedtls",
+ "mbedtls 0.8.3",
  "serde",
 ]
 
@@ -3628,7 +3667,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
 dependencies = [
- "libc",
+ "libc 0.2.146",
  "signal-hook-registry",
 ]
 
@@ -3638,7 +3677,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -3674,7 +3713,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
- "libc",
+ "libc 0.2.146",
  "winapi 0.3.9",
 ]
 
@@ -3746,7 +3785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
- "libc",
+ "libc 0.2.146",
  "xattr",
 ]
 
@@ -3767,7 +3806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.146",
  "rand 0.7.3",
  "redox_syscall 0.1.57",
  "remove_dir_all",
@@ -3827,7 +3866,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
- "libc",
+ "libc 0.2.146",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
@@ -3838,7 +3877,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -3877,7 +3916,7 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static",
- "libc",
+ "libc 0.2.146",
  "memchr",
  "mio 0.6.22",
  "mio-named-pipes",
@@ -3898,7 +3937,7 @@ checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.1.0",
- "libc",
+ "libc 0.2.146",
  "memchr",
  "mio 0.7.14",
  "num_cpus",
@@ -4243,7 +4282,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b57c6eace16c00eccb98a28e85db3370eab0685bdd5e13831d59e2bcb49a1d8a"
 dependencies = [
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -4338,7 +4377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cf11afbc4ebc0d5c7a7748a77d19e2042677fc15faa2f4ccccb27c18a60605"
 dependencies = [
  "bitflags",
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -4353,7 +4392,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b4354dabee252603a8b1a63e4adb3934dfbf1ff05ef4c3d653c2dfd67f0788"
 dependencies = [
- "libc",
+ "libc 0.2.146",
  "nix 0.15.0",
 ]
 
@@ -4363,7 +4402,7 @@ version = "0.2.4"
 source = "git+https://github.com/fortanix/vsock-rs.git?branch=fortanixvme#95834efa8f54a3c9c07544de8a561c028bd4fbcb"
 dependencies = [
  "getrandom 0.2.3",
- "libc",
+ "libc 0.2.138",
  "nix 0.22.2",
 ]
 
@@ -4482,7 +4521,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -4491,7 +4530,7 @@ version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
 dependencies = [
- "libc",
+ "libc 0.2.146",
  "thiserror",
 ]
 
@@ -4572,7 +4611,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
- "libc",
+ "libc 0.2.146",
 ]
 
 [[package]]
@@ -4633,3 +4672,8 @@ name = "zero"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f1bc8a6b2005884962297587045002d8cfb8dcec9db332f4ca216ddc5de82c5"
+
+[[patch.unused]]
+name = "mbedtls"
+version = "0.10.0"
+source = "git+https://github.com/fortanix/rust-mbedtls?branch=master#ce358f430258a5514c8b699875c90705d7622d96"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc 0.2.146",
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -115,7 +115,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9138ac237191fcb830a6c5fb45b93573ee670956bef2b2dd1ee8609daa59a4a"
 dependencies = [
- "libc 0.2.146",
+ "libc",
  "log 0.4.14",
  "nix 0.20.2",
  "serde",
@@ -137,7 +137,7 @@ checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
- "libc 0.2.146",
+ "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
@@ -354,7 +354,7 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "libc 0.2.146",
+ "libc",
  "num-integer",
  "num-traits",
  "serde",
@@ -369,7 +369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
 dependencies = [
  "glob",
- "libc 0.2.146",
+ "libc",
  "libloading 0.7.2",
 ]
 
@@ -421,7 +421,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 dependencies = [
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -468,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -667,7 +667,7 @@ dependencies = [
  "dcap-ql-sys",
  "failure",
  "lazy_static",
- "libc 0.2.146",
+ "libc",
  "mbedtls 0.9.1",
  "num",
  "num-derive 0.2.5",
@@ -763,7 +763,7 @@ version = "0.1.0"
 source = "git+https://github.com/fortanix/aws-nitro-enclaves-cli.git?branch=main#93193b1317c544ff07dd3ddcc6e126f847449cbb"
 dependencies = [
  "eif_defs",
- "libc 0.2.146",
+ "libc",
  "nix 0.15.0",
  "vsock 0.1.5",
 ]
@@ -881,7 +881,7 @@ dependencies = [
  "futures 0.3.17",
  "ipc-queue",
  "lazy_static",
- "libc 0.2.146",
+ "libc",
  "nix 0.13.1",
  "num_cpus",
  "openssl",
@@ -1017,7 +1017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.146",
+ "libc",
  "redox_syscall 0.2.10",
  "winapi 0.3.9",
 ]
@@ -1036,7 +1036,7 @@ checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
 dependencies = [
  "cfg-if 0.1.10",
  "crc32fast",
- "libc 0.2.146",
+ "libc",
  "miniz_oxide",
 ]
 
@@ -1110,7 +1110,7 @@ dependencies = [
  "enclave-runner",
  "failure",
  "failure_derive",
- "libc 0.2.146",
+ "libc",
  "nix 0.13.1",
  "num_cpus",
  "serde",
@@ -1328,7 +1328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.146",
+ "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
@@ -1338,7 +1338,7 @@ version = "0.2.3"
 source = "git+https://github.com/fortanix/getrandom.git?branch=fortanixvme#cf4c6875ca03932aca760eb3a1fcfc4d4f9b47cd"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.138",
+ "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
@@ -1432,7 +1432,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -1729,7 +1729,7 @@ dependencies = [
  "bitflags",
  "futures-core",
  "inotify-sys",
- "libc 0.2.146",
+ "libc",
  "tokio 1.14.0",
 ]
 
@@ -1739,7 +1739,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -1757,7 +1757,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -1856,12 +1856,6 @@ source = "git+https://github.com/fortanix/libc.git?branch=fortanixvme#c62c6451c4
 dependencies = [
  "rustc-std-workspace-core",
 ]
-
-[[package]]
-name = "libc"
-version = "0.2.146"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libloading"
@@ -2006,7 +2000,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cmake",
  "lazy_static",
- "libc 0.2.146",
+ "libc",
  "quote 1.0.10",
  "syn 1.0.81",
 ]
@@ -2093,7 +2087,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc 0.2.146",
+ "libc",
  "log 0.4.14",
  "miow 0.2.1",
  "net2",
@@ -2107,7 +2101,7 @@ version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
- "libc 0.2.146",
+ "libc",
  "log 0.4.14",
  "miow 0.3.7",
  "ntapi",
@@ -2133,7 +2127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
- "libc 0.2.146",
+ "libc",
  "mio 0.6.22",
 ]
 
@@ -2177,7 +2171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
- "libc 0.2.146",
+ "libc",
  "log 0.4.14",
  "openssl",
  "openssl-probe",
@@ -2195,7 +2189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.146",
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -2232,7 +2226,7 @@ dependencies = [
  "hex 0.3.2",
  "inotify",
  "lazy_static",
- "libc 0.2.146",
+ "libc",
  "log 0.4.14",
  "nix 0.15.0",
  "once_cell",
@@ -2257,7 +2251,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
- "libc 0.2.146",
+ "libc",
  "void",
 ]
 
@@ -2270,7 +2264,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 0.1.10",
- "libc 0.2.146",
+ "libc",
  "void",
 ]
 
@@ -2282,7 +2276,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 1.0.0",
- "libc 0.2.146",
+ "libc",
  "memoffset 0.6.4",
 ]
 
@@ -2295,7 +2289,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if 1.0.0",
- "libc 0.2.146",
+ "libc",
  "memoffset 0.6.4",
 ]
 
@@ -2324,7 +2318,7 @@ name = "nsm-driver"
 version = "0.1.0"
 source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api#9ddb589875baf345d085a980aa96cf3a4e480ea8"
 dependencies = [
- "libc 0.2.146",
+ "libc",
  "log 0.4.14",
  "nix 0.20.2",
  "nsm-io",
@@ -2476,7 +2470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -2512,7 +2506,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
- "libc 0.2.146",
+ "libc",
  "once_cell",
  "openssl-sys",
 ]
@@ -2531,7 +2525,7 @@ checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
- "libc 0.2.146",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2552,7 +2546,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 dependencies = [
- "libc 0.2.146",
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -2586,7 +2580,7 @@ checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if 0.1.10",
  "cloudabi",
- "libc 0.2.146",
+ "libc",
  "redox_syscall 0.1.57",
  "rustc_version",
  "smallvec 0.6.13",
@@ -2601,7 +2595,7 @@ checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
- "libc 0.2.146",
+ "libc",
  "redox_syscall 0.2.10",
  "smallvec 1.7.0",
  "winapi 0.3.9",
@@ -2922,7 +2916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc 0.2.146",
+ "libc",
  "rand_core 0.3.1",
  "rdrand",
  "winapi 0.3.9",
@@ -2935,7 +2929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
  "autocfg 0.1.7",
- "libc 0.2.146",
+ "libc",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
  "rand_hc 0.1.0",
@@ -2954,7 +2948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.15",
- "libc 0.2.146",
+ "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
@@ -3037,7 +3031,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
- "libc 0.2.146",
+ "libc",
  "rand_core 0.4.2",
  "winapi 0.3.9",
 ]
@@ -3050,7 +3044,7 @@ checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
  "cloudabi",
  "fuchsia-cprng",
- "libc 0.2.146",
+ "libc",
  "rand_core 0.4.2",
  "rdrand",
  "winapi 0.3.9",
@@ -3332,7 +3326,7 @@ dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
- "libc 0.2.146",
+ "libc",
  "security-framework-sys",
 ]
 
@@ -3343,7 +3337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -3667,7 +3661,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
 dependencies = [
- "libc 0.2.146",
+ "libc",
  "signal-hook-registry",
 ]
 
@@ -3677,7 +3671,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -3713,7 +3707,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
- "libc 0.2.146",
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -3785,7 +3779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
- "libc 0.2.146",
+ "libc",
  "xattr",
 ]
 
@@ -3806,7 +3800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.146",
+ "libc",
  "rand 0.7.3",
  "redox_syscall 0.1.57",
  "remove_dir_all",
@@ -3866,7 +3860,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
- "libc 0.2.146",
+ "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
@@ -3877,7 +3871,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -3916,7 +3910,7 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static",
- "libc 0.2.146",
+ "libc",
  "memchr",
  "mio 0.6.22",
  "mio-named-pipes",
@@ -3937,7 +3931,7 @@ checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.1.0",
- "libc 0.2.146",
+ "libc",
  "memchr",
  "mio 0.7.14",
  "num_cpus",
@@ -4282,7 +4276,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b57c6eace16c00eccb98a28e85db3370eab0685bdd5e13831d59e2bcb49a1d8a"
 dependencies = [
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -4377,7 +4371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cf11afbc4ebc0d5c7a7748a77d19e2042677fc15faa2f4ccccb27c18a60605"
 dependencies = [
  "bitflags",
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -4392,17 +4386,17 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b4354dabee252603a8b1a63e4adb3934dfbf1ff05ef4c3d653c2dfd67f0788"
 dependencies = [
- "libc 0.2.146",
+ "libc",
  "nix 0.15.0",
 ]
 
 [[package]]
 name = "vsock"
 version = "0.2.4"
-source = "git+https://github.com/fortanix/vsock-rs.git?branch=fortanixvme#95834efa8f54a3c9c07544de8a561c028bd4fbcb"
+source = "git+https://github.com/fortanix/vsock-rs.git?branch=fortanixvme#4628538042a0308d9a1f737da816666ab899dba4"
 dependencies = [
  "getrandom 0.2.3",
- "libc 0.2.138",
+ "libc",
  "nix 0.22.2",
 ]
 
@@ -4521,7 +4515,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]
@@ -4530,7 +4524,7 @@ version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
 dependencies = [
- "libc 0.2.146",
+ "libc",
  "thiserror",
 ]
 
@@ -4611,7 +4605,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
- "libc 0.2.146",
+ "libc",
 ]
 
 [[package]]

--- a/intel-sgx/dcap-ql/Cargo.toml
+++ b/intel-sgx/dcap-ql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-ql"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -45,7 +45,7 @@ byteorder = "1.1.0" # Unlicense/MIT
 failure = "0.1.1"   # MIT/Apache-2.0
 lazy_static = "1"   # MIT/Apache-2.0
 libc = { version = "0.2", optional = true }        # MIT/Apache-2.0
-"mbedtls" = { version = "0.8.0", default-features = false, optional = true }
+mbedtls = { version = ">=0.8.0, <0.10.0", default-features = false, feature = ["std"], optional = true }
 num = { version = "0.2", optional = true }
 num-derive = "0.2"  # MIT/Apache-2.0
 num-traits = "0.2"  # MIT/Apache-2.0
@@ -53,8 +53,8 @@ serde = { version = "1.0.104", features = ["derive"], optional = true } # MIT/Ap
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"], optional = true }
 
 [dev-dependencies]
-"mbedtls" = { version = "0.8.0" }
-"report-test" = { version = "0.3.1", path = "../report-test" }
-"sgxs" = { version = "0.7.0", path = "../sgxs" }
+mbedtls = { version = ">=0.8.0, <0.10.0" }
+report-test = { version = "0.3.1", path = "../report-test" }
+sgxs = { version = "0.7.0", path = "../sgxs" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = { version = "1.0" }


### PR DESCRIPTION
This PR upgrade `dcap-ql`'s dependency on `mbedtls` to `0.9`

Note: what `mbedtls` API used by `dcap-ql` is not changed in both 0.8 and 0.9, so I use version range to accept both minor version.

This PR also is one step to upgrade `mbedtls` dependency in `rust-sgx` to next major release `0.10.0` which support TLS 1.3

:boom: After this PR is merged, new version of  `dcap-ql` need to be published!!