### PR TITLE
Update to mbedtls v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ version = "0.1.0"
 source = "git+https://github.com/fortanix/aws-nitro-enclaves-cose.git?branch=v0.1.0-patched#fe2558390c13cbd0e82f9c1610e74c4a4ddfd7e1"
 dependencies = [
  "openssl",
- "serde",
+ "serde 1.0.215",
  "serde_bytes",
  "serde_cbor",
  "serde_repr",
@@ -135,7 +135,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce1d9954a5cb2841ad8ab206a050cd07ed34200ea6aafb7fa73a33771aaf48c"
 dependencies = [
- "serde",
+ "serde 1.0.215",
  "serde_bytes",
  "serde_cbor",
  "serde_repr",
@@ -151,7 +151,7 @@ dependencies = [
  "libc",
  "log 0.4.21",
  "nix 0.20.2",
- "serde",
+ "serde 1.0.215",
  "serde_bytes",
  "serde_cbor",
 ]
@@ -246,7 +246,7 @@ dependencies = [
  "lazycell",
  "log 0.4.21",
  "peeking_take_while",
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "regex",
  "rustc-hash",
@@ -375,7 +375,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad639525b1c67b6a298f378417b060fbc04618bea559482a8484381cce27d965"
 dependencies = [
- "serde",
+ "serde 1.0.215",
  "toml 0.8.19",
 ]
 
@@ -416,7 +416,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "serde",
+ "serde 1.0.215",
  "time 0.1.44",
  "wasm-bindgen",
  "winapi",
@@ -642,7 +642,7 @@ checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "strsim 0.10.0",
  "syn 1.0.81",
@@ -667,15 +667,15 @@ dependencies = [
  "clap",
  "lazy_static",
  "lru-cache",
- "mbedtls",
+ "mbedtls 0.13.0",
  "num_enum",
  "pcs",
  "percent-encoding 2.1.0",
- "pkix 0.2.1",
+ "pkix",
  "quick-error",
  "reqwest 0.12.4",
  "rustc-serialize",
- "serde",
+ "serde 1.0.215",
  "serde_cbor",
  "serde_json",
  "yasna 0.3.2",
@@ -704,12 +704,12 @@ dependencies = [
  "dcap-ql-sys",
  "lazy_static",
  "libc",
- "mbedtls",
+ "mbedtls 0.13.0",
  "num",
  "num-derive 0.2.5",
  "num-traits",
  "report-test",
- "serde",
+ "serde 1.0.215",
  "serde_json",
  "sgx-isa 0.4.1",
  "sgxs",
@@ -793,7 +793,7 @@ dependencies = [
  "log 0.4.21",
  "nitro-cli",
  "once_cell",
- "serde",
+ "serde 1.0.215",
  "sha2 0.9.8",
  "tempdir",
  "thiserror",
@@ -807,7 +807,7 @@ dependencies = [
  "byteorder 1.3.4",
  "num-derive 0.3.3",
  "num-traits",
- "serde",
+ "serde 1.0.215",
  "serde_json",
  "sha2 0.9.8",
 ]
@@ -835,7 +835,7 @@ dependencies = [
  "hex 0.3.2",
  "log 0.4.21",
  "openssl",
- "serde",
+ "serde 1.0.215",
  "serde_cbor",
  "sha2 0.9.8",
 ]
@@ -858,13 +858,13 @@ dependencies = [
  "em-client",
  "em-node-agent-client",
  "hyper 0.10.16",
- "mbedtls",
- "pkix 0.1.2",
+ "mbedtls 0.13.0",
+ "pkix",
  "rustc-serialize",
  "sdkms",
- "serde",
+ "serde 1.0.215",
  "serde_bytes",
- "serde_derive 1.0.132",
+ "serde_derive 1.0.215",
  "serde_json",
  "sgx-isa 0.4.1",
  "sgx_pkix 0.2.2",
@@ -887,10 +887,10 @@ dependencies = [
  "hyper 0.10.16",
  "lazy_static",
  "log 0.3.9",
- "mbedtls",
+ "mbedtls 0.12.3",
  "mime 0.2.6",
- "serde",
- "serde_derive 1.0.132",
+ "serde 1.0.215",
+ "serde_derive 1.0.215",
  "serde_ignored",
  "serde_json",
  "url 1.7.2",
@@ -910,8 +910,8 @@ dependencies = [
  "lazy_static",
  "log 0.3.9",
  "mime 0.2.6",
- "serde",
- "serde_derive 1.0.132",
+ "serde 1.0.215",
+ "serde_derive 1.0.215",
  "serde_ignored",
  "serde_json",
  "url 1.7.2",
@@ -950,7 +950,7 @@ dependencies = [
  "eif_utils",
  "futures 0.3.17",
  "log 0.4.21",
- "serde",
+ "serde 1.0.215",
  "serde_json",
  "serde_yaml",
  "sha2 0.9.8",
@@ -1030,7 +1030,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "syn 1.0.81",
  "synstructure",
@@ -1138,8 +1138,8 @@ dependencies = [
  "libc",
  "nix 0.13.1",
  "num_cpus",
- "serde",
- "serde_derive 1.0.132",
+ "serde 1.0.215",
+ "serde_derive 1.0.215",
  "sgx-isa 0.4.1",
  "sgxs",
  "sgxs-loaders",
@@ -1155,7 +1155,7 @@ dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
- "serde",
+ "serde 1.0.204",
  "vsock 0.2.4",
 ]
 
@@ -1168,7 +1168,7 @@ dependencies = [
  "fortanix-vme-abi",
  "log 0.4.21",
  "nix 0.22.2",
- "serde",
+ "serde 1.0.215",
  "serde_cbor",
  "vsock 0.2.4",
 ]
@@ -1241,7 +1241,7 @@ checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg 1.0.1",
  "proc-macro-hack",
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "syn 1.0.81",
 ]
@@ -1317,7 +1317,7 @@ name = "get-certificate"
 version = "0.2.0"
 dependencies = [
  "em-app",
- "mbedtls",
+ "mbedtls 0.13.0",
  "serde_json",
 ]
 
@@ -1713,12 +1713,12 @@ dependencies = [
  "env_logger 0.9.0",
  "lazy_static",
  "log 0.4.21",
- "mbedtls",
+ "mbedtls 0.13.0",
  "percent-encoding 2.1.0",
- "pkix 0.1.2",
+ "pkix",
  "report-test",
  "reqwest 0.11.10",
- "serde",
+ "serde 1.0.215",
  "serde-bytes-repr",
  "serde_bytes",
  "serde_json",
@@ -1996,8 +1996,27 @@ dependencies = [
  "mbedtls-platform-support",
  "mbedtls-sys-auto",
  "rs-libc 0.2.3",
- "serde",
- "serde_derive 1.0.132",
+ "serde 1.0.215",
+ "serde_derive 1.0.215",
+ "yasna 0.2.2",
+]
+
+[[package]]
+name = "mbedtls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c1a79c64122e22312679a350d1c8e6b21605b3836ee5d8fe3722f1d0187a6f7"
+dependencies = [
+ "bitflags 1.2.1",
+ "byteorder 1.3.4",
+ "cc",
+ "cfg-if 1.0.0",
+ "mbedtls-platform-support",
+ "mbedtls-sys-auto",
+ "rs-libc 0.2.3",
+ "rustc_version",
+ "serde 1.0.215",
+ "serde_derive 1.0.215",
  "yasna 0.2.2",
 ]
 
@@ -2165,10 +2184,10 @@ dependencies = [
  "aws-nitro-enclaves-cose 0.5.1",
  "chrono",
  "lazy_static",
- "mbedtls",
+ "mbedtls 0.13.0",
  "num-bigint 0.4.3",
- "pkix 0.1.2",
- "serde",
+ "pkix",
+ "serde 1.0.215",
  "serde_bytes",
  "serde_cbor",
  "yasna 0.4.0",
@@ -2197,7 +2216,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "page_size",
- "serde",
+ "serde 1.0.215",
  "serde_cbor",
  "serde_json",
  "sha2 0.9.8",
@@ -2296,7 +2315,7 @@ version = "0.1.0"
 source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api#9ddb589875baf345d085a980aa96cf3a4e480ea8"
 dependencies = [
  "log 0.4.21",
- "serde",
+ "serde 1.0.215",
  "serde_bytes",
  "serde_cbor",
 ]
@@ -2306,7 +2325,7 @@ name = "nsm-test"
 version = "0.1.0"
 dependencies = [
  "nsm",
- "pkix 0.1.2",
+ "pkix",
 ]
 
 [[package]]
@@ -2378,7 +2397,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "syn 1.0.81",
 ]
@@ -2451,9 +2470,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2513,9 +2532,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2617,13 +2636,13 @@ dependencies = [
  "dcap-ql",
  "failure",
  "hex 0.4.3",
- "mbedtls",
+ "mbedtls 0.13.0",
  "num",
  "percent-encoding 2.1.0",
- "pkix 0.2.1",
+ "pkix",
  "quick-error",
  "rustc-serialize",
- "serde",
+ "serde 1.0.215",
  "serde_json",
  "sgx-isa 0.4.1",
  "sgx_pkix 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2721,7 +2740,7 @@ version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "syn 1.0.81",
 ]
@@ -2732,7 +2751,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "syn 1.0.81",
 ]
@@ -2754,21 +2773,6 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
-
-[[package]]
-name = "pkix"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643768328ce074b546bc11af4581bc3e8f1242706be53946eb7b30f686194fba"
-dependencies = [
- "b64-ct",
- "bit-vec 0.6.2",
- "chrono",
- "lazy_static",
- "num-bigint 0.2.6",
- "num-integer",
- "yasna 0.3.2",
-]
 
 [[package]]
 name = "pkix"
@@ -2838,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2875,7 +2879,7 @@ version = "2.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6653d384a260fedff0a466e894e05c5b8d75e261a14e9f93e81e43ef86cad23"
 dependencies = [
- "log 0.3.9",
+ "log 0.4.21",
  "which 4.0.2",
 ]
 
@@ -2912,7 +2916,7 @@ version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
 ]
 
 [[package]]
@@ -3199,7 +3203,7 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "serde",
+ "serde 1.0.215",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -3239,7 +3243,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "pin-project-lite",
  "rustls-pemfile",
- "serde",
+ "serde 1.0.215",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
@@ -3301,6 +3305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1956f5517128a2b6f23ab2dadf1a976f4f5b27962e7724c2bf3d45e539ec098c"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,7 +3335,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "syn 1.0.81",
 ]
@@ -3366,7 +3379,7 @@ dependencies = [
  "hyper 0.10.16",
  "log 0.4.21",
  "rustc-serialize",
- "serde",
+ "serde 1.0.215",
  "serde_json",
  "url 1.7.2",
  "uuid 0.8.2",
@@ -3396,6 +3409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
 name = "serde"
 version = "1.0.204"
 source = "git+https://github.com/fortanix/serde.git?branch=master#1755f934942d36f9caf6cb73177fda1d25ca20f4"
@@ -3407,6 +3426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.215"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+dependencies = [
+ "serde_derive 1.0.215",
+]
+
+[[package]]
 name = "serde-bytes-repr"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,7 +3442,7 @@ checksum = "9eb83481bce328081ced4404f986de002bf2e08865bec386734595ebf3b2c425"
 dependencies = [
  "base64 0.13.0",
  "hex 0.4.3",
- "serde",
+ "serde 1.0.215",
 ]
 
 [[package]]
@@ -3423,7 +3451,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde",
+ "serde 1.0.215",
 ]
 
 [[package]]
@@ -3433,18 +3461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.132"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 1.0.81",
+ "serde 1.0.215",
 ]
 
 [[package]]
@@ -3452,9 +3469,20 @@ name = "serde_derive"
 version = "1.0.204"
 source = "git+https://github.com/fortanix/serde.git?branch=master#1755f934942d36f9caf6cb73177fda1d25ca20f4"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.215"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+dependencies = [
+ "proc-macro2 1.0.89",
+ "quote 1.0.35",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3463,18 +3491,19 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190e9765dcedb56be63b6e0993a006c7e3b071a016a304736e4a315dc01fb142"
 dependencies = [
- "serde",
+ "serde 1.0.215",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa 1.0.1",
+ "memchr",
  "ryu",
- "serde",
+ "serde 1.0.215",
 ]
 
 [[package]]
@@ -3483,7 +3512,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "syn 1.0.81",
 ]
@@ -3494,7 +3523,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
- "serde",
+ "serde 1.0.215",
 ]
 
 [[package]]
@@ -3506,7 +3535,7 @@ dependencies = [
  "form_urlencoded",
  "itoa 1.0.1",
  "ryu",
- "serde",
+ "serde 1.0.215",
 ]
 
 [[package]]
@@ -3516,7 +3545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edeeaecd5445109b937a3a335dc52780ca7779c4b4b7374cc6340dedfe44cfca"
 dependencies = [
  "rustversion",
- "serde",
+ "serde 1.0.215",
  "serde_with_macros",
 ]
 
@@ -3527,7 +3556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48b35457e9d855d3dc05ef32a73e0df1e2c0fd72c38796a4ee909160c8eeec2"
 dependencies = [
  "darling",
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "syn 1.0.81",
 ]
@@ -3540,7 +3569,7 @@ checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 dependencies = [
  "dtoa",
  "linked-hash-map",
- "serde",
+ "serde 1.0.215",
  "yaml-rust",
 ]
 
@@ -3549,8 +3578,8 @@ name = "sgx-isa"
 version = "0.4.1"
 dependencies = [
  "bitflags 1.2.1",
- "mbedtls",
- "serde",
+ "mbedtls 0.13.0",
+ "serde 1.0.215",
 ]
 
 [[package]]
@@ -3568,7 +3597,7 @@ version = "0.2.2"
 dependencies = [
  "byteorder 1.3.4",
  "lazy_static",
- "pkix 0.1.2",
+ "pkix",
  "quick-error",
  "sgx-isa 0.4.1",
 ]
@@ -3581,7 +3610,7 @@ checksum = "dbd99155dbd1b4c45ad6a742cb0415387b68f22ab7e8f4cabba4e49d606e5ded"
 dependencies = [
  "byteorder 1.3.4",
  "lazy_static",
- "pkix 0.1.2",
+ "pkix",
  "quick-error",
  "sgx-isa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3644,8 +3673,8 @@ dependencies = [
  "regex",
  "report-test",
  "reqwest 0.11.10",
- "serde",
- "serde_derive 1.0.132",
+ "serde 1.0.215",
+ "serde_derive 1.0.215",
  "serde_yaml",
  "sgx-isa 0.4.1",
  "sgxs",
@@ -3712,7 +3741,7 @@ dependencies = [
  "mime 0.3.16",
  "openssl",
  "pin-project 1.0.8",
- "serde",
+ "serde 1.0.215",
  "serde_json",
  "tar",
  "tokio",
@@ -3817,18 +3846,18 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "unicode-xid 0.2.1",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "unicode-ident",
 ]
@@ -3845,7 +3874,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "syn 1.0.81",
  "unicode-xid 0.2.1",
@@ -3940,9 +3969,9 @@ version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3978,7 +4007,7 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde 1.0.215",
  "time-core",
  "time-macros",
 ]
@@ -4041,9 +4070,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4088,7 +4117,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 dependencies = [
- "serde",
+ "serde 1.0.215",
 ]
 
 [[package]]
@@ -4097,7 +4126,7 @@ version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
- "serde",
+ "serde 1.0.215",
  "serde_spanned",
  "toml_datetime",
  "toml_edit",
@@ -4109,7 +4138,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
- "serde",
+ "serde 1.0.215",
 ]
 
 [[package]]
@@ -4119,7 +4148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
  "indexmap 2.2.6",
- "serde",
+ "serde 1.0.215",
  "serde_spanned",
  "toml_datetime",
  "winnow",
@@ -4169,9 +4198,9 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4316,7 +4345,7 @@ checksum = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 dependencies = [
  "cfg-if 0.1.10",
  "rand 0.4.6",
- "serde",
+ "serde 1.0.215",
 ]
 
 [[package]]
@@ -4326,7 +4355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
+ "serde 1.0.215",
 ]
 
 [[package]]
@@ -4358,7 +4387,7 @@ name = "vme-pkix"
 version = "0.1.1"
 dependencies = [
  "lazy_static",
- "pkix 0.1.2",
+ "pkix",
 ]
 
 [[package]]
@@ -4444,7 +4473,7 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.21",
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "syn 1.0.81",
  "wasm-bindgen-shared",
@@ -4478,7 +4507,7 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2 1.0.89",
  "quote 1.0.35",
  "syn 1.0.81",
  "wasm-bindgen-backend",

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -14,14 +14,14 @@ b64-ct = "0.1.0"
 em-client = { version = "4.0.0", default-features = false, features = ["client"] }
 em-node-agent-client = "1.0.0"
 hyper = { version = "0.10", default-features = false }
-mbedtls = { version = "0.12", default-features = false, features = ["rdrand", "std", "ssl"] }
+mbedtls = { version = "0.13.0", default-features = false, features = ["rdrand", "std", "ssl"] }
 pkix = ">=0.1.2, <0.3.0"
 
 rustc-serialize = "0.3.24"
 sdkms = { version = "0.3", default-features = false }
-serde = "1.0.123"
+serde = "1.0.214"
 serde_bytes = "0.11"
-serde_derive = "1.0.123"
+serde_derive = "1.0.214"
 serde_json = "1.0"
 url = "1"
 uuid = { version = "0.6.3", features = ["v4", "serde"] }

--- a/em-app/examples/get-certificate/Cargo.toml
+++ b/em-app/examples/get-certificate/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 
 [dependencies]
 em-app = { path = "../../" }
-mbedtls = { version = "0.12", default-features = false, features = ["std"] }
+mbedtls = { version = "0.13.0", default-features = false, features = ["std"] }
 serde_json = "1.0"

--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 chrono = "0.4"
-mbedtls = { version = "0.12", default-features = false, features = ["std"] }
+mbedtls = { version = "0.13.0", default-features = false, features = ["std"] }

--- a/fortanix-vme/aws-nitro-enclaves/eif-tools/Cargo.toml
+++ b/fortanix-vme/aws-nitro-enclaves/eif-tools/Cargo.toml
@@ -22,7 +22,7 @@ env_logger = "0.9"
 log = "0.4"
 nitro-cli = { git = "https://github.com/fortanix/aws-nitro-enclaves-cli.git", branch = "main" }
 once_cell = "1.9.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.214", features = ["derive"] }
 sha2 = "0.9.5"
 tempdir = "0.3"
 thiserror = "1.0"

