### PR TITLE
feat: add implementation of `explicit_bzero` in `rs-libc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,7 +2837,7 @@ version = "2.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6653d384a260fedff0a466e894e05c5b8d75e261a14e9f93e81e43ef86cad23"
 dependencies = [
- "log 0.3.9",
+ "log 0.4.14",
  "which 4.0.2",
 ]
 
@@ -3192,6 +3192,7 @@ name = "rs-libc"
 version = "0.2.3"
 dependencies = [
  "cc",
+ "zeroize",
 ]
 
 [[package]]
@@ -4647,6 +4648,12 @@ name = "zero"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f1bc8a6b2005884962297587045002d8cfb8dcec9db332f4ca216ddc5de82c5"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[patch.unused]]
 name = "mbedtls"

--- a/rs-libc/Cargo.toml
+++ b/rs-libc/Cargo.toml
@@ -13,3 +13,6 @@ categories = ["external-ffi-bindings", "os"]
 
 [build-dependencies]
 cc = "1.0.46"
+
+[dependencies]
+zeroize = "1.6.0"

--- a/rs-libc/build.rs
+++ b/rs-libc/build.rs
@@ -5,11 +5,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate cc;
+use std::collections::BTreeSet;
 use std::env;
 use std::ffi::OsStr;
 use std::fs::{read_dir, DirEntry};
 use std::path::PathBuf;
-use std::collections::BTreeSet;
 
 fn main() {
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
@@ -59,17 +59,17 @@ fn main() {
         .define("__NO_STRING_INLINES", None)
         .define("__NO_MATH_INLINES", None);
     #[cfg(unix)]
-        {
-            b = b.flag("-ffreestanding");
-        }
+    {
+        b = b.flag("-ffreestanding");
+    }
     #[cfg(windows)]
-        {
-            b = b.define("restrict", "__restrict").ar_flag("/NODEFAULTLIB");
-        }
+    {
+        b = b.define("restrict", "__restrict").ar_flag("/NODEFAULTLIB");
+    }
 
     b.warnings(false).compile(name);
 }
 
-fn sorted<A: Ord, I: Iterator<Item=A>>(iterator: I) -> BTreeSet<A> {
+fn sorted<A: Ord, I: Iterator<Item = A>>(iterator: I) -> BTreeSet<A> {
     iterator.collect()
 }

--- a/rs-libc/src/alloc.rs
+++ b/rs-libc/src/alloc.rs
@@ -13,7 +13,8 @@ use std::ptr;
 pub(crate) type size_t = usize;
 const ALIGN: usize = 8;
 
-// We purposefully mangle symbols, when compiling for test to avoid collision with libc.a
+// We purposefully mangle symbols, when compiling for test to avoid collision
+// with libc.a
 #[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn malloc(size: size_t) -> *mut c_void {
     let ptr_size = mem::size_of::<*mut usize>();

--- a/rs-libc/src/alloc.rs
+++ b/rs-libc/src/alloc.rs
@@ -10,7 +10,7 @@ use std::mem;
 use std::ptr;
 
 #[allow(non_camel_case_types)]
-type size_t = usize;
+pub(crate) type size_t = usize;
 const ALIGN: usize = 8;
 
 // We purposefully mangle symbols, when compiling for test to avoid collision with libc.a

--- a/rs-libc/src/lib.rs
+++ b/rs-libc/src/lib.rs
@@ -5,3 +5,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 pub mod alloc;
+
+extern crate zeroize;
+use zeroize::Zeroize;
+
+#[no_mangle]
+/// Rust version of [`explicit_bzero`], implemented by using [`zeroize::Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html)
+pub unsafe extern "C" fn explicit_bzero(buf: *mut std::ffi::c_void, len: alloc::size_t)  {
+    let buffer = core::slice::from_raw_parts_mut(buf as *mut std::ffi::c_char, len);
+    buffer.zeroize();
+}

--- a/rs-libc/src/lib.rs
+++ b/rs-libc/src/lib.rs
@@ -9,9 +9,9 @@ pub mod alloc;
 extern crate zeroize;
 use zeroize::Zeroize;
 
-#[no_mangle]
 /// Rust version of [`explicit_bzero`], implemented by using [`zeroize::Zeroize`](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html)
-pub unsafe extern "C" fn explicit_bzero(buf: *mut std::ffi::c_void, len: alloc::size_t)  {
+#[no_mangle]
+pub unsafe extern "C" fn explicit_bzero(buf: *mut std::ffi::c_void, len: alloc::size_t) {
     let buffer = core::slice::from_raw_parts_mut(buf as *mut std::ffi::c_char, len);
     buffer.zeroize();
 }

--- a/rs-libc/src/lib.rs
+++ b/rs-libc/src/lib.rs
@@ -15,3 +15,38 @@ pub unsafe extern "C" fn explicit_bzero(buf: *mut std::ffi::c_void, len: alloc::
     let buffer = core::slice::from_raw_parts_mut(buf as *mut std::ffi::c_char, len);
     buffer.zeroize();
 }
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::c_void;
+
+    use super::*;
+
+    #[test]
+    fn test_explicit_bzero() {
+        let mut buf = [1u8, 2, 3, 4, 5];
+        let len = buf.len();
+
+        // Call the unsafe C function
+        unsafe {
+            explicit_bzero(buf.as_mut_ptr() as *mut c_void, len as alloc::size_t);
+        }
+
+        // Check that the buffer has been zeroed out
+        assert_eq!(&buf, &[0u8; 5]);
+    }
+
+    #[test]
+    fn test_explicit_bzero_zero_buffer() {
+        let mut buf = [0u8; 5];
+        let len = buf.len();
+
+        // Call the unsafe C function
+        unsafe {
+            explicit_bzero(buf.as_mut_ptr() as *mut c_void, len as alloc::size_t);
+        }
+
+        // Check that the buffer is still all zero
+        assert_eq!(&buf, &[0u8; 5]);
+    }
+}


### PR DESCRIPTION
See https://github.com/fortanix/rust-mbedtls/pull/278

We need  `explicit_bzero` in `libc` in SGX