### PR TITLE
Update pkix version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.vscode
+.idea

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding">
-    <file url="PROJECT" charset="UTF-8" />
-  </component>
-</project>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.17",
  "libc",
  "winapi",
 ]
@@ -257,6 +257,15 @@ name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.4",
 ]
@@ -556,6 +565,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "crypto-hash"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +699,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1304,6 +1332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1798,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mem-alloc-test"
+version = "1.0.0"
+dependencies = [
+ "num_cpus",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "mem-correctness-test"
+version = "0.1.0"
+dependencies = [
+ "crossbeam",
+ "num_cpus",
+ "rand 0.8.5",
+ "sha2 0.10.1",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,11 +2189,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -2542,7 +2594,7 @@ version = "2.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6653d384a260fedff0a466e894e05c5b8d75e261a14e9f93e81e43ef86cad23"
 dependencies = [
- "log 0.3.9",
+ "log 0.4.14",
  "which 4.0.2",
 ]
 
@@ -3257,6 +3309,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "ias"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aesm-client",
  "base64 0.13.0",
@@ -3852,7 +3852,7 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "vme-pkix"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "lazy_static",
  "pkix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,20 @@ members = [
     "ipc-queue",
     "rs-libc",
     "em-app",
-    "em-app/examples/get-certificate/",
+    "em-app/examples/get-certificate",
+    "examples/mem-correctness-test",
+    "examples/mem-alloc-test",
 ]
-exclude = ["examples/*"]
+exclude = [
+    "examples/usercall-extension-bind/runner",
+    "examples/usercall-extension-bind/app",
+    "examples/usercall-extension/runner",
+    "examples/usercall-extension/app",
+    "examples/unit_tests",
+    "examples/mpsc-crypto-mining",
+    "examples/tls",
+    "examples/backtrace_panic",
+]
 resolver = "2"
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,19 @@
 [workspace]
 members = [
+    "em-app",
+    "em-app/examples/get-certificate",
+    "examples/mem-alloc-test",
+    "examples/mem-correctness-test",
     "fortanix-vme/aws-nitro-enclaves/eif-tools",
-    "fortanix-vme/aws-nitro-enclaves/nsm",
     "fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify",
+    "fortanix-vme/aws-nitro-enclaves/nsm",
     "fortanix-vme/aws-nitro-enclaves/tests/nsm-test",
     "fortanix-vme/fortanix-vme-abi",
     "fortanix-vme/fortanix-vme-runner",
     "fortanix-vme/tests/hello_world",
-    "fortanix-vme/tests/outgoing_connection",
     "fortanix-vme/tests/incoming_connection",
     "fortanix-vme/tests/iron",
+    "fortanix-vme/tests/outgoing_connection",
     "fortanix-vme/vme-pkix",
     "intel-sgx/aesm-client",
     "intel-sgx/async-usercalls",
@@ -22,27 +26,23 @@ members = [
     "intel-sgx/fortanix-sgx-tools",
     "intel-sgx/ias",
     "intel-sgx/report-test",
-    "intel-sgx/sgxs",
-    "intel-sgx/sgx-isa",
     "intel-sgx/sgx_pkix",
+    "intel-sgx/sgx-isa",
     "intel-sgx/sgxs-loaders",
     "intel-sgx/sgxs-tools",
+    "intel-sgx/sgxs",
     "ipc-queue",
     "rs-libc",
-    "em-app",
-    "em-app/examples/get-certificate",
-    "examples/mem-correctness-test",
-    "examples/mem-alloc-test",
 ]
 exclude = [
-    "examples/usercall-extension-bind/runner",
-    "examples/usercall-extension-bind/app",
-    "examples/usercall-extension/runner",
-    "examples/usercall-extension/app",
-    "examples/unit_tests",
+    "examples/backtrace_panic",
     "examples/mpsc-crypto-mining",
     "examples/tls",
-    "examples/backtrace_panic",
+    "examples/unit_tests",
+    "examples/usercall-extension-bind/app",
+    "examples/usercall-extension-bind/runner",
+    "examples/usercall-extension/app",
+    "examples/usercall-extension/runner",
     "intel-sgx/sgxs-loaders/tests/driver-crawler",
 ]
 resolver = "2"
@@ -50,6 +50,6 @@ resolver = "2"
 [patch.crates-io]
 libc = { git = "https://github.com/fortanix/libc.git", branch = "fortanixvme" }
 nix = { git = "https://github.com/fortanix/nix.git", branch = "raoul/fortanixvme_r0.20.2" }
+rustc-serialize = { git = "https://github.com/fortanix/rustc-serialize.git", branch = "portability" }
 serde = { git = "https://github.com/fortanix/serde.git", branch = "master" }
 vsock = { git = "https://github.com/fortanix/vsock-rs.git", branch = "fortanixvme" }
-rustc-serialize = { git = "https://github.com/fortanix/rustc-serialize.git", branch = "portability" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ exclude = [
     "examples/mpsc-crypto-mining",
     "examples/tls",
     "examples/backtrace_panic",
+    "intel-sgx/sgxs-loaders/tests/driver-crawler",
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,12 @@ members = [
     "em-app",
     "em-app/examples/get-certificate/",
 ]
-exclude = ["examples"]
+exclude = ["examples/*"]
 resolver = "2"
 
 [patch.crates-io]
-libc  = { git = "https://github.com/fortanix/libc.git", branch = "fortanixvme" }
-nix   = { git = "https://github.com/fortanix/nix.git", branch = "raoul/fortanixvme_r0.20.2" }
+libc = { git = "https://github.com/fortanix/libc.git", branch = "fortanixvme" }
+nix = { git = "https://github.com/fortanix/nix.git", branch = "raoul/fortanixvme_r0.20.2" }
 serde = { git = "https://github.com/fortanix/serde.git", branch = "master" }
 vsock = { git = "https://github.com/fortanix/vsock-rs.git", branch = "fortanixvme" }
 rustc-serialize = { git = "https://github.com/fortanix/rustc-serialize.git", branch = "portability" }

--- a/examples/backtrace_panic/Cargo.toml
+++ b/examples/backtrace_panic/Cargo.toml
@@ -3,5 +3,6 @@ name = "backtrace_panic"
 version = "0.1.0"
 authors = ["Fortanix, Inc."]
 edition = "2018"
+publish = false
 
 [dependencies]

--- a/examples/mem-alloc-test/Cargo.toml
+++ b/examples/mem-alloc-test/Cargo.toml
@@ -3,6 +3,7 @@ name = "mem-alloc-test"
 version = "1.0.0"
 edition = "2021"
 authors = ["Fortanix, Inc."]
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/mem-correctness-test/Cargo.toml
+++ b/examples/mem-correctness-test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mem-correctness-test"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/mpsc-crypto-mining/Cargo.toml
+++ b/examples/mpsc-crypto-mining/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mpsc-crypto-mining"
 version = "0.1.0"
 authors = ["belfz <marcinbar1@gmail.com>"]
+publish = false
 
 [dependencies]
 easy-hash = "0.1.0"

--- a/examples/unit_tests/Cargo.toml
+++ b/examples/unit_tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-sgx-ut"
 version = "0.1.0"
 authors = ["Fortanix, Inc."]
+publish = false
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/usercall-extension-bind/app/Cargo.toml
+++ b/examples/usercall-extension-bind/app/Cargo.toml
@@ -3,5 +3,6 @@ name = "app"
 version = "0.1.0"
 authors = ["Vardhan Thigle <vardhan.thigle@fortanix.com>"]
 edition = "2018"
+publish = false
 
 [dependencies]

--- a/examples/usercall-extension-bind/runner/Cargo.toml
+++ b/examples/usercall-extension-bind/runner/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
+publish = false
 
 [dependencies]
 aesm-client = { version = "0.5.0", features = ["sgxs"], path="../../../intel-sgx/aesm-client"}

--- a/examples/usercall-extension/app/Cargo.toml
+++ b/examples/usercall-extension/app/Cargo.toml
@@ -3,5 +3,6 @@ name = "app"
 version = "0.1.0"
 authors = ["Vardhan Thigle <vardhan.thigle@fortanix.com>"]
 edition = "2018"
+publish = false
 
 [dependencies]

--- a/examples/usercall-extension/runner/Cargo.toml
+++ b/examples/usercall-extension/runner/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
+publish = false
 
 [dependencies]
 aesm-client = { version = "0.5.0", features = ["sgxs"], path="../../../intel-sgx/aesm-client"}

--- a/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/Cargo.toml
+++ b/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/Cargo.toml
@@ -15,12 +15,12 @@ mbedtls = { version = "0.12", features = ["rdrand", "std", "time", "ssl"], defau
 num-bigint = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
-pkix = "0.1"
+pkix = ">=0.1.2, <0.3.0"
 yasna = { version = "0.4", features = ["num-bigint"] }
 
 [dev-dependencies]
 chrono = "0.4.0"
-pkix = "0.1"
+pkix = ">=0.1.2, <0.3.0"
 lazy_static = "1.3.0"
 
 [features]

--- a/fortanix-vme/aws-nitro-enclaves/tests/nsm-test/Cargo.toml
+++ b/fortanix-vme/aws-nitro-enclaves/tests/nsm-test/Cargo.toml
@@ -2,9 +2,9 @@
 name = "nsm-test"
 version = "0.1.0"
 edition = "2021"
-
+publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 nsm = { path = "../../nsm" }
-pkix = { version = "0.1" }
+pkix = { version = ">=0.1.2, <0.3.0" }

--- a/fortanix-vme/vme-pkix/Cargo.toml
+++ b/fortanix-vme/vme-pkix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vme-pkix"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"
@@ -13,4 +13,4 @@ categories = ["cryptography"]
 
 [dependencies]
 lazy_static = "1"
-pkix = "0.1.1"
+pkix = ">=0.1.0, <0.3.0"

--- a/intel-sgx/ias/Cargo.toml
+++ b/intel-sgx/ias/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ias"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -21,7 +21,7 @@ serde = { version = "1.0.7", features = ["derive"] }
 url = "2.2"
 
 mbedtls = { version = "0.12", features = ["std"], default-features = false, optional = true }
-pkix = "0.1"
+pkix = ">=0.1.0, <0.3.0"
 
 sgx-isa = { version = "0.4", path = "../sgx-isa" }
 sgx_pkix = { version = "0.2", path = "../sgx_pkix" }


### PR DESCRIPTION
- Update required pkix version for some crates.
- Bump ias version.
- Bump vme-pkix version.
- Add missing `publish = false`.
- Correct workspace exclude syntax.