### PR TITLE
Group enclave baseaddress un/registration together

### DIFF
--- a/intel-sgx/sgxs-loaders/src/generic.rs
+++ b/intel-sgx/sgxs-loaders/src/generic.rs
@@ -16,7 +16,6 @@ use sgxs::sgxs::{
     CreateInfo, Error as SgxsError, MeasEAdd, MeasECreate, PageChunks, PageReader, SgxsRead,
 };
 
-use crate::isgx::debugging;
 use crate::{MappingInfo, Tcs};
 
 pub(crate) trait EnclaveLoad: Debug + Sized + Send + Sync + 'static {
@@ -55,7 +54,6 @@ pub(crate) struct Mapping<D: EnclaveLoad> {
 
 impl<D: EnclaveLoad> Drop for Mapping<D> {
     fn drop(&mut self) {
-        debugging::unregister_terminated_enclave(self.base);
         D::destroy(self)
     }
 }

--- a/intel-sgx/sgxs-loaders/src/isgx/mod.rs
+++ b/intel-sgx/sgxs-loaders/src/isgx/mod.rs
@@ -186,6 +186,7 @@ impl EnclaveLoad for InnerDevice {
             size: ecreate.size,
             tcss: vec![],
         };
+        debugging::register_new_enclave(mapping.base, mapping.size);
 
         let secs = Secs {
             baseaddr: mapping.base,
@@ -195,7 +196,6 @@ impl EnclaveLoad for InnerDevice {
             attributes,
             ..Default::default()
         };
-        debugging::register_new_enclave(secs.baseaddr, secs.size);
         let createdata = ioctl::CreateData { secs: &secs };
         ioctl_unsafe!(
             Create,
@@ -384,6 +384,7 @@ impl EnclaveLoad for InnerDevice {
     }
 
     fn destroy(mapping: &mut Mapping<Self>) {
+        debugging::unregister_terminated_enclave(mapping.base);
         unsafe { let _ = munmap(mapping.base as usize as *mut _, mapping.size as usize); }
     }
 }


### PR DESCRIPTION
Currently, the enclave's baseaddress is registered in a different module than where it is unregistered. This is error-prone.