### PR TITLE
Bump `enclave-runner` to `v0.7.0` (also bump dependent crates `sgx-tools`, `report-test`, `dcap-provider`, and `dcap-retrieve-pkcid`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-provider"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "byteorder 1.3.4",
  "dcap-ql",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-retrieve-pckid"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aesm-client",
  "anyhow",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runner"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "report-test"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "enclave-runner",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs-tools"
-version = "0.8.6"
+version = "0.9.0"
 dependencies = [
  "aesm-client",
  "anyhow",

--- a/intel-sgx/aesm-client/Cargo.toml
+++ b/intel-sgx/aesm-client/Cargo.toml
@@ -54,5 +54,5 @@ protoc-rust = "2.8.0" # MIT/Apache-2.0
 
 [dev-dependencies]
 sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
-"report-test" = { version = "0.4.0", path = "../report-test" }
+"report-test" = { version = "0.5.0", path = "../report-test" }
 "sgxs-loaders" = { version = "0.4.0", path = "../sgxs-loaders" }

--- a/intel-sgx/dcap-provider/Cargo.toml
+++ b/intel-sgx/dcap-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-provider"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"
@@ -35,7 +35,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # Project dependencies
 "dcap-ql" = { version = "0.4.0", path = "../dcap-ql", features = ["link"] }
-"report-test" = { version = "0.4.0", path = "../report-test" }
+"report-test" = { version = "0.5.0", path = "../report-test" }
 
 # External dependencies
 byteorder = "1.1.0"        # Unlicense/MIT

--- a/intel-sgx/dcap-ql/Cargo.toml
+++ b/intel-sgx/dcap-ql/Cargo.toml
@@ -54,7 +54,7 @@ yasna = { version = "0.3", features = ["num-bigint", "bit-vec"], optional = true
 
 [dev-dependencies]
 mbedtls = { version = "0.12" }
-report-test = { version = "0.4.0", path = "../report-test" }
+report-test = { version = "0.5.0", path = "../report-test" }
 sgxs = { version = "0.8.0", path = "../sgxs" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/intel-sgx/dcap-retrieve-pckid/Cargo.toml
+++ b/intel-sgx/dcap-retrieve-pckid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-retrieve-pckid"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -16,7 +16,7 @@ categories = ["command-line-utilities"]
 # Project dependencies
 "aesm-client" = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
 "dcap-ql" = { version = "0.4.0", path = "../dcap-ql", default-features = false }
-"report-test" = { version = "0.4.0", path = "../report-test" }
+"report-test" = { version = "0.5.0", path = "../report-test" }
 "sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
 "sgxs-loaders" = { version = "0.4.0", path = "../sgxs-loaders" }
 

--- a/intel-sgx/enclave-runner/Cargo.toml
+++ b/intel-sgx/enclave-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runner"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/fortanix-sgx-tools/Cargo.toml
+++ b/intel-sgx/fortanix-sgx-tools/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2018"
 # Project dependencies
 aesm-client = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
 sgxs-loaders = { version = "0.4.0", path = "../sgxs-loaders" }
-enclave-runner = { version = "0.6.0", path = "../enclave-runner" }
+enclave-runner = { version = "0.7.0", path = "../enclave-runner" }
 sgxs = { version = "0.8.0", path = "../sgxs" }
 sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
 

--- a/intel-sgx/ias/Cargo.toml
+++ b/intel-sgx/ias/Cargo.toml
@@ -41,7 +41,7 @@ env_logger = "0.9.0"
 [target.'cfg(not(target_env="sgx"))'.dev-dependencies]
 clap = "2.34.0"
 
-report-test = { version = "0.4", path = "../report-test" }
+report-test = { version = "0.5", path = "../report-test" }
 aesm-client = { version = "0.6", features = ["sgxs"], path = "../aesm-client" }
 sgxs = { version = "0.8", path = "../sgxs" }
 sgxs-loaders = { version = "0.4", path = "../sgxs-loaders" }

--- a/intel-sgx/report-test/Cargo.toml
+++ b/intel-sgx/report-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "report-test"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -16,7 +16,7 @@ categories = ["development-tools"]
 
 [dependencies]
 # Project dependencies
-"enclave-runner" = { version = "0.6.0", path = "../enclave-runner" }
+"enclave-runner" = { version = "0.7.0", path = "../enclave-runner" }
 "sgxs" = { version = "0.8.0", path = "../sgxs" }
 "sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
 

--- a/intel-sgx/sgxs-loaders/Cargo.toml
+++ b/intel-sgx/sgxs-loaders/Cargo.toml
@@ -40,5 +40,5 @@ winapi = { version = "0.3.7", features = ["enclaveapi","memoryapi","processthrea
 
 [dev-dependencies]
 # Project dependencies
-"report-test" = { version = "0.4.0", path = "../report-test" }
+"report-test" = { version = "0.5.0", path = "../report-test" }
 "aesm-client" = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }

--- a/intel-sgx/sgxs-tools/Cargo.toml
+++ b/intel-sgx/sgxs-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-tools"
-version = "0.8.6"
+version = "0.9.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -29,8 +29,8 @@ path = "src/sgx_detect/main.rs"
 "sgxs-loaders" = { version = "0.4.0", path = "../sgxs-loaders" }
 "aesm-client" = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
 "sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
-"report-test" = { version = "0.4.0", path = "../report-test" }
-"enclave-runner" = { version = "0.6.0", path = "../enclave-runner" }
+"report-test" = { version = "0.5.0", path = "../report-test" }
+"enclave-runner" = { version = "0.7.0", path = "../enclave-runner" }
 
 # External dependencies
 lazy_static = "1"                                # MIT/Apache-2.0


### PR DESCRIPTION
Also:
- sgxs-tools: 0.8.6 -> 0.9.0
- report-test: 0.4.0 -> 0.5.0
- dcap-provider: 0.4.0 -> 0.5.0
- dcap-retrieve-pckid: 0.2.0 -> 0.3.0

These are all published crates that (transitively) depend on `enclave-runner`, so we should bump their versions as well, and publish new versions of them if/when needed.

See this comment: https://github.com/fortanix/rust-sgx/pull/681#issuecomment-2616354292 for why we decided to bump enclave runner to a semver-incompatible version.