### PR TITLE
chore: stop grouping dependabot version update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
-  groups:
-    crates-io:
-      patterns:
-        - "*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Stop grouping Dependabot version updates and Dependabot security updates.