### PR TITLE
Added version of certificate request functions that accept Subject as parameter

### DIFF
--- a/em-app/src/csr.rs
+++ b/em-app/src/csr.rs
@@ -6,6 +6,7 @@
 
 use crate::Error;
 use crate::Result;
+use crate::common_name_to_subject;
 use mbedtls::hash;
 use mbedtls::pk::{Pk, Type as PkType};
 pub use mbedtls::rng::Rdrand as FtxRng;
@@ -15,10 +16,8 @@ use pkix::pem::{der_to_pem, PEM_CERTIFICATE_REQUEST};
 use pkix::pkcs10::{CertificationRequest, CertificationRequestInfo};
 use pkix::types::{
     Attribute, DerSequence, EcdsaX962, Extension, Name, ObjectIdentifier, RsaPkcs15, Sha256,
-    TaggedDerValue,
 };
 use pkix::DerWrite;
-use yasna::tags::TAG_UTF8STRING;
 
 #[derive(Clone, Copy, Debug)]
 pub enum SignatureAlgorithm {
@@ -94,14 +93,6 @@ impl ExternalKey for Pk {
 
         Ok((sig, sigalg))
     }
-}
-
-pub(crate) fn common_name_to_subject(common_name: &str) -> Name {
-    vec![(
-        pkix::oid::commonName.clone(),
-        TaggedDerValue::from_tag_and_bytes(TAG_UTF8STRING, common_name.as_bytes().to_vec()),
-    )]
-    .into()
 }
 
 pub fn get_csr(

--- a/em-app/src/lib.rs
+++ b/em-app/src/lib.rs
@@ -3,17 +3,19 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-#[macro_use] pub extern crate serde_derive;
+#[macro_use]
+pub extern crate serde_derive;
 
-pub mod utils;
 pub mod mbedtls_hyper;
 
-use em_node_agent_client::{Api, Client, models};
+pub mod utils;
+
+use em_node_agent_client::{models, Api, Client};
 use mbedtls::hash;
-use std::borrow::Cow;
-use rustc_serialize::hex::FromHex;
-use uuid::Uuid;
 use pkix::types::Name;
+use rustc_serialize::hex::FromHex;
+use std::borrow::Cow;
+use uuid::Uuid;
 
 mod platform;
 
@@ -42,21 +44,37 @@ pub fn get_certificate_status(url: &str, task_id: Uuid) -> Result<models::IssueC
     client.get_issue_certificate_response(task_id).map_err(|e| Error::NodeAgentClient(Box::new(e)))
 }
 
