### PR TITLE
Indicate that `em-app` is compatible with both `pkix` 0.1 and 0.2 versions

### DIFF
--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -15,7 +15,7 @@ em-client = { version = "3.0.0", default-features = false, features = ["client"]
 em-node-agent-client = "1.0.0"
 hyper = { version = "0.10", default-features = false }
 mbedtls = { version = "0.9", features = [ "rdrand", "std", "force_aesni_support", "mpi_force_c_code" ], default-features = false }
-pkix = "0.1.2"
+pkix = ">=0.1.2, <0.3.0"
 
 rustc-serialize = "0.3.24"
 sdkms = { version = "0.2.1", default-features = false }


### PR DESCRIPTION
The `em-app` is compatible with `pkix` v0.1.3 and v0.2.x. The `pkix` crate was bumped to v0.2 [only due](https://github.com/fortanix/pkix/commits/master/?after=bdda1b505e7b13cbb7c5e7a6c0ad696f71917ecd+34) to [a change](https://github.com/fortanix/pkix/commit/9a08c7fdd4aa85e6cdfa17f7cac5c707d5c81969) in the `DateTime` type. This type isn't used by `em-app`.

Fixed #562 