### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  groups:
+    crates-io:
+      patterns:
+        - "*"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
This PR added GitHub dependabot config.

It will allow GitHub Dependabot to start scanning `Cargo.toml` and `Cargo.lock` file and open pull requests automatically to keep your dependencies up-to-date when new versions are available.