-pub fn get_fortanix_em_certificate(url: &str, common_name: &str, signer: &mut dyn CsrSigner) -> Result<FortanixEmCertificate> {
+pub fn get_fortanix_em_certificate_subject(
+    url: &str,
+    subject: &Name,
+    signer: &mut dyn CsrSigner,
+) -> Result<FortanixEmCertificate> {
+    get_certificate_subject(url, subject, signer, None, None)
+}
+
+pub fn get_fortanix_em_certificate(
+    url: &str,
+    common_name: &str,
+    signer: &mut dyn CsrSigner,
+) -> Result<FortanixEmCertificate> {
     get_certificate(url, common_name, signer, None, None)
 }
 
-pub fn get_certificate_subject(url: &str,
-                       subject: &Name,
-                       signer: &mut dyn CsrSigner,
-                       alt_names: Option<Vec<Cow<str>>>,
-                       config_id: Option<&str>
-) -> Result<FortanixEmCertificate> {
 
+pub fn get_certificate_subject(
+    url: &str,
+    subject: &Name,
+    signer: &mut dyn CsrSigner,
+    alt_names: Option<Vec<Cow<str>>>,
+    config_id: Option<&str>,
+) -> Result<FortanixEmCertificate> {
     let pub_key = signer.get_public_key_der()?;
     let user_data = get_user_data(&pub_key, config_id)?;
 
-    let (attestation_certificate_der, node_certificate_der, csr_pem) = platform::get_remote_attestation_parameters_subject(signer, url, subject, &user_data, alt_names)?;
+    let (attestation_certificate_der, node_certificate_der, csr_pem) =
+        platform::get_remote_attestation_parameters_subject(
+            signer, url, subject, &user_data, alt_names,
+        )?;
 
     let certificate_response = request_issue_certificate(url, csr_pem)?;
 
@@ -67,49 +85,41 @@ pub fn get_certificate_subject(url: &str,
     })
 }
 
-pub fn get_certificate(url: &str,
-                       common_name: &str, 
-                       signer: &mut dyn CsrSigner,
-                       alt_names: Option<Vec<Cow<str>>>, 
-                       config_id: Option<&str>
+pub fn get_certificate(
+    url: &str,
+    common_name: &str,
+    signer: &mut dyn CsrSigner,
+    alt_names: Option<Vec<Cow<str>>>,
+    config_id: Option<&str>,
 ) -> Result<FortanixEmCertificate> {
-
-    let pub_key = signer.get_public_key_der()?;
-    let user_data = get_user_data(&pub_key, config_id)?;
-
-    let (attestation_certificate_der, node_certificate_der, csr_pem) = platform::get_remote_attestation_parameters(signer, url, common_name, &user_data, alt_names)?;
-
-    let certificate_response = request_issue_certificate(url, csr_pem)?;
-    
-    Ok(FortanixEmCertificate {
-        attestation_certificate_der,
-        node_certificate_der,
-        certificate_response,
-    })
+    let subject = common_name_to_subject(common_name);
+    get_certificate_subject(url, &subject, signer, alt_names, config_id)
 }
 
-pub fn get_remote_attestation_csr(url: &str, 
-                                  common_name: &str, 
-                                  signer: &mut dyn CsrSigner,
-                                  alt_names: Option<Vec<Cow<str>>>, 
-                                  config_id: Option<&str>
+pub fn get_remote_attestation_csr_subject(
+    url: &str,
+    subject: &Name,
+    signer: &mut dyn CsrSigner,
+    alt_names: Option<Vec<Cow<str>>>,
+    config_id: Option<&str>,
 ) -> Result<String> {
     let pub_key = signer.get_public_key_der()?;
     let user_data = get_user_data(&pub_key, config_id)?;
-    let (_, _, csr_pem) = platform::get_remote_attestation_parameters(signer, url, common_name, &user_data, alt_names)?;
+    let (_, _, csr_pem) = platform::get_remote_attestation_parameters_subject(
+        signer, url, subject, &user_data, alt_names,
+    )?;
     Ok(csr_pem)
 }
 
-pub fn get_remote_attestation_csr_subject(url: &str,
-                                          subject: &Name,
-                                          signer: &mut dyn CsrSigner,
-                                          alt_names: Option<Vec<Cow<str>>>,
-                                          config_id: Option<&str>
+pub fn get_remote_attestation_csr(
+    url: &str,
+    common_name: &str,
+    signer: &mut dyn CsrSigner,
+    alt_names: Option<Vec<Cow<str>>>,
+    config_id: Option<&str>,
 ) -> Result<String> {
-    let pub_key = signer.get_public_key_der()?;
-    let user_data = get_user_data(&pub_key, config_id)?;
-    let (_, _, csr_pem) = platform::get_remote_attestation_parameters_subject(signer, url, subject, &user_data, alt_names)?;
-    Ok(csr_pem)
+    let subject = common_name_to_subject(common_name);
+    get_remote_attestation_csr_subject(url, &subject, signer, alt_names, config_id)
 }
 
 pub fn request_issue_certificate(url: &str, csr_pem: String) -> Result<models::IssueCertificateResponse> {
@@ -127,14 +137,14 @@ fn get_user_data(pub_key: &Vec<u8>, config_id: Option<&str>) -> Result<[u8;64]> 
         if id.len() != 32 {
             return Err(Error::ConfigIdIssue(format!("config ID is invalid, length: {}, expected length: 32", id.len())));
         }
-        
+
         let mut payload=[0u8;65];
         payload[0] = 1;
         payload[1..33].copy_from_slice(&data[0..32]);
         payload[33..65].copy_from_slice(&id[0..32]);
 
         // The payload is formed as follows in case of workflow report.
-        
+
         // First 32 bytes is a Sha256 of (Version + public key sha256 + config-id)
         hash::Md::hash(hash::Type::Sha256, &payload, &mut data[0..32]).map_err(|e| Error::TargetReportHash(Box::new(e)))?;
 

--- a/em-app/src/lib.rs
+++ b/em-app/src/lib.rs
@@ -24,6 +24,8 @@ pub use csr::*;
 
 pub mod error;
 pub use error::*;
+use yasna::models::TaggedDerValue;
+use yasna::tags::TAG_UTF8STRING;
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -37,6 +39,14 @@ pub struct FortanixEmCertificate {
 
     // Response
     pub certificate_response: models::IssueCertificateResponse,
+}
+
+pub(crate) fn common_name_to_subject(common_name: &str) -> Name {
+    vec![(
+        pkix::oid::commonName.clone(),
+        TaggedDerValue::from_tag_and_bytes(TAG_UTF8STRING, common_name.as_bytes().to_vec()),
+    )]
+        .into()
 }
 
 pub fn get_certificate_status(url: &str, task_id: Uuid) -> Result<models::IssueCertificateResponse> {
@@ -155,4 +165,3 @@ fn get_user_data(pub_key: &Vec<u8>, config_id: Option<&str>) -> Result<[u8;64]> 
 
     Ok(data)
 }
-

--- a/em-app/src/lib.rs
+++ b/em-app/src/lib.rs
@@ -41,12 +41,12 @@ pub struct FortanixEmCertificate {
     pub certificate_response: models::IssueCertificateResponse,
 }
 
-pub(crate) fn common_name_to_subject(common_name: &str) -> Name {
+pub fn common_name_to_subject(common_name: &str) -> Name {
     vec![(
         pkix::oid::commonName.clone(),
         TaggedDerValue::from_tag_and_bytes(TAG_UTF8STRING, common_name.as_bytes().to_vec()),
     )]
-        .into()
+    .into()
 }
 
 pub fn get_certificate_status(url: &str, task_id: Uuid) -> Result<models::IssueCertificateResponse> {

--- a/em-app/src/platform/mod.rs
+++ b/em-app/src/platform/mod.rs
@@ -3,38 +3,41 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use std::borrow::Cow;
-use pkix::DerWrite;
 use pkix::x509::DnsAltNames;
+use pkix::DerWrite;
+use std::borrow::Cow;
 use yasna::models::ObjectIdentifier;
 
 #[cfg(target_env = "sgx")]
 pub(crate) mod sgx;
 
 #[cfg(target_env = "sgx")]
-pub(crate) use sgx::{get_remote_attestation_parameters, get_remote_attestation_parameters_subject};
+pub(crate) use sgx::get_remote_attestation_parameters_subject;
 
-#[cfg(all(target_arch="x86_64",
-          target_vendor="unknown",
-          target_os="linux",
-          any(target_env="gnu",
-              target_env="musl",
-              target_env = "fortanixvme")))]
+#[cfg(all(
+    target_arch = "x86_64",
+    target_vendor = "unknown",
+    target_os = "linux",
+    any(target_env = "gnu", target_env = "musl", target_env = "fortanixvme")
+))]
 pub(crate) mod nitro;
 
-#[cfg(all(target_arch="x86_64",
-          target_vendor="unknown",
-          target_os="linux",
-          any(target_env="gnu",
-              target_env="musl",
-              target_env = "fortanixvme")))]
-pub(crate) use nitro::{get_remote_attestation_parameters, get_remote_attestation_parameters_subject};
+#[cfg(all(
+    target_arch = "x86_64",
+    target_vendor = "unknown",
+    target_os = "linux",
+    any(target_env = "gnu", target_env = "musl", target_env = "fortanixvme")
+))]
+pub(crate) use nitro::get_remote_attestation_parameters_subject;
 
