### PR TITLE
Upgrade deps: mbedtls, pkix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "ias"
-version = "0.1.3"
+version = "0.1.2"
 dependencies = [
  "aesm-client",
  "base64 0.13.0",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "sgx-isa"
-version = "0.4.2"
+version = "0.4.1"
 dependencies = [
  "bitflags",
  "mbedtls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "em-app"
-version = "0.4.1"
+version = "0.4.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "b64-ct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,11 +38,26 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.14"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -181,7 +196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
 dependencies = [
  "bitflags",
- "cexpr",
+ "cexpr 0.4.0",
  "clang-sys",
  "clap",
  "env_logger 0.8.4",
@@ -189,12 +204,35 @@ dependencies = [
  "lazycell",
  "log 0.4.14",
  "peeking_take_while",
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "regex",
  "rustc-hash",
  "shlex",
- "which 3.1.1",
+ "which 3.0.0",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags",
+ "cexpr 0.6.0",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log 0.4.14",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.42",
+ "which 4.2.2",
 ]
 
 [[package]]
@@ -253,7 +291,7 @@ checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
 dependencies = [
  "lazy_static",
  "memchr",
- "regex-automata",
+ "regex-automata 0.1.10",
  "serde",
 ]
 
@@ -333,7 +371,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
- "nom",
+ "nom 5.1.2",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -350,16 +397,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
- "libc",
- "num-integer",
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
- "time 0.1.44",
- "winapi 0.3.9",
+ "wasm-bindgen",
+ "windows-targets",
 ]
 
 [[package]]
@@ -404,6 +452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -611,6 +669,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxx"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88abab2f5abbe4c56e8f1fb431b784d710b709888f35755a160e62e33fe38e8"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0c11acd0e63bae27dcd2afced407063312771212b7a823b4fd72d633be30fb"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
+ "scratch",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3816ed957c008ccd4728485511e3d9aaf7db419aa321e3d2c5a2f3411e36c8"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26acccf6f445af85ea056362561a24ef56cdc15fcc685f03aec50b9c702cb6d"
+dependencies = [
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
+ "syn 2.0.42",
+]
+
+[[package]]
 name = "darling"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,8 +730,8 @@ checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "strsim 0.10.0",
  "syn 1.0.81",
 ]
@@ -641,7 +743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
  "darling_core",
- "quote 1.0.10",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -661,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-ql"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "byteorder 1.3.4",
  "dcap-ql-sys",
@@ -802,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "em-app"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "b64-ct",
@@ -966,8 +1068,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "rustversion",
  "syn 1.0.81",
  "synstructure",
@@ -998,8 +1100,8 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
  "synstructure",
 ]
@@ -1241,8 +1343,8 @@ checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg 1.0.1",
  "proc-macro-hack",
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -1314,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "get-certificate"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "em-app",
  "mbedtls",
@@ -1399,7 +1501,7 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "harmonize"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "b64-ct",
  "csv",
@@ -1650,8 +1752,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "ias"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aesm-client",
  "base64 0.13.0",
