### PR TITLE
Remove unused import

### DIFF
--- a/intel-sgx/aesm-client/src/imp/aesm_protobuf/mod.rs
+++ b/intel-sgx/aesm-client/src/imp/aesm_protobuf/mod.rs
@@ -1,5 +1,5 @@
 use imp::AesmClient;
-pub use error::{AesmError, Error, Result};
+pub use error::{Error, Result};
 use protobuf::Message;
 use std::io::{Read, Write};
 use std::mem::size_of;

--- a/intel-sgx/aesm-client/src/imp/sgx.rs
+++ b/intel-sgx/aesm-client/src/imp/sgx.rs
@@ -1,5 +1,5 @@
 use std::net::TcpStream;
-pub use error::{AesmError, Error, Result};
+pub use error::Result;
 mod aesm_protobuf;
 
 #[derive(Debug)]

--- a/intel-sgx/aesm-client/src/imp/unix.rs
+++ b/intel-sgx/aesm-client/src/imp/unix.rs
@@ -7,7 +7,7 @@ use unix_socket::UnixStream;
 #[cfg(feature = "sgxs")]
 use sgxs::sigstruct::{Attributes, Sigstruct};
 
-pub use error::{AesmError, Error, Result};
+pub use error::Result;
 
 mod aesm_protobuf;
 


### PR DESCRIPTION
Fixes error due to unused import in `aesm-client`.

Fixes #537