### PR TITLE
Allow specifying number of worker threads used to run an enclave

### DIFF
--- a/intel-sgx/aesm-client/src/lib.rs
+++ b/intel-sgx/aesm-client/src/lib.rs
@@ -17,6 +17,9 @@
  * In order to avoid CI failures, allow the below lint. */
 #![allow(renamed_and_removed_lints)]
 #![deny(warnings)]
+// To fix this error, which appears in generated code:
+// "lint `box_pointers` has been removed: it does not detect other kinds of allocations, and existed only for historical reasons."
+#![allow(renamed_and_removed_lints)]
 
 extern crate byteorder;
 pub extern crate anyhow;

--- a/intel-sgx/enclave-runner/src/command.rs
+++ b/intel-sgx/enclave-runner/src/command.rs
@@ -24,6 +24,7 @@ pub struct Command {
     forward_panics: bool,
     force_time_usercalls: bool,
     cmd_args: Vec<Vec<u8>>,
+    num_worker_threads: usize,
 }
 
 impl MappingInfo for Command {
@@ -47,6 +48,7 @@ impl Command {
         forward_panics: bool,
         force_time_usercalls: bool,
         cmd_args: Vec<Vec<u8>>,
+        num_worker_threads: usize,
     ) -> Command {
         let main = tcss.remove(0);
         Command {
@@ -58,6 +60,7 @@ impl Command {
             forward_panics,
             force_time_usercalls,
             cmd_args,
+            num_worker_threads,
         }
     }
 
@@ -66,6 +69,6 @@ impl Command {
     }
 
     pub fn run(self) -> Result<(), Error> {
-        EnclaveState::main_entry(self.main, self.threads, self.usercall_ext, self.forward_panics, self.force_time_usercalls, self.cmd_args)
+        EnclaveState::main_entry(self.main, self.threads, self.usercall_ext, self.forward_panics, self.force_time_usercalls, self.cmd_args, self.num_worker_threads)
     }
 }

--- a/intel-sgx/enclave-runner/src/usercalls/mod.rs
+++ b/intel-sgx/enclave-runner/src/usercalls/mod.rs
@@ -1106,7 +1106,9 @@ impl EnclaveState {
         forward_panics: bool,
         force_time_usercalls: bool,
         cmd_args: Vec<Vec<u8>>,
+        num_of_worker_threads: usize,
     ) -> StdResult<(), anyhow::Error> {
+        assert!(num_of_worker_threads > 0, "worker_threads cannot be zero");
         let mut event_queues =
             FnvHashMap::with_capacity_and_hasher(threads.len() + 1, Default::default());
         let main = Self::event_queue_add_tcs(&mut event_queues, main);
@@ -1128,8 +1130,6 @@ impl EnclaveState {
             },
             entry: CoEntry::Initial(main.tcs, argv as _, argc as _, 0, 0, 0),
         };
-
-        let num_of_worker_threads = num_cpus::get();
 
         let kind = EnclaveKind::Command(Command {
             panic_reason: Mutex::new(PanicReason {

--- a/ipc-queue/src/fifo.rs
+++ b/ipc-queue/src/fifo.rs
@@ -356,10 +356,12 @@ impl Offsets {
         }
     }
 
+    #[allow(unused)]
     pub(crate) fn read_high_bit(&self) -> bool {
         self.read & self.len == self.len
     }
 
+    #[allow(unused)]
     pub(crate) fn write_high_bit(&self) -> bool {
         self.write & self.len == self.len
     }

--- a/ipc-queue/src/lib.rs
+++ b/ipc-queue/src/lib.rs
@@ -146,11 +146,13 @@ pub trait AsyncSynchronizer: Clone {
     fn notify(&self, event: QueueEvent);
 }
 
+#[allow(dead_code)]
 pub struct AsyncSender<T: 'static, S> {
     inner: Fifo<T>,
     synchronizer: S,
 }
 
+#[allow(dead_code)]
 pub struct AsyncReceiver<T: 'static, S> {
     inner: Fifo<T>,
     synchronizer: S,
@@ -159,6 +161,7 @@ pub struct AsyncReceiver<T: 'static, S> {
 
 /// `DescriptorGuard<T>` can produce a `FifoDescriptor<T>` that is guaranteed
 /// to remain valid as long as the DescriptorGuard is not dropped.
+#[allow(dead_code)]
 pub struct DescriptorGuard<T> {
     descriptor: FifoDescriptor<T>,
     #[cfg(not(target_env = "sgx"))]

--- a/ipc-queue/src/position.rs
+++ b/ipc-queue/src/position.rs
@@ -19,18 +19,22 @@ use std::sync::atomic::Ordering;
 /// arranged as a ring buffer, we can assign a position to each value written/
 /// read to/from the queue. This is useful in case we want to know whether or
 /// not a particular value written to the queue has been read.
+#[allow(dead_code)]
 pub struct PositionMonitor<T: 'static> {
     read_epoch: Arc<AtomicU64>,
     fifo: Fifo<T>,
 }
 
 /// A read position in a queue.
+#[allow(dead_code)]
 pub struct ReadPosition(u64);
 
 /// A write position in a queue.
+#[allow(dead_code)]
 pub struct WritePosition(u64);
 
 impl<T> PositionMonitor<T> {
+    #[allow(dead_code)]
     pub (crate) fn new(read_epoch: Arc<AtomicU64>,fifo: Fifo<T>) -> PositionMonitor<T> {
         PositionMonitor {
             read_epoch,


### PR DESCRIPTION
This change allows users of this library to specify the number of worker threads. This lets users limit the number of cores used by an enclave. 

This is a backwards-compatible change.