### PR TITLE
Fix CI issue with `x86_64-unknown-linux-musl` target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,8 @@ matrix:
         #  fault while compiling. We only execute `faketime` during the tests
         #- cargo test --locked -p nitro-attestation-verify --no-run && faketime '2021-09-08 11:00:00 GMT' cargo test --locked -p nitro-attestation-verify --lib
         - cargo test --locked -p nitro-attestation-verify --no-run && faketime '2021-09-10 11:00:00 GMT' cargo test --locked -p nitro-attestation-verify --lib
-        # NOTE: linking glibc version of OpenSSL with musl binary.
-        # Unlikely to produce a working binary, but at least the build succeeds.
-        - mkdir -p /tmp/muslinclude && ln -sf /usr/include/x86_64-linux-gnu/openssl /tmp/muslinclude/openssl && PKG_CONFIG_ALLOW_CROSS=1 CFLAGS=-I/tmp/muslinclude cargo build --locked -p fortanix-sgx-tools --target x86_64-unknown-linux-musl
+        # NOTE: Skipping linking with the glibc version of OpenSSL to produce a musl based binary. It is unlikely that this would produce a working binary anyway.
+        - mkdir -p /tmp/muslinclude && ln -sf /usr/include/x86_64-linux-gnu/openssl /tmp/muslinclude/openssl && PKG_CONFIG_ALLOW_CROSS=1 CFLAGS=-I/tmp/muslinclude CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=true cargo build --locked -p fortanix-sgx-tools --target x86_64-unknown-linux-musl
         - cargo build --verbose --locked -p em-app -p get-certificate -p harmonize --target=x86_64-unknown-linux-musl
         - cargo build --verbose --locked -p em-app -p get-certificate -p harmonize --target=x86_64-fortanix-unknown-sgx
         - ./doc/generate-api-docs.sh


### PR DESCRIPTION
CI builds `fortanix-sgx-tools` for the `x86_64-unknown-linux-musl` target by linking a glibc version of openssl. This likely never resulted in runnable executables, but only recently resulted in missing symbol issues. This PR "fixes" this issue by ignoring the linking step altogether. 

Fixes #516 
Opened #518 for a proper fix (if we even want to support the platform properly)