### PR TITLE
Update FORTANIX-SGX-ELF.md

### DIFF
--- a/doc/FORTANIX-SGX-ELF.md
+++ b/doc/FORTANIX-SGX-ELF.md
@@ -33,7 +33,7 @@ This section describes the requirements on the SGX thread control structure
 
 - `NSSA` should be set to 1.
 - `OGSBASGX` should point to a thread-specific memory region (e.g. TLS) of at 
-  least 112 bytes.
+  least 120 bytes.
 
 ### TLS
 


### PR DESCRIPTION
Update the minimum storage requirements of the TCS as snmalloc replaces dlmalloc as the default sgx allocator