### PR TITLE
Adding some documentation for the parameters and test description memory allocator tests

### DIFF
--- a/examples/mem-correctness-test/src/main.rs
+++ b/examples/mem-correctness-test/src/main.rs
@@ -13,7 +13,10 @@
         }
     }
 }
- * So this basically runs for a long time and should never crash
+ * So this basically runs for a long time and should never crash.
+ * The todos before running this test is there in the description of
+ * https://fortanix.atlassian.net/browse/RTE-39 (under the heading
+ * "Instructions on how to run the test:" )
  */
 
 use core::arch::asm;


### PR DESCRIPTION
Adding some documentation for the parameters and test description for ```rust-sgx/examples/mem-alloc-test``` and ```rust-sgx/examples/mem-correctness-test```