--- a/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/Cargo.toml
+++ b/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 chrono = "0.4"
 serde_cbor = "0.11"
 aws-nitro-enclaves-cose = { version = "0.5.0", default-features = false }
-mbedtls = { version = "0.12", features = ["rdrand", "std", "time", "ssl"], default-features = false, optional = true }
+mbedtls = { version = "0.13.0", features = ["rdrand", "std", "time", "ssl"], default-features = false, optional = true }
 num-bigint = "0.4"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.214", features = ["derive"] }
 serde_bytes = "0.11"
 pkix = ">=0.1.2, <0.3.0"
 yasna = { version = "0.4", features = ["num-bigint"] }

--- a/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/src/mbedtls.rs
+++ b/fortanix-vme/aws-nitro-enclaves/nitro-attestation-verify/src/mbedtls.rs
@@ -6,6 +6,7 @@
 use aws_nitro_enclaves_cose::crypto::{Hash, MessageDigest, SignatureAlgorithm, SigningPublicKey};
 use aws_nitro_enclaves_cose::error::CoseError;
 use mbedtls::alloc::Box as MbedtlsBox;
+use mbedtls::error::{codes, Error as ErrMbed};
 use mbedtls::hash::{self, Md};
 use mbedtls::pk::EcGroupId;
 use mbedtls::x509::Certificate;
