### PR TITLE
Add missing version for pcs and dcap-artifact-retrieval dependencies

### DIFF
--- a/intel-sgx/dcap-artifact-retrieval/Cargo.toml
+++ b/intel-sgx/dcap-artifact-retrieval/Cargo.toml
@@ -15,7 +15,7 @@ mbedtls = { version = "0.12.3", features = [
     "std",
 ], default-features = false }
 num_enum = { version = "0.7", features = ["complex-expressions"] }
-pcs = { path = "../pcs" }
+pcs = { version = "0.1.0", path = "../pcs" }
 percent-encoding = "2.1.0"
 pkix = "0.2.0"
 quick-error = "1.1.0"
@@ -30,7 +30,7 @@ default = ["clap", "reqwest"]
 
 [dev-dependencies]
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
-pcs = { path = "../pcs", features = ["verify"] }
+pcs = { version = "0.1.0", path = "../pcs", features = ["verify"] }
 
 [build-dependencies]
 mbedtls = { version = "0.12.3", features = ["ssl", "x509"] }

--- a/intel-sgx/pcs/Cargo.toml
+++ b/intel-sgx/pcs/Cargo.toml
@@ -8,8 +8,8 @@ description = "Datastructures related to the Intel Provisioning Certification Se
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dcap-ql = { path = "../dcap-ql", default-features = false }
-sgx-isa = { path = "../sgx-isa", default-features = true }
+dcap-ql = { version = "0.4.0", path = "../dcap-ql", default-features = false }
+sgx-isa = { version = "0.4.1", path = "../sgx-isa", default-features = true }
 pkix = "0.2.0"
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 rustc-serialize = "0.3"


### PR DESCRIPTION
This is needed before we can publish `pcs` and `dcap-artifact-retrieval` crates.