### PR TITLE
[DEVOPS-5452] Support choose native-tls or rustls-tls for dcap-artifact-retrieval

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" | sudo tee /etc/apt/sources.list.d/llvm-snapshot.list > /dev/null
         # Install dependencies for build & test
         sudo apt-get update -y
-        sudo apt-get install -y faketime protobuf-compiler libsgx-dcap-ql-dev clang-11 musl-tools gcc-multilib
+        sudo apt-get install -y faketime protobuf-compiler libsgx-dcap-ql-dev clang-11 musl-tools gcc-multilib ca-certificates
 
     - name: Setup Rust toolchain
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.2.8",
  "instant",
  "rand 0.8.5",
 ]
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-artifact-retrieval"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "backoff",
  "clap 2.34.0",
@@ -1431,8 +1431,7 @@ dependencies = [
 [[package]]
 name = "getrandom"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+source = "git+https://github.com/fortanix/getrandom.git?branch=fortanixvme#cf4c6875ca03932aca760eb3a1fcfc4d4f9b47cd"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1441,12 +1440,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
-source = "git+https://github.com/fortanix/getrandom.git?branch=fortanixvme#cf4c6875ca03932aca760eb3a1fcfc4d4f9b47cd"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1716,6 +1716,23 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tower-layer",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -3135,7 +3152,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -3332,6 +3349,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
+ "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -3342,7 +3360,9 @@ dependencies = [
  "once_cell",
  "percent-encoding 2.1.0",
  "pin-project-lite",
+ "rustls",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3350,12 +3370,28 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg 0.52.0",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
+dependencies = [
+ "cc",
+ "getrandom 0.2.8",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3405,6 +3441,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1956f5517128a2b6f23ab2dadf1a976f4f5b27962e7724c2bf3d45e539ec098c"
 
 [[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log 0.4.21",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,6 +3469,17 @@ name = "rustls-pki-types"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -3887,6 +3948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3909,6 +3976,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -4179,6 +4252,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4396,6 +4480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4441,7 +4531,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.2.8",
  "serde",
 ]
 
@@ -4508,7 +4598,7 @@ name = "vsock"
 version = "0.2.4"
 source = "git+https://github.com/fortanix/vsock-rs.git?branch=fortanixvme#4628538042a0308d9a1f737da816666ab899dba4"
 dependencies = [
- "getrandom 0.2.3 (git+https://github.com/fortanix/getrandom.git?branch=fortanixvme)",
+ "getrandom 0.2.3",
  "libc",
  "nix 0.22.2",
 ]
@@ -4615,6 +4705,15 @@ checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/intel-sgx/dcap-artifact-retrieval/Cargo.toml
+++ b/intel-sgx/dcap-artifact-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-artifact-retrieval"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -33,13 +33,15 @@ percent-encoding = "2.1.0"
 pkix = "0.2.0"
 quick-error = "1.1.0"
 rustc-serialize = "0.3"
-reqwest = { version = "0.12", features = ["blocking", "native-tls"], optional = true }
+reqwest = { version = "0.12", features = ["blocking"], optional = true }
 serde_cbor = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [features]
-default = ["clap", "reqwest"]
+default = ["clap", "reqwest", "native-tls"]
+native-tls = ["reqwest?/native-tls"]
+rustls-tls = ["reqwest?/rustls-tls"]
 
 [dev-dependencies]
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }

--- a/intel-sgx/dcap-artifact-retrieval/src/lib.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/lib.rs
@@ -113,7 +113,8 @@ quick_error! {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[cfg(feature = "reqwest")]
+/// Create a reqwest client using native tls.
+#[cfg(all(feature = "reqwest", feature = "native-tls"))]
 pub fn reqwest_client() -> ReqwestClient {
     ReqwestClient::builder()
         .use_native_tls()
@@ -121,7 +122,16 @@ pub fn reqwest_client() -> ReqwestClient {
         .expect("Failed to build reqwest client")
 }
 
-#[cfg(feature = "reqwest")]
+/// Create a reqwest client using rustls tls.
+#[cfg(all(feature = "reqwest", feature = "rustls-tls"))]
+pub fn reqwest_client_rustls() -> ReqwestClient {
+    ReqwestClient::builder()
+        .use_rustls_tls()
+        .build()
+        .expect("Failed to build reqwest client")
+}
+
+#[cfg(all(feature = "reqwest", feature = "native-tls"))]
 #[doc(hidden)]
 pub fn reqwest_client_insecure_tls() -> ReqwestClient {
     ReqwestClient::builder()

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -500,6 +500,7 @@ mod tests {
     #[test]
     pub fn pcks() {
         for api_version in [PcsVersion::V3, PcsVersion::V4] {
+            println!("Using Intel API version: {:?}", api_version);
             let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT);
             if api_version == PcsVersion::V3 {
@@ -527,6 +528,7 @@ mod tests {
     #[test]
     pub fn pcks_cached() {
         for api_version in [PcsVersion::V3, PcsVersion::V4] {
+            println!("Using Intel API version: {:?}", api_version);
             let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT);
             if api_version == PcsVersion::V3 {
@@ -580,6 +582,7 @@ mod tests {
     #[test]
     pub fn pck() {
         for api_version in [PcsVersion::V3, PcsVersion::V4] {
+            println!("Using Intel API version: {:?}", api_version);
             let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT);
             if api_version == PcsVersion::V3 {
@@ -610,6 +613,7 @@ mod tests {
     #[test]
     pub fn pck_cached() {
         for api_version in [PcsVersion::V3, PcsVersion::V4] {
+            println!("Using Intel API version: {:?}", api_version);
             let root_ca = include_bytes!("../../tests/data/root_SGX_CA_der.cert");
             let root_cas = [&root_ca[..]];
             let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
@@ -696,6 +700,7 @@ mod tests {
     #[test]
     pub fn tcb_info() {
         for api_version in [PcsVersion::V3, PcsVersion::V4] {
+            println!("Using Intel API version: {:?}", api_version);
             let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT);
             if api_version == PcsVersion::V3 {
@@ -720,6 +725,7 @@ mod tests {
     #[test]
     pub fn tcb_info_cached() {
         for api_version in [PcsVersion::V3, PcsVersion::V4] {
+            println!("Using Intel API version: {:?}", api_version);
             let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT);
             if api_version == PcsVersion::V3 {

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -130,7 +130,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for PckCertsApi {
             INTEL_BASE_URL, api_version, encrypted_ppid, pce_id,
         );
         let headers = if let Some(api_key) = &input.api_key {
-            println!("Set api_key for PckCertsApi: {}", api_key);
+            println!("Set api_key for PckCertsApi: '{}'", api_key);
             vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
         } else {
             Vec::new()
@@ -211,7 +211,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for PckCertApi {
             INTEL_BASE_URL, api_version, encrypted_ppid, cpusvn, pce_isvsvn, pce_id,
         );
         let headers = if let Some(api_key) = input.api_key {
-            println!("Set api_key for PckCertApi: {}", api_key);
+            println!("Set api_key for PckCertApi: '{}'", api_key);
             vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
         } else {
             Vec::new()
@@ -496,7 +496,9 @@ mod tests {
     const TIME_RETRY_TIMEOUT: Duration = Duration::from_secs(180);
 
     fn pcs_api_key() -> String {
-        std::env::var("PCS_API_KEY").expect("PCS_API_KEY must be set")
+        let api_key = std::env::var("PCS_API_KEY").expect("PCS_API_KEY must be set");
+        assert!(!api_key.is_empty(), "Empty string in PCS_API_KEY");
+        api_key
     }
 
     #[test]
@@ -588,7 +590,7 @@ mod tests {
             let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT);
             if api_version == PcsVersion::V3 {
-                intel_builder.set_api_key(pcs_api_key());
+                intel_builder.set_api_key(dbg!(pcs_api_key()));
             }
             let client = intel_builder.build(reqwest_client());
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -130,6 +130,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for PckCertsApi {
             INTEL_BASE_URL, api_version, encrypted_ppid, pce_id,
         );
         let headers = if let Some(api_key) = &input.api_key {
+            println!("Set api_key for PckCertsApi");
             vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
         } else {
             Vec::new()
@@ -210,6 +211,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for PckCertApi {
             INTEL_BASE_URL, api_version, encrypted_ppid, cpusvn, pce_isvsvn, pce_id,
         );
         let headers = if let Some(api_key) = input.api_key {
+            println!("Set api_key for PckCertApi");
             vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
         } else {
             Vec::new()

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -130,7 +130,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for PckCertsApi {
             INTEL_BASE_URL, api_version, encrypted_ppid, pce_id,
         );
         let headers = if let Some(api_key) = &input.api_key {
-            println!("Set api_key for PckCertsApi");
+            println!("Set api_key for PckCertsApi: {}", api_key);
             vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
         } else {
             Vec::new()
@@ -211,7 +211,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for PckCertApi {
             INTEL_BASE_URL, api_version, encrypted_ppid, cpusvn, pce_isvsvn, pce_id,
         );
         let headers = if let Some(api_key) = input.api_key {
-            println!("Set api_key for PckCertApi");
+            println!("Set api_key for PckCertApi: {}", api_key);
             vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
         } else {
             Vec::new()

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
@@ -325,12 +325,12 @@ impl<T: for<'a> ProvisioningServiceApi<'a> + Sync + ?Sized> PcsService<T> {
         let (status_code, resp) = fetcher.send(req)?;
         match <T as ProvisioningServiceApi<'a>>::validate_response(self.pcs_service(), status_code) {
             Ok(_) => {},
-            err @ Err(_) => {
+            Err(err) => {
                 // print headers for debugging
                 if let Ok((response_body, response_headers)) = fetcher.parse_response(resp) {
                     println!("{:?}", response_headers);
                 }
-                return err;
+                return Err(err);
             },
         };
         let (response_body, response_headers) = fetcher.parse_response(resp)?;

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
@@ -117,7 +117,7 @@ pub enum StatusCode {
     Unassigned = 599,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum PcsVersion {
     V3 = 3,
     V4 = 4,


### PR DESCRIPTION
Original `native-tls` in `dcap-artifact-retrieval` wont work in distroless container where no CA is provided by system.
It will throw some error like this:
```
FetcherFailure("error sending request for url (...), caused by: client error (Connect), caused by: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:../ssl/statem/statem_clnt.c:1913: (unable to get local issuer certificate), caused by: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:../ssl/statem/statem_clnt.c:1913:")
```

The solution I proposed here is to adding support for choosing  `rustls` as TLS provider for `reqwest`, `rustls` will use [webpki-roots](https://crates.io/crates/webpki-roots) for default root CAs.
Also the original `native-tls`  becomes addictive feature but remain default.