### PR TITLE
Use updated em-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,9 +816,8 @@ dependencies = [
 
 [[package]]
 name = "em-client"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0bd923300728ad79f8c36f689f96d928d224524a2120a204fa2bb7801991e7c"
+version = "4.0.0"
+source = "git+https://github.com/fortanix/em-client-rust#60c5764e78a24caa80591d79a260fcd83359319b"
 dependencies = [
  "base64 0.10.1",
  "bitflags 1.2.1",
@@ -827,6 +826,7 @@ dependencies = [
  "hyper 0.10.16",
  "lazy_static",
  "log 0.3.9",
+ "mbedtls",
  "mime 0.2.6",
  "serde",
  "serde_derive 1.0.132",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,4 @@ nix = { git = "https://github.com/fortanix/nix.git", branch = "raoul/fortanixvme
 rustc-serialize = { git = "https://github.com/fortanix/rustc-serialize.git", branch = "portability" }
 serde = { git = "https://github.com/fortanix/serde.git", branch = "master" }
 vsock = { git = "https://github.com/fortanix/vsock-rs.git", branch = "fortanixvme" }
+em-client = { git = "https://github.com/fortanix/em-client-rust" }

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "sgx" ]
 
 [dependencies]
 b64-ct = "0.1.0"
-em-client = { version = "3.0.0", default-features = false, features = ["client"] }
+em-client = { git = "https://github.com/fortanix/em-client-rust", default-features = false, features = ["client"] }
 em-node-agent-client = "1.0.0"
 hyper = { version = "0.10", default-features = false }
 mbedtls = { version = "0.12", default-features = false, features = ["rdrand", "std", "ssl"] }

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "sgx" ]
 
 [dependencies]
 b64-ct = "0.1.0"
-em-client = { git = "https://github.com/fortanix/em-client-rust", default-features = false, features = ["client"] }
+em-client = { version = "4.0.0", default-features = false, features = ["client"] }
 em-node-agent-client = "1.0.0"
 hyper = { version = "0.10", default-features = false }
 mbedtls = { version = "0.12", default-features = false, features = ["rdrand", "std", "ssl"] }


### PR DESCRIPTION
Updated `em-app` to use latest version of `em-client` which check application config hash before returning it as a result. Corresponding PR is: https://github.com/fortanix/em-client-rust/pull/3.