@@ -97,7 +98,7 @@ impl SigningPublicKey for WrappedCert {
         // We'll throw error if signature verify does not work
         match pk.verify(*md, &digest, &sig) {
             Ok(_) => Ok(true),
-            Err(mbedtls::Error::EcpVerifyFailed) => Ok(false),
+            Err(ErrMbed::HighLevel(codes::EcpVerifyFailed)) => Ok(false),
             Err(e) => Err(CoseError::SignatureError(Box::new(e))),
         }
     }

--- a/intel-sgx/dcap-artifact-retrieval/Cargo.toml
+++ b/intel-sgx/dcap-artifact-retrieval/Cargo.toml
@@ -9,7 +9,7 @@ backoff = "0.4.0"
 clap = { version = "2.23.3", optional = true }
 lazy_static = "1"
 lru-cache = "0.1.2"
-mbedtls = { version = "0.12.3", features = [
+mbedtls = { version = "0.13.0", features = [
     "x509",
     "ssl",
     "std",
@@ -22,7 +22,7 @@ quick-error = "1.1.0"
 rustc-serialize = "0.3"
 reqwest = { version = "0.12", features = ["blocking", "native-tls"], optional = true }
 serde_cbor = "0.11"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0"
 
 [features]
@@ -33,6 +33,6 @@ yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 pcs = { path = "../pcs", features = ["verify"] }
 
 [build-dependencies]
-mbedtls = { version = "0.12.3", features = ["ssl", "x509"] }
+mbedtls = { version = "0.13.0", features = ["ssl", "x509"] }
 pkix = "0.2.0"
 serde_cbor = "0.11"

--- a/intel-sgx/dcap-ql/Cargo.toml
+++ b/intel-sgx/dcap-ql/Cargo.toml
@@ -45,16 +45,16 @@ byteorder = "1.1.0" # Unlicense/MIT
 anyhow = "1.0"   # MIT/Apache-2.0
 lazy_static = "1"   # MIT/Apache-2.0
 libc = { version = "0.2", optional = true }        # MIT/Apache-2.0
-mbedtls = { version = "0.12", default-features = false, features = ["std", "x509"], optional = true }
+mbedtls = { version = "0.13.0", default-features = false, features = ["std", "x509"], optional = true }
 num = { version = "0.2", optional = true }
 num-derive = "0.2"  # MIT/Apache-2.0
 num-traits = "0.2"  # MIT/Apache-2.0
-serde = { version = "1.0.104", features = ["derive"], optional = true } # MIT/Apache-2.0
+serde = { version = "1.0.214", features = ["derive"], optional = true } # MIT/Apache-2.0
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"], optional = true }
 
 [dev-dependencies]
-mbedtls = { version = "0.12" }
+mbedtls = { version = "0.13.0" }
 report-test = { version = "0.4.0", path = "../report-test" }
 sgxs = { version = "0.8.0", path = "../sgxs" }
-serde = { version = "1.0.104", features = ["derive"] }
-serde_json = { version = "1.0" }
+serde = { version = "1.0.214", features = ["derive"] }
+serde_json = { version = "1.0.133" }

--- a/intel-sgx/ias/Cargo.toml
+++ b/intel-sgx/ias/Cargo.toml
@@ -17,10 +17,10 @@ percent-encoding = "2.1"
 serde_bytes = "0.11"
 serde-bytes-repr = { version = "0.1", optional = true }
 serde_json = { version = "1", optional = true }
-serde = { version = "1.0.7", features = ["derive"] }
+serde = { version = "1.0.214", features = ["derive"] }
 url = "2.2"
 
-mbedtls = { version = "0.12", features = ["std"], default-features = false, optional = true }
+mbedtls = { version = "0.13.0", features = ["std"], default-features = false, optional = true }
 pkix = ">=0.1.0, <0.3.0"
 
 sgx-isa = { version = "0.4", path = "../sgx-isa" }

--- a/intel-sgx/pcs/Cargo.toml
+++ b/intel-sgx/pcs/Cargo.toml
@@ -13,7 +13,7 @@ sgx-isa = { path = "../sgx-isa", default-features = true }
 pkix = "0.2.0"
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 rustc-serialize = "0.3"
-serde = { version = "1.0.7", features = ["derive"] }
+serde = { version = "1.0.214", features = ["derive"] }
 sgx_pkix = "0.2"
 serde_json = { version = "1.0", features = ["raw_value"] }
 percent-encoding = "2.1.0"
@@ -23,7 +23,7 @@ failure = "0.1.1"
 anyhow = { version = "1", optional = true }
 quick-error = "1.2.3"
 num = "0.2"
-mbedtls = { version = "0.12.3", features = ["std", "time"], default-features = false, optional = true }
+mbedtls = { version = "0.13.0", features = ["std", "time"], default-features = false, optional = true }
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/intel-sgx/sgx-isa/Cargo.toml
+++ b/intel-sgx/sgx-isa/Cargo.toml
@@ -17,12 +17,12 @@ categories = ["hardware-support"]
 
 [dev-dependencies]
 # External dependencies
-mbedtls = { version = "0.12", default-features = false, features = ["std"] }
+mbedtls = { version = "0.13.0", default-features = false, features = ["std"] }
 
 [dependencies]
 # External dependencies
 bitflags = "1" # MIT/Apache-2.0
-serde = { version = "1.0.104", features = ["derive"], optional = true } # MIT/Apache-2.0
+serde = { version = "1.0.214", features = ["derive"], optional = true } # MIT/Apache-2.0
 
 [features]
 large_array_derive = []


### PR DESCRIPTION
rust-mbedtls [PR #372](https://github.com/fortanix/rust-mbedtls/pull/372) adds combined errors for mbedtls. this enhancement is available from mbedtls v0.13.0