### PR TITLE
Initialize enclave args with the first argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runner"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "crossbeam",
  "failure",

--- a/intel-sgx/enclave-runner/Cargo.toml
+++ b/intel-sgx/enclave-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runner"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/enclave-runner/src/loader.rs
+++ b/intel-sgx/enclave-runner/src/loader.rs
@@ -332,6 +332,7 @@ impl<'a> EnclaveBuilder<'a> {
     }
 
     pub fn build<T: Load>(mut self, loader: &mut T) -> Result<Command, Error> {
+        self.initialized_args_mut();
         let args = self.cmd_args.take().unwrap_or_default();
         let c = self.usercall_ext.take();
         self.load(loader)


### PR DESCRIPTION
When calling the enclave main first argument must be always initialized

Resolves #386