### PR TITLE
Support letting enclaves do time keeping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,6 +1022,7 @@ dependencies = [
  "fnv",
  "fortanix-sgx-abi",
  "futures 0.3.17",
+ "insecure-time",
  "ipc-queue",
  "lazy_static",
  "libc",
@@ -1216,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "fortanix-sgx-abi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",

--- a/intel-sgx/async-usercalls/Cargo.toml
+++ b/intel-sgx/async-usercalls/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["asynchronous"]
 [dependencies]
 # Project dependencies
 ipc-queue = { version = "0.3", path = "../../ipc-queue" }
-fortanix-sgx-abi = { version = "0.5.0", path = "../fortanix-sgx-abi" }
+fortanix-sgx-abi = { version = "0.6.0", path = "../fortanix-sgx-abi" }
 
 # External dependencies
 lazy_static = "1.4.0"     # MIT/Apache-2.0

--- a/intel-sgx/async-usercalls/src/test_support.rs
+++ b/intel-sgx/async-usercalls/src/test_support.rs
@@ -41,7 +41,7 @@ impl Drop for AutoPollingProvider {
     fn drop(&mut self) {
         self.shutdown.store(true, Ordering::Relaxed);
         // send a usercall to ensure thread wakes up
-        self.provider.insecure_time(|_| {});
+        self.provider.insecure_time(|_, _| {});
         self.join_handle.take().unwrap().join().unwrap();
     }
 }

--- a/intel-sgx/enclave-runner/Cargo.toml
+++ b/intel-sgx/enclave-runner/Cargo.toml
@@ -21,8 +21,9 @@ exclude = ["fake-vdso/.gitignore", "fake-vdso/Makefile", "fake-vdso/main.S"]
 [dependencies]
 # Project dependencies
 sgxs = { version = "0.8.0", path = "../sgxs" }
-fortanix-sgx-abi = { version = "0.5.0", path = "../fortanix-sgx-abi" }
+fortanix-sgx-abi = { version = "0.6.0", path = "../fortanix-sgx-abi" }
 sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
+insecure-time = { version = "0.1", path = "../insecure-time", features = ["estimate_crystal_clock_freq"] }
 ipc-queue = { version = "0.3.0", path = "../../ipc-queue" }
 
 # External dependencies

--- a/intel-sgx/enclave-runner/src/command.rs
+++ b/intel-sgx/enclave-runner/src/command.rs
@@ -22,6 +22,7 @@ pub struct Command {
     size: usize,
     usercall_ext: Option<Box<dyn UsercallExtension>>,
     forward_panics: bool,
+    force_time_usercalls: bool,
     cmd_args: Vec<Vec<u8>>,
 }
 
@@ -44,6 +45,7 @@ impl Command {
         size: usize,
         usercall_ext: Option<Box<dyn UsercallExtension>>,
         forward_panics: bool,
+        force_time_usercalls: bool,
         cmd_args: Vec<Vec<u8>>,
     ) -> Command {
         let main = tcss.remove(0);
@@ -54,6 +56,7 @@ impl Command {
             size,
             usercall_ext,
             forward_panics,
+            force_time_usercalls,
             cmd_args,
         }
     }
@@ -63,6 +66,6 @@ impl Command {
     }
 
     pub fn run(self) -> Result<(), Error> {
-        EnclaveState::main_entry(self.main, self.threads, self.usercall_ext, self.forward_panics, self.cmd_args)
+        EnclaveState::main_entry(self.main, self.threads, self.usercall_ext, self.forward_panics, self.force_time_usercalls, self.cmd_args)
     }
 }

