### PR TITLE
[RTE-241] Always fetch early variant of DCAP artifacts

### DIFF
--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -355,7 +355,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for TcbInfoApi {
         let api_version = input.api_version as u8;
         let fmspc = input.fmspc.as_bytes().to_hex();
         let url = format!(
-            "{}/sgx/certification/v{}/tcb?fmspc={}",
+            "{}/sgx/certification/v{}/tcb?fmspc={}&update=early",
             INTEL_BASE_URL, api_version, fmspc,
         );
         Ok((url, Vec::new()))
@@ -430,7 +430,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for QeIdApi {
     fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let url = format!(
-            "{}/sgx/certification/v{}/qe/identity",
+            "{}/sgx/certification/v{}/qe/identity?update=early",
             INTEL_BASE_URL, api_version,
         );
         Ok((url, Vec::new()))

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
@@ -281,7 +281,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for TcbInfoApi {
         let api_version = input.api_version as u8;
         let fmspc = input.fmspc.as_bytes().to_hex();
         let url = format!(
-            "{}/sgx/certification/v{}/tcb?fmspc={}",
+            "{}/sgx/certification/v{}/tcb?fmspc={}&update=early",
             self.base_url, api_version, fmspc
         );
         Ok((url, Vec::new()))
@@ -359,7 +359,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for QeIdApi {
     fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let url = format!(
-            "{}/sgx/certification/v{}/qe/identity",
+            "{}/sgx/certification/v{}/qe/identity?update=early",
             self.base_url, api_version,
         );
         Ok((url, Vec::new()))


### PR DESCRIPTION
By default we want to fetch the "early" variant of DCAP artifacts. See the [pcs](https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-tcb-info-model-v3) API documentation.