### PR TITLE
Adds cache to dcap-artifact-retrieval-tool

### DIFF
--- a/intel-sgx/pcs/src/pckcrl.rs
+++ b/intel-sgx/pcs/src/pckcrl.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::io::{self};
 use crate::Error;
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct PckCrl {
     crl: String,
     ca_chain: Vec<String>,

--- a/intel-sgx/pcs/src/pckcrt.rs
+++ b/intel-sgx/pcs/src/pckcrt.rs
@@ -89,7 +89,7 @@ struct IntelSgxTcbComponentsV3 {
 
 /// TCB component as specified in TcbInfo (version 3) of the PCS version 4 API
 /// https://api.trustedservices.intel.com/documents/PCS_V3-V4_migration_guide.pdf
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 struct IntelSgxTcbComponentV4 {
     svn: u8,
     #[serde(default)]
@@ -108,7 +108,7 @@ impl From<u8> for IntelSgxTcbComponentV4 {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 struct IntelSgxTcbComponentsV4 {
     pub sgxtcbcomponents: [IntelSgxTcbComponentV4; 16],
     pub pcesvn: u16,
@@ -121,7 +121,7 @@ enum IntelSgxTcbComponents {
     V4(IntelSgxTcbComponentsV4),
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 #[serde(from = "IntelSgxTcbComponents")]
 pub struct TcbComponents(IntelSgxTcbComponentsV4);
 
@@ -246,14 +246,14 @@ impl Serialize for PckCertValue {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct PckCertBodyItem {
     tcb: TcbComponents,
     tcbm: String,
     cert: PckCertValue,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct PckCerts {
     pck_data: Vec<PckCertBodyItem>,
     ca_chain: Vec<String>,

--- a/intel-sgx/pcs/src/qe_identity.rs
+++ b/intel-sgx/pcs/src/qe_identity.rs
@@ -226,7 +226,7 @@ where
     serializer.serialize_str(&miscselect)
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct QeIdentitySigned {
     raw_enclave_identity: String,
     signature: Vec<u8>,

--- a/intel-sgx/pcs/src/tcb_info.rs
+++ b/intel-sgx/pcs/src/tcb_info.rs
@@ -134,7 +134,7 @@ impl<V: VerificationType> TcbData<V> {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct TcbInfo {
     raw_tcb_info: String,
     signature: Vec<u8>,


### PR DESCRIPTION
Adds caching functionality for `dcap-artifact-retrieval-tool` that caches API responses in memory. In detail the cache is implemented for `CachedService` type which is similar to `BackoffService` in a sense that it wraps a caching functionality around a call to the underlying service:
```
self.service.call_service::<F>(fetcher, input)
```
The cache itself is a `LruCache` with a capacity specified by user.