--- a/intel-sgx/enclave-runner/src/library.rs
+++ b/intel-sgx/enclave-runner/src/library.rs
@@ -48,9 +48,10 @@ impl Library {
         size: usize,
         usercall_ext: Option<Box<dyn UsercallExtension>>,
         forward_panics: bool,
+        force_time_usercalls: bool,
     ) -> Library {
         Library {
-            enclave: EnclaveState::library(tcss, usercall_ext, forward_panics),
+            enclave: EnclaveState::library(tcss, usercall_ext, forward_panics, force_time_usercalls),
             address,
             size,
         }

--- a/intel-sgx/enclave-runner/src/usercalls/interface.rs
+++ b/intel-sgx/enclave-runner/src/usercalls/interface.rs
@@ -222,7 +222,7 @@ impl<'future, 'ioinput: 'future, 'tcs: 'ioinput> Usercalls<'future> for Handler<
 
     fn insecure_time(
         self,
-    ) -> std::pin::Pin<Box<dyn Future<Output = (Self, UsercallResult<u64>)> + 'future>> {
+    ) -> std::pin::Pin<Box<dyn Future<Output = (Self, UsercallResult<(u64, *const InsecureTimeInfo)>)> + 'future>> {
         async move {
             let ret = Ok(self.0.insecure_time());
             return (self, ret);

--- a/intel-sgx/fortanix-sgx-abi/Cargo.toml
+++ b/intel-sgx/fortanix-sgx-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortanix-sgx-abi"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/fortanix-sgx-abi/src/lib.rs
+++ b/intel-sgx/fortanix-sgx-abi/src/lib.rs
@@ -75,6 +75,7 @@
 //! synchronously or asynchronously.
 #![allow(unused)]
 #![no_std]
+#![cfg_attr(feature = "rustc-dep-of-std", allow(internal_features))]
 #![cfg_attr(feature = "rustc-dep-of-std", feature(staged_api))]
 #![cfg_attr(feature = "rustc-dep-of-std", unstable(feature = "sgx_platform", issue = "56975"))]
 #![doc(html_logo_url = "https://edp.fortanix.com/img/docs/edp-logo.svg",
@@ -566,13 +567,21 @@ impl Usercalls {
     pub fn send(event_set: u64, tcs: Option<Tcs>) -> Result { unimplemented!() }
 }
 
+#[repr(C)]
+#[cfg_attr(feature = "rustc-dep-of-std", unstable(feature = "sgx_platform", issue = "56975"))]
+#[derive(Copy, Clone, Debug, Default)]
+pub struct InsecureTimeInfo {
+    pub version: u64,
+    pub frequency: u64,
+}
+
 /// # Miscellaneous
 impl Usercalls {
     /// This returns the number of nanoseconds since midnight UTC on January 1,
     /// 1970\. The enclave must not rely on the accuracy of this time for
     /// security purposes, such as checking credential expiry or preventing
     /// rollback.
-    pub fn insecure_time() -> u64 { unimplemented!() }
+    pub fn insecure_time() -> (u64, *const InsecureTimeInfo) { unimplemented!() }
 }
 
 /// # Memory

--- a/ipc-queue/Cargo.toml
+++ b/ipc-queue/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["sgx", "fifo", "queue", "ipc"]
 categories = ["asynchronous"]
 
 [dependencies]
-fortanix-sgx-abi = { version = "0.5.0", path = "../intel-sgx/fortanix-sgx-abi" }
+fortanix-sgx-abi = { version = "0.6.0", path = "../intel-sgx/fortanix-sgx-abi" }
 
 [dev-dependencies]
 static_assertions = "1.1.0"


### PR DESCRIPTION
SGXv2 platforms support calling the rdtscp instruction inside an enclave. This PR piggy backs on #659 that implemented logic to keep track of time. This PR starts using this logic in various tools and crates (e.g., async-usercalls, enclave-runner, ...).
Note that the enclave-runner _does not_ change the returned value of `insecure_time` usercalls at this point; it will always return a null pointer as the second value in the returned tuple. These changes can thus be used on all existing enclaves, no new Rust compiler is required. Another PR will be filed to change the default behavior of enclave runner so enclaves by default take advantage of their improved hardware capabilities.