### PR TITLE
Fix typo in `dcap-ql` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-ql"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "byteorder 1.3.4",
  "dcap-ql-sys",

--- a/intel-sgx/dcap-ql/Cargo.toml
+++ b/intel-sgx/dcap-ql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-ql"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -45,7 +45,7 @@ byteorder = "1.1.0" # Unlicense/MIT
 failure = "0.1.1"   # MIT/Apache-2.0
 lazy_static = "1"   # MIT/Apache-2.0
 libc = { version = "0.2", optional = true }        # MIT/Apache-2.0
-mbedtls = { version = ">=0.8.0, <0.10.0", default-features = false, feature = ["std"], optional = true }
+mbedtls = { version = ">=0.8.0, <0.10.0", default-features = false, features = ["std"], optional = true }
 num = { version = "0.2", optional = true }
 num-derive = "0.2"  # MIT/Apache-2.0
 num-traits = "0.2"  # MIT/Apache-2.0


### PR DESCRIPTION
A typo in the specification of the `mbedtls` dependency of `dcap-ql` may lead to a compilation error.

Fixes #497
cc: @Taowyoo @jethrogb @vn971 @mkaynov 