### PR TITLE
Bump `enclave_runner` version to `0.6.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runner"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "crossbeam",

--- a/intel-sgx/enclave-runner/Cargo.toml
+++ b/intel-sgx/enclave-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runner"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
According to `cargo semver-check` this is a semver-compatible change.

Disclosure: the following dependencies of `enclave-runner` have been updated (since v0.6.0 release of `enclave-runner`):
- `fortanix-sgx-abi`: `0.5.0` -> `0.6.0`
- `ipc_queue`: `0.2.0` -> `0.3.0`