-pub(crate) fn get_extensions_from_alt_names(alt_names: Option<Vec<Cow<str>>>) -> Option<Vec<(ObjectIdentifier, bool, Vec<u8>)>> {
+pub(crate) fn get_extensions_from_alt_names(
+    alt_names: Option<Vec<Cow<str>>>,
+) -> Option<Vec<(ObjectIdentifier, bool, Vec<u8>)>> {
     alt_names.and_then(|names| {
-        Some(vec![
-            (pkix::oid::subjectAltName.clone(),
-             false,
-             pkix::yasna::construct_der(|w| DnsAltNames { names }.write(w)).into())])
+        Some(vec![(
+            pkix::oid::subjectAltName.clone(),
+            false,
+            pkix::yasna::construct_der(|w| DnsAltNames { names }.write(w)).into(),
+        )])
     })
 }

--- a/em-app/src/platform/mod.rs
+++ b/em-app/src/platform/mod.rs
@@ -3,12 +3,16 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+use std::borrow::Cow;
+use pkix::DerWrite;
+use pkix::x509::DnsAltNames;
+use yasna::models::ObjectIdentifier;
 
 #[cfg(target_env = "sgx")]
 pub(crate) mod sgx;
 
 #[cfg(target_env = "sgx")]
-pub(crate) use sgx::get_remote_attestation_parameters;
+pub(crate) use sgx::{get_remote_attestation_parameters, get_remote_attestation_parameters_subject};
 
 #[cfg(all(target_arch="x86_64",
           target_vendor="unknown",
@@ -24,4 +28,13 @@ pub(crate) mod nitro;
           any(target_env="gnu",
               target_env="musl",
               target_env = "fortanixvme")))]
