### PR TITLE
sgx: gdb: fix syntax warning in python 3.12+

### DIFF
--- a/intel-sgx/scripts/gdb.py
+++ b/intel-sgx/scripts/gdb.py
@@ -69,9 +69,9 @@ def find_vma_base_from_proc_mappings(addr):
   s = gdb.execute("info proc mappings", from_tty = False, to_string = True)
   for l in s.split('\n'):
     # Python doesn't support repeated group captures
-    m = re.match("^(?:\s*0x[0-9a-fA-F]+\s){4}", l)
+    m = re.match(r"^(?:\s*0x[0-9a-fA-F]+\s){4}", l)
     if m:
-      addrs = re.findall("0x([0-9a-fA-F]+)", l)
+      addrs = re.findall(r"0x([0-9a-fA-F]+)", l)
       start = int(addrs[0], 16)
       end = int(addrs[1], 16)
       if start <= addr and addr < end:
@@ -97,7 +97,7 @@ def get_text_offset(file_name):
       if ".text" in line:
           # 1     2    3    4
           # [Nr]  Name Type Address
-          m=re.match('^\s+\[\s*(\d+)\]\s+(\.text)\s+(\S+)\s+([0-9a-fA-F]+)\s', line)
+          m=re.match(r'^\s+\[\s*(\d+)\]\s+(\.text)\s+(\S+)\s+([0-9a-fA-F]+)\s', line)
           if m is not None:
               return int(m.group(4), 16)
           break


### PR DESCRIPTION
Python 3.12 recently changed how it parses string escapes, so it now warns on unrecognized escape codes. Trying to `source intel-sgx/scripts/gdb.py` in a recent `gdb` install results in these error messages:

```bash
$ nix shell github:NixOS/nixpkgs/release-24.11#gdb
$ gdb
GNU gdb (GDB) 15.2
(gdb) python-interactive
>>> import sys
>>> sys.version
'3.12.8 (main, Dec  3 2024, 18:42:41) [GCC 13.3.0]'
>>> ^D
(gdb) source intel-sgx/scripts/gdb.py
intel-sgx/scripts/gdb.py:72: SyntaxWarning: invalid escape sequence '\s'
  m = re.match("^(?:\s*0x[0-9a-fA-F]+\s){4}", l)
intel-sgx/scripts/gdb.py:100: SyntaxWarning: invalid escape sequence '\s'
  m=re.match('^\s+\[\s*(\d+)\]\s+(\.text)\s+(\S+)\s+([0-9a-fA-F]+)\s', line)
(gdb)
```

With an older gdb+python:

```bash
$ nix shell github:NixOS/nixpkgs/release-24.05#gdb
$ gdb
GNU gdb (GDB) 14.2
(gdb) python-interactive
>>> import sys
>>> sys.version
'3.11.10 (main, Sep  7 2024, 01:03:31) [GCC 13.2.0]'
>>> ^D
(gdb) source intel-sgx/scripts/gdb.py
(gdb)
```

This PR fixes the issue by using "raw" strings for all regexes in `gdb.py`, which prevents python from trying to expand any escape codes. The fix is backwards compatible -- the older python versions sources also interpret it correctly.

Testing everything still works:

```bash
$ gdb
GNU gdb (GDB) 15.2
(gdb) attach 37391
(gdb) thread apply all bt
Thread 3 (Thread 0x7fa9a32946c0 (LWP 37392) "run-sgx"):
#0  0x00007ffeddbe8f5e in __vdso_sgx_enter_enclave ()
#1  0x0000564b02b7147b in coenter<enclave_runner::loader::ErasedTcs> () at src/tcs.rs:139
#2  0x0000564b345ad960 in ?? ()
#3  0x0000564b345a95b0 in ?? ()
#4  0x0000564b02b7108e in enclave_runner::tcs::Usercall<T>::coreturn () at src/tcs.rs:43
#5  0x0000564b02ba6ee8 in enclave_runner::usercalls::Work::do_work () at src/usercalls/mod.rs:685
...

(gdb) thread 3
(gdb) source ../rust-sgx/intel-sgx/scripts/gdb.py
(gdb) sgxstate auto target/debug/sgx-test
add symbol table from file "target/debug/sgx-test" at
        .text_addr = 0x7fa998a75b40
Saving original register state

(gdb) bt
#0  compiler_builtins::mem::impls::rep_param () at src/mem/x86_64.rs:310
#1  compiler_builtins::mem::impls::copy_forward () at src/mem/x86_64.rs:39
#2  compiler_builtins::mem::memcpy () at src/mem/mod.rs:25
#3  compiler_builtins::mem::memcpy::memcpy () at src/macros.rs:480
#4  0x00007fc323eccf0d in libunwind::CFI_Parser<libunwind::LocalAddressSpace>::parseCIE(libunwind::LocalAddressSpace&, unsigned long, libunwind::CFI_Parser<libunwind::LocalAddressSpace>::CIE_Info*) ()
...
```