@@ -1878,6 +2004,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,9 +2077,8 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "mbedtls"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f2c88dbe2fcc6fddc0dc33eb2694471fef46f48b2081996335adb2f8085c53"
+version = "0.12.1"
+source = "git+https://github.com/fortanix/rust-mbedtls?branch=main#51429f1db35d986ddb3f43bbefc078df74be62ff"
 dependencies = [
  "bitflags",
  "byteorder 1.3.4",
@@ -1960,9 +2094,8 @@ dependencies = [
 
 [[package]]
 name = "mbedtls-platform-support"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85be113c8c2dc54cc6a5fba20130c7128f78dcb3ed0bb6797427333fa8cdb54d"
+version = "0.1.1"
+source = "git+https://github.com/fortanix/rust-mbedtls?branch=main#51429f1db35d986ddb3f43bbefc078df74be62ff"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
@@ -1972,25 +2105,24 @@ dependencies = [
 
 [[package]]
 name = "mbedtls-sys-auto"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2231108271d9a10052178d940926baf24b57a2eb1703732faae387592dd6ac3"
+version = "2.28.4+mbedtls-2.28.3"
+source = "git+https://github.com/fortanix/rust-mbedtls?branch=main#51429f1db35d986ddb3f43bbefc078df74be62ff"
 dependencies = [
- "bindgen",
+ "bindgen 0.65.1",
  "cc",
  "cfg-if 1.0.0",
  "cmake",
  "lazy_static",
  "libc",
- "quote 1.0.10",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -2046,6 +2178,12 @@ dependencies = [
  "mime 0.3.16",
  "unicase 2.6.0",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2176,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "nitro-attestation-verify"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aws-nitro-enclaves-cose 0.5.0",
  "chrono",
@@ -2196,7 +2334,7 @@ version = "1.1.0"
 source = "git+https://github.com/fortanix/aws-nitro-enclaves-cli.git?branch=main#93193b1317c544ff07dd3ddcc6e126f847449cbb"
 dependencies = [
  "aws-nitro-enclaves-cose 0.1.0",
- "bindgen",
+ "bindgen 0.58.1",
  "chrono",
  "clap",
  "eif_defs",
@@ -2282,6 +2420,16 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
  "version_check 0.9.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2397,8 +2545,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -2682,8 +2830,8 @@ version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -2693,8 +2841,8 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -2724,9 +2872,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "pkix"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643768328ce074b546bc11af4581bc3e8f1242706be53946eb7b30f686194fba"
+checksum = "3627d36de10749cd6bba01a975d64c01f1deb95d22823dbfbb4d7a913a240850"
 dependencies = [
  "b64-ct",
  "bit-vec 0.6.2",
@@ -2753,14 +2901,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2 1.0.71",
+ "syn 2.0.42",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
  "version_check 0.9.2",
 ]
@@ -2771,8 +2929,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "version_check 0.9.2",
 ]
 
@@ -2799,11 +2957,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2838,7 +2996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6653d384a260fedff0a466e894e05c5b8d75e261a14e9f93e81e43ef86cad23"
 dependencies = [
  "log 0.3.9",
- "which 4.0.2",
+ "which 4.2.2",
 ]
 
 [[package]]
@@ -2883,11 +3041,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.32",
+ "proc-macro2 1.0.71",
 ]
 
 [[package]]
@@ -3076,14 +3234,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-automata 0.4.3",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
@@ -3093,10 +3251,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
-name = "regex-syntax"
-version = "0.6.20"
+name = "regex-automata"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "remove_dir_all"
@@ -3248,8 +3417,8 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -3280,6 +3449,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
 
 [[package]]
 name = "sdkms"
@@ -3383,8 +3558,8 @@ name = "serde_derive"
 version = "1.0.130"
 source = "git+https://github.com/fortanix/serde.git?branch=master#80449547025fc4a016a333e96c0cdaf7e4a96f67"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -3394,8 +3569,8 @@ version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -3425,8 +3600,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -3472,8 +3647,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48b35457e9d855d3dc05ef32a73e0df1e2c0fd72c38796a4ee909160c8eeec2"
 dependencies = [
  "darling",
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -3491,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "sgx-isa"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bitflags",
  "mbedtls",
@@ -3737,9 +3912,20 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
+dependencies = [
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3748,8 +3934,8 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
  "unicode-xid 0.2.1",
 ]
@@ -3822,18 +4008,9 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -3970,8 +4147,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -3981,8 +4158,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -4142,8 +4319,8 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
 ]
 
@@ -4224,6 +4401,12 @@ checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 dependencies = [
  "matches",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -4340,7 +4523,7 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "vme-pkix"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "lazy_static",
  "pkix",
@@ -4434,8 +4617,8 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.14",
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
  "wasm-bindgen-shared",
 ]
@@ -4458,7 +4641,7 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
- "quote 1.0.10",
+ "quote 1.0.33",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4468,8 +4651,8 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.71",
+ "quote 1.0.33",
  "syn 1.0.81",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -4493,21 +4676,22 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "240a31163872f7e8e49f35b42b58485e35355b07eb009d9f3686733541339a69"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "which"
-version = "4.0.2"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
 dependencies = [
+ "either",
+ "lazy_static",
  "libc",
- "thiserror",
 ]
 
 [[package]]
@@ -4552,6 +4736,72 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winreg"
@@ -4654,8 +4904,3 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
-
-[[patch.unused]]
-name = "mbedtls"
-version = "0.10.0"
-source = "git+https://github.com/fortanix/rust-mbedtls?branch=master#ce358f430258a5514c8b699875c90705d7622d96"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ exclude = ["examples"]
 
 [patch.crates-io]
 libc  = { git = "https://github.com/fortanix/libc.git", branch = "fortanixvme" }
-mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", branch = "master" }
+mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", branch = "main" }
 nix   = { git = "https://github.com/fortanix/nix.git", branch = "raoul/fortanixvme_r0.20.2" }
 serde = { git = "https://github.com/fortanix/serde.git", branch = "master" }
 vsock = { git = "https://github.com/fortanix/vsock-rs.git", branch = "fortanixvme" }

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "em-app"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["fortanix.com"]
 license = "MPL-2.0"
 edition = "2018"
@@ -14,8 +14,8 @@ b64-ct = "0.1.0"
 em-client = { version = "3.0.0", default-features = false, features = ["client"] }
 em-node-agent-client = "1.0.0"
 hyper = { version = "0.10", default-features = false }
-mbedtls = { version = "0.9", features = [ "rdrand", "std", "force_aesni_support", "mpi_force_c_code" ], default-features = false }
-pkix = "0.1.2"
+mbedtls = { version = "0.12.1", features = [ "rdrand", "std", "force_aesni_support", "mpi_force_c_code", "ssl" ], default-features = false }
+pkix = ">=0.1.2, <0.3.0"
 
 rustc-serialize = "0.3.24"
 sdkms = { version = "0.2.1", default-features = false }

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "em-app"
-version = "0.4.1"
+version = "0.4.0"
 authors = ["fortanix.com"]
 license = "MPL-2.0"
 edition = "2018"

--- a/em-app/examples/get-certificate/Cargo.toml
+++ b/em-app/examples/get-certificate/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "get-certificate"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["fortanix.com"]
 edition = "2018"
 license = "MPL-2.0"
+publish = false
 
 [dependencies]
 em-app = { path = "../../" }
-mbedtls = { version = "0.9", features = [ "rdrand", "std", "force_aesni_support", "mpi_force_c_code" ], default-features = false }
+mbedtls = { version = "0.12.1", features = [ "rdrand", "std", "force_aesni_support", "mpi_force_c_code" ], default-features = false }
 serde_json = "1.0"

--- a/em-app/examples/harmonize/Cargo.toml
+++ b/em-app/examples/harmonize/Cargo.toml
@@ -1,14 +1,15 @@
 # Minimal application for testing purposes - used to fetch app config via cert auth.
 [package]
 name = "harmonize"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["fortanix.com"]
 edition = "2018"
 license = "MPL-2.0"
+publish = false
 
 [dependencies]
 em-app = { path = "../../" }
-mbedtls = { version = "0.9", features = [ "rdrand", "std", "force_aesni_support", "mpi_force_c_code" ], default-features = false }
+mbedtls = { version = "0.12.1", features = [ "rdrand", "std", "force_aesni_support", "mpi_force_c_code", "x509" ], default-features = false }
 serde_json = "1.0.62"
 serde = "1.0.123"
 serde_derive = "1.0.123"
@@ -18,5 +19,5 @@ hyper = "0.10"
 sdkms = { version = "0.2.1", default-features = false }
 rustc-serialize = "0.3.24"
 csv = "1.1"
-pkix = "0.1.2"
+pkix = ">=0.1.2, <0.3.0"
 url = "1"

--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "tls"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["fortanix.com"]
 edition = "2018"
 
 [dependencies]
 chrono = "0.4"
-mbedtls = {version="0.5", default-features = false, features = ["sgx"]}
+mbedtls = { version = "0.12.1", default-features = false, features = ["std", "ssl", "rdrand"] }

--- a/examples/tls/src/main.rs
+++ b/examples/tls/src/main.rs
@@ -5,6 +5,8 @@ extern crate mbedtls;
 
 use chrono::prelude::*;
 
+use mbedtls::alloc::Box as MbedtlsBox;
+use mbedtls::alloc::List as MbedtlsList;
 use mbedtls::hash::Type::Sha256;
 use mbedtls::pk::Pk;
 use mbedtls::rng::Rdrand;
@@ -13,15 +15,15 @@ use mbedtls::ssl::{Config, Context};
 use mbedtls::x509::certificate::{Builder, Certificate};
 use mbedtls::x509::Time;
 use mbedtls::Result as TlsResult;
-use std::io::Write;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const RSA_KEY_SIZE: u32 = 3072;
 const RSA_KEY_EXP: u32 = 0x10001;
 const DAYS_TO_SES: u64 = 86400;
-const CERT_VAL_SECS: u64 = (365 * DAYS_TO_SES);
+const CERT_VAL_SECS: u64 = 365 * DAYS_TO_SES;
 
 trait ToTime {
     fn to_time(&self) -> Time;
@@ -47,8 +49,8 @@ fn get_validity() -> (Time, Time) {
         .unwrap()
         .as_secs();
     let end = start + CERT_VAL_SECS;
-    let not_before = Utc.timestamp(start as _, 0);
-    let not_after = Utc.timestamp(end as _, 0);
+    let not_before = Utc.timestamp_opt(start as _, 0).unwrap();
+    let not_after = Utc.timestamp_opt(end as _, 0).unwrap();
     (not_before.to_time(), not_after.to_time())
 }
 
@@ -59,7 +61,7 @@ fn get_validity() -> (Time, Time) {
 /// also verify attestation information.
 /// along with traditional certificate verification.
 /// But this example doesn't show that.
-fn get_key_and_cert() -> (Pk, Certificate) {
+fn get_key_and_cert() -> (Pk, MbedtlsBox<Certificate>) {
     let mut rng = Rdrand;
     let mut key = Pk::generate_rsa(&mut rng, RSA_KEY_SIZE, RSA_KEY_EXP).unwrap();
     let mut key_i = Pk::generate_rsa(&mut rng, RSA_KEY_SIZE, RSA_KEY_EXP).unwrap();
@@ -89,18 +91,13 @@ fn get_key_and_cert() -> (Pk, Certificate) {
 /// a self signed certificate.
 /// After a session is established, echo the incoming stream to the client.
 /// till EOF is detected.
-fn serve(mut conn: TcpStream, key: &mut Pk, cert: &mut Certificate) -> TlsResult<()> {
-    let mut rng = Rdrand;
-
-    let mut config = Config::new(Endpoint::Server, Transport::Stream, Preset::Default);
-    config.set_rng(Some(&mut rng));
-    config.push_cert(&mut **cert, key)?;
-    let mut ctx = Context::new(&config)?;
+fn serve(conn: TcpStream, config: Arc<Config>) -> TlsResult<()> {
+    let mut ctx = Context::new(config);
 
     let mut buf = String::new();
-    let session = ctx.establish(&mut conn, None)?;
+    ctx.establish(conn, None)?;
     println!("Connection established!");
-    let mut reader = BufReader::new(session);
+    let mut reader = BufReader::new(ctx);
     while let Ok(1..=std::usize::MAX) = reader.read_line(&mut buf) {
         let session = reader.get_mut();
         session.write_all(&buf.as_bytes()).unwrap();
@@ -109,14 +106,29 @@ fn serve(mut conn: TcpStream, key: &mut Pk, cert: &mut Certificate) -> TlsResult
     Ok(())
 }
 
+fn create_server_config(
+    cert: MbedtlsBox<Certificate>,
+    key: Pk,
+) -> Result<Arc<Config>, mbedtls::Error> {
+    let rng = Rdrand;
+    let mut config = Config::new(Endpoint::Server, Transport::Stream, Preset::Default);
+    config.set_rng(Arc::new(rng));
+    let mut certs = MbedtlsList::new();
+    certs.push(cert);
+    config.push_cert(Arc::new(certs), Arc::new(key))?;
+    let config = Arc::new(config);
+    Ok(config)
+}
+
 /// The below main() starts a TLS echo server on `local host:7878`.
 fn main() {
-    let (mut key, mut cert) = get_key_and_cert();
+    let (key, cert) = get_key_and_cert();
+    let config = create_server_config(cert, key).unwrap();
     let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
 
     for stream in listener.incoming() {
         let stream = stream.unwrap();
-        let _ = serve(stream, &mut key, &mut cert).unwrap();
+        let _ = serve(stream, config.clone()).unwrap();
         println!("Connection closed!");
     }
 }

--- a/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/Cargo.toml
+++ b/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitro-attestation-verify"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Adrian Cruceru <adrian.cruceru@fortanix.com>"]
 edition = "2018"
 
@@ -10,16 +10,14 @@ serde_cbor = "0.11"
 # Required until PR36 is accepted
 # https://github.com/awslabs/aws-nitro-enclaves-cose/pull/36
 aws-nitro-enclaves-cose = { version = "0.5.0", git = "https://github.com/fortanix/aws-nitro-enclaves-cose.git", branch = "raoul/crypto_abstraction_pinned", default-features = false }
-mbedtls = { version = ">=0.8.0, <0.10.0", features = ["rdrand", "std", "time"], default-features = false, optional = true }
+mbedtls = { version = "0.12.1", features = ["rdrand", "std", "time", "x509"], default-features = false, optional = true }
 num-bigint = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
-pkix = "0.1"
+pkix = ">=0.1, <0.3.0"
 yasna = { version = "0.4", features = ["num-bigint"] }
 
 [dev-dependencies]
-chrono = "0.4.0"
-pkix = "0.1"
 lazy_static = "1.3.0"
 
 [features]

--- a/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/src/lib.rs
+++ b/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/src/lib.rs
@@ -327,7 +327,7 @@ mod tests {
         //   Not Before: Sep  9 10:19:20 2021 GMT
         //   Not After : Sep  9 13:19:20 2021 GMT
         static ref PROPER_TOKEN : Vec<u8> = include_bytes!("../data/request_proper.bin").to_vec();
-        static ref PROPER_VALIDITY: (DateTime<Utc>, DateTime<Utc>) = (Utc.ymd(2021, 9, 9).and_hms(10, 19, 19),  Utc.ymd(2021, 9, 9).and_hms(13, 19, 21));
+        static ref PROPER_VALIDITY: (DateTime<Utc>, DateTime<Utc>) = (Utc.with_ymd_and_hms(2021, 9, 9, 10, 19, 19).unwrap(),  Utc.with_ymd_and_hms(2021, 9, 9, 13, 19, 21).unwrap());
         static ref NOT_VALID_YET_ERR: NitroError = NitroError::CertificateVerifyFailure("Certificate verify failure: X509CertVerifyFailed, The certificate validity starts in the future\n".to_string());
         static ref EXPIRED_ERR: NitroError = NitroError::CertificateVerifyFailure("Certificate verify failure: X509CertVerifyFailed, The certificate validity has expired\n".to_string());
         static ref TAMPERED_SIGNATURE : Vec<u8> = include_bytes!("../data/tampered_signature.bin").to_vec();

--- a/fortanix-vme/aws-nitro-enclaves/tests/nsm-test/Cargo.toml
+++ b/fortanix-vme/aws-nitro-enclaves/tests/nsm-test/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 nsm = { path = "../../nsm" }
-pkix = { version = "0.1" }
+pkix = { version = ">=0.1, <0.3.0" }

--- a/fortanix-vme/vme-pkix/Cargo.toml
+++ b/fortanix-vme/vme-pkix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vme-pkix"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"
@@ -13,4 +13,4 @@ categories = ["cryptography"]
 
 [dependencies]
 lazy_static = "1"
-pkix = "0.1.1"
+pkix = ">=0.1, <0.3.0"

--- a/intel-sgx/dcap-ql/Cargo.toml
+++ b/intel-sgx/dcap-ql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-ql"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -45,7 +45,7 @@ byteorder = "1.1.0" # Unlicense/MIT
 failure = "0.1.1"   # MIT/Apache-2.0
 lazy_static = "1"   # MIT/Apache-2.0
 libc = { version = "0.2", optional = true }        # MIT/Apache-2.0
-mbedtls = { version = ">=0.8.0, <0.10.0", default-features = false, features = ["std"], optional = true }
+mbedtls = { version = "0.12.1", default-features = false, features = ["std"], optional = true }
 num = { version = "0.2", optional = true }
 num-derive = "0.2"  # MIT/Apache-2.0
 num-traits = "0.2"  # MIT/Apache-2.0
@@ -53,7 +53,7 @@ serde = { version = "1.0.104", features = ["derive"], optional = true } # MIT/Ap
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"], optional = true }
 
 [dev-dependencies]
-mbedtls = { version = ">=0.8.0, <0.10.0" }
+mbedtls = { version = "0.12.1", features = ["x509"] }
 report-test = { version = "0.3.1", path = "../report-test" }
 sgxs = { version = "0.7.0", path = "../sgxs" }
 serde = { version = "1.0.104", features = ["derive"] }

--- a/intel-sgx/ias/Cargo.toml
+++ b/intel-sgx/ias/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ias"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -20,8 +20,8 @@ serde_json = { version = "1", optional = true }
 serde = { version = "1.0.7", features = ["derive"] }
 url = "2.2"
 
-mbedtls = { version = ">=0.8.0, <0.10.0", features = ["std"], default-features = false, optional = true }
-pkix = "0.1"
+mbedtls = { version = "0.12.1", features = ["std"], default-features = false, optional = true }
+pkix = ">=0.1, <0.3.0"
 
 sgx-isa = { version = "0.4", path = "../sgx-isa" }
 sgx_pkix = { version = "0.2", path = "../sgx_pkix" }

--- a/intel-sgx/ias/Cargo.toml
+++ b/intel-sgx/ias/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ias"
-version = "0.1.3"
+version = "0.1.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/sgx-isa/Cargo.toml
+++ b/intel-sgx/sgx-isa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgx-isa"
-version = "0.4.2"
+version = "0.4.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/sgx-isa/Cargo.toml
+++ b/intel-sgx/sgx-isa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgx-isa"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -17,7 +17,7 @@ categories = ["hardware-support"]
 
 [dev-dependencies]
 # External dependencies
-mbedtls = { version = ">=0.8.0, <0.10.0", default-features = false, features = ["std"] }
+mbedtls = { version = "0.12.1", default-features = false, features = ["std"] }
 
 [dependencies]
 # External dependencies


### PR DESCRIPTION
This PR upgrades the dependency of following crates:
- em-app
- em-app/examples/get-certificate
- em-app/examples/harmonize
- nitro-attestation-verify
- nsm-test
- vme-pkix
- dcap-ql
- ias
- sgx-isa

This PR only bumps versions if needed, some of crates' version are not yet published.

The dependencies updated are: `mbedtls` and `pkix`.