### PR TITLE
Upgrade dependence of mbedtls and prepare for releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "em-app"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "b64-ct",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "ias"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "aesm-client",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,9 +1713,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mbedtls"
-version = "0.9.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f2c88dbe2fcc6fddc0dc33eb2694471fef46f48b2081996335adb2f8085c53"
+checksum = "8730cf71e8d79ba70b3b7986af7af7629c0c4ee58b59e4a2e30d855cc31552e8"
 dependencies = [
  "bitflags",
  "byteorder 1.3.4",

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -14,7 +14,7 @@ b64-ct = "0.1.0"
 em-client = { version = "3.0.0", default-features = false, features = ["client"] }
 em-node-agent-client = "1.0.0"
 hyper = { version = "0.10", default-features = false }
-mbedtls = { version = "0.9", features = [ "rdrand", "std", "force_aesni_support", "mpi_force_c_code" ], default-features = false }
+mbedtls = { version = "0.12", default-features = false, features = ["rdrand", "std", "ssl"] }
 pkix = ">=0.1.2, <0.3.0"
 
 rustc-serialize = "0.3.24"

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "em-app"
-version = "0.5.0"
+version = "0.4.0"
 authors = ["fortanix.com"]
 license = "MPL-2.0"
 edition = "2018"

--- a/em-app/examples/get-certificate/Cargo.toml
+++ b/em-app/examples/get-certificate/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 authors = ["fortanix.com"]
 edition = "2018"
 license = "MPL-2.0"
+publish = false
 
 [dependencies]
 em-app = { path = "../../" }

--- a/em-app/examples/get-certificate/Cargo.toml
+++ b/em-app/examples/get-certificate/Cargo.toml
@@ -7,5 +7,5 @@ license = "MPL-2.0"
 
 [dependencies]
 em-app = { path = "../../" }
-mbedtls = { version = "0.9", features = [ "rdrand", "std", "force_aesni_support", "mpi_force_c_code" ], default-features = false }
+mbedtls = { version = "0.12", default-features = false, features = ["std"] }
 serde_json = "1.0"

--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4"
-mbedtls = {version="0.5", default-features = false, features = ["sgx"]}
+mbedtls = { version = "0.12", default-features = false, features = ["std"] }

--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -3,6 +3,7 @@ name = "tls"
 version = "0.1.0"
 authors = ["fortanix.com"]
 edition = "2018"
+publish = false
 
 [dependencies]
 chrono = "0.4"

--- a/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/Cargo.toml
+++ b/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/Cargo.toml
@@ -3,6 +3,7 @@ name = "nitro-attestation-verify"
 version = "0.1.1"
 authors = ["Adrian Cruceru <adrian.cruceru@fortanix.com>"]
 edition = "2018"
+publish = false
 
 [dependencies]
 chrono = "0.4"

--- a/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/Cargo.toml
+++ b/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/Cargo.toml
@@ -10,7 +10,7 @@ serde_cbor = "0.11"
 # Required until PR36 is accepted
 # https://github.com/awslabs/aws-nitro-enclaves-cose/pull/36
 aws-nitro-enclaves-cose = { version = "0.5.0", git = "https://github.com/fortanix/aws-nitro-enclaves-cose.git", branch = "raoul/crypto_abstraction_pinned", default-features = false }
-mbedtls = { version = ">=0.8.0, <0.10.0", features = ["rdrand", "std", "time"], default-features = false, optional = true }
+mbedtls = { version = "0.12", features = ["rdrand", "std", "time", "ssl"], default-features = false, optional = true }
 num-bigint = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/intel-sgx/dcap-ql/Cargo.toml
+++ b/intel-sgx/dcap-ql/Cargo.toml
@@ -45,7 +45,7 @@ byteorder = "1.1.0" # Unlicense/MIT
 anyhow = "1.0"   # MIT/Apache-2.0
 lazy_static = "1"   # MIT/Apache-2.0
 libc = { version = "0.2", optional = true }        # MIT/Apache-2.0
-mbedtls = { version = ">=0.8.0, <0.10.0", default-features = false, features = ["std"], optional = true }
+mbedtls = { version = "0.12", default-features = false, features = ["std", "x509"], optional = true }
 num = { version = "0.2", optional = true }
 num-derive = "0.2"  # MIT/Apache-2.0
 num-traits = "0.2"  # MIT/Apache-2.0
@@ -53,7 +53,7 @@ serde = { version = "1.0.104", features = ["derive"], optional = true } # MIT/Ap
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"], optional = true }
 
 [dev-dependencies]
-mbedtls = { version = ">=0.8.0, <0.10.0" }
+mbedtls = { version = "0.12" }
 report-test = { version = "0.4.0", path = "../report-test" }
 sgxs = { version = "0.8.0", path = "../sgxs" }
 serde = { version = "1.0.104", features = ["derive"] }

--- a/intel-sgx/ias/Cargo.toml
+++ b/intel-sgx/ias/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ias"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/ias/Cargo.toml
+++ b/intel-sgx/ias/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = { version = "1", optional = true }
 serde = { version = "1.0.7", features = ["derive"] }
 url = "2.2"
 
-mbedtls = { version = ">=0.8.0, <0.10.0", features = ["std"], default-features = false, optional = true }
+mbedtls = { version = "0.12", features = ["std"], default-features = false, optional = true }
 pkix = "0.1"
 
 sgx-isa = { version = "0.4", path = "../sgx-isa" }

--- a/intel-sgx/sgx-isa/Cargo.toml
+++ b/intel-sgx/sgx-isa/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["hardware-support"]
 
 [dev-dependencies]
 # External dependencies
-mbedtls = { version = ">=0.8.0, <0.10.0", default-features = false, features = ["std"] }
+mbedtls = { version = "0.12", default-features = false, features = ["std"] }
 
 [dependencies]
 # External dependencies


### PR DESCRIPTION
Update dependence mbedtls version to `0.12.X`.
Update or correct the new version number of crates to be published.