-pub(crate) use nitro::get_remote_attestation_parameters;
+pub(crate) use nitro::{get_remote_attestation_parameters, get_remote_attestation_parameters_subject};
+
+pub(crate) fn get_extensions_from_alt_names(alt_names: Option<Vec<Cow<str>>>) -> Option<Vec<(ObjectIdentifier, bool, Vec<u8>)>> {
+    alt_names.and_then(|names| {
+        Some(vec![
+            (pkix::oid::subjectAltName.clone(),
+             false,
+             pkix::yasna::construct_der(|w| DnsAltNames { names }.write(w)).into())])
+    })
+}

--- a/em-app/src/platform/sgx.rs
+++ b/em-app/src/platform/sgx.rs
@@ -3,22 +3,21 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use b64_ct::{ToBase64, FromBase64, STANDARD};
-use em_node_agent_client::{Api, Client, models};
-use mbedtls::cipher::{Cipher, raw};
-use mbedtls::hash::{Type,Md};
+use crate::platform::get_extensions_from_alt_names;
+use crate::{common_name_to_subject, get_csr, CsrSigner, Error};
+use b64_ct::{FromBase64, ToBase64, STANDARD};
+use em_node_agent_client::{models, Api, Client};
+use mbedtls::cipher::{raw, Cipher};
 use mbedtls::hash;
-use pkix::ToDer;
+use mbedtls::hash::{Md, Type};
+use pkix;
 use pkix::pem::{pem_to_der, PEM_CERTIFICATE};
 use pkix::types::Name;
-use pkix;
+use pkix::ToDer;
 use sgx_isa::{Report, Targetinfo};
-use sgx_pkix::attestation::{AttestationInlineSgxLocal, AttestationEmbeddedFqpe};
+use sgx_pkix::attestation::{AttestationEmbeddedFqpe, AttestationInlineSgxLocal, SgxName};
 use sgx_pkix::oid;
 use std::borrow::Cow;
-use sgx_pkix::attestation::{SgxName};
-use crate::platform::get_extensions_from_alt_names;
-use crate::{CsrSigner, Error, get_csr};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -43,7 +42,7 @@ pub(crate) fn get_remote_attestation_parameters_subject(
 
     let attributes = vec![(oid::attestationInlineSgxLocal.clone(), vec![attestation])];
     let extensions = get_extensions_from_alt_names(alt_names);
-    let mut sgx_name = SgxName::from_report(&report, true);
+    let sgx_name = SgxName::from_report(&report, true);
     let mut subject = subject.clone(); // Copy the subject, since it must be modified
     subject.value.append(&mut sgx_name.to_name().value); // Extend the subject with SGX names
     let csr_pem = get_csr(signer, &subject, attributes, &extensions)?;
@@ -63,6 +62,8 @@ pub(crate) fn get_remote_attestation_parameters_subject(
     Ok((Some(fqpe_cert), Some(node_cert), csr_pem))
 }
 
+// Kept in place for legacy purposes
+#[allow(dead_code)]
 pub(crate) fn get_remote_attestation_parameters(
     signer: &mut dyn CsrSigner,
     url: &str,
@@ -70,19 +71,19 @@ pub(crate) fn get_remote_attestation_parameters(
     user_data: &[u8;64],
     alt_names: Option<Vec<Cow<str>>>,
 ) -> Result<(Option<Vec<u8>>, Option<Vec<u8>>, String)> {
-    let subject = Name::from(vec![(pkix::oid::commonName.clone(), common_name.to_string().into())]);
+    let subject = common_name_to_subject(common_name);
     get_remote_attestation_parameters_subject(signer, url, &subject, user_data, alt_names)
 }
 
 pub(crate) fn get_target_report(client: &mut Client, user_data: &[u8;64]) -> Result<sgx_isa::Report> {
     let result = client.get_target_info().map_err(|e| Error::TargetReport(Box::new(e)))?;
-    
+
     let target_info = Targetinfo::try_copy_from(
         result.target_info.ok_or(Error::TargetReportInternal("Node Agent returned empty target_info".to_string()))?
             .from_base64().map_err(|e| Error::TargetReportInternal(format!("Base64 decode failed: {:?}", e)))?
             .as_ref()
     ).ok_or(Error::TargetReportInternal("Failed creating SGX structure from remote target info".to_string()))?;
-    
+
     Ok(sgx_isa::Report::for_target(&target_info, user_data))
 }
 
@@ -90,14 +91,14 @@ pub(crate) fn get_target_report(client: &mut Client, user_data: &[u8;64]) -> Res
 pub(crate) fn get_attestation_certificates(client: &mut Client, report: &Report, csr_pem: String) -> Result<(Vec<u8>, Vec<u8>)> {
     let mut corr_report_bytes = vec![0; Report::UNPADDED_SIZE];
     corr_report_bytes.copy_from_slice(report.as_ref());
-    
+
     let request = models::GetFortanixAttestationRequest {
         report: Some(corr_report_bytes.to_base64(STANDARD)),
         attestation_csr: Some(csr_pem),
     };
-    
+
     let result = client.get_fortanix_attestation(request).map_err(|e| Error::AttestationCert(Box::new(e)))?;
-    
+
     let qe_report = Report::try_copy_from(result.fqpe_report.ok_or(Error::AttestationCertInternal("No fqpe report returned by node agent".to_string()))?
                                           .from_base64().map_err(|e| Error::AttestationCertInternal(format!("Base64 decode failed: {:?}", e)))?
                                           .as_ref()


### PR DESCRIPTION
In light of recent requirements to be able to request certificates with no Common Name (as this is deprecated), this change creates versions of several functions that accept a `Name`  as a parameter instead of a common name string. In this case, the user will be able to provide an empty `Name`, where the internal value is an empty `Vec`. In order to provide backwards compatibility, the existing functions that use common name have not been changed.