### PR TITLE
ci: upgrade clang version to 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CFLAGS_x86_64_fortanix_unknown_sgx: "-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
-  CC_x86_64_fortanix_unknown_sgx: clang-11
+  CC_x86_64_fortanix_unknown_sgx: clang-12
 
 jobs:
   test:
@@ -39,10 +39,10 @@ jobs:
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/intel-sgx-deb.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/intel-sgx-deb.list > /dev/null
         # Add llbm package repository, key is download from https://apt.llvm.org/llvm-snapshot.gpg.key
         cat llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/llvm-snapshot.gpg > /dev/null
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" | sudo tee /etc/apt/sources.list.d/llvm-snapshot.list > /dev/null
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main" | sudo tee /etc/apt/sources.list.d/llvm-snapshot.list > /dev/null
         # Install dependencies for build & test
         sudo apt-get update -y
-        sudo apt-get install -y faketime protobuf-compiler libsgx-dcap-ql-dev clang-11 musl-tools gcc-multilib
+        sudo apt-get install -y faketime protobuf-compiler libsgx-dcap-ql-dev clang-12 musl-tools gcc-multilib
 
     - name: Setup Rust toolchain
       run: |


### PR DESCRIPTION
We need to upgrade clang version to sync up in other projects like DSM.