### PR TITLE
[RTE-370] Generate valid xfrm when required

### DIFF
--- a/intel-sgx/enclave-runner/src/loader.rs
+++ b/intel-sgx/enclave-runner/src/loader.rs
@@ -196,16 +196,9 @@ impl<'a> EnclaveBuilder<'a> {
                     return 0;
                 }
 
-                let (base, size) = {
-                    let cpuid = cpuid(0x0d, bit);
-                    let base = cpuid.map_or(0, |c| c.ebx);
-
-                    if base == 0 {
-                        (0, 0)
-                    } else {
-                        let size = cpuid.map_or(0, |c| c.eax);
-                        (base, size)
-                    }
+                let CpuidResult { ebx: base, eax: size, .. } = match cpuid(0x0d, bit) {
+                    None | Some(CpuidResult { ebx: 0, .. }) => return 0,
+                    Some(v) => v,
                 };
 
                 if max_ssaframesize_in_pages * 0x1000 < base + size {

--- a/intel-sgx/sgxs-loaders/src/isgx/mod.rs
+++ b/intel-sgx/sgxs-loaders/src/isgx/mod.rs
@@ -202,7 +202,6 @@ impl EnclaveLoad for InnerDevice {
             ..Default::default()
         };
         let createdata = ioctl::CreateData { secs: &secs };
-
         ioctl_unsafe!(
             Create,
             ioctl::create(mapping.device.fd.as_raw_fd(), &createdata)

--- a/intel-sgx/sgxs-loaders/src/isgx/mod.rs
+++ b/intel-sgx/sgxs-loaders/src/isgx/mod.rs
@@ -202,6 +202,7 @@ impl EnclaveLoad for InnerDevice {
             ..Default::default()
         };
         let createdata = ioctl::CreateData { secs: &secs };
+
         ioctl_unsafe!(
             Create,
             ioctl::create(mapping.device.fd.as_raw_fd(), &createdata)


### PR DESCRIPTION
There are two issues with running SGX enclaves on Sapphire Rapids:

- When running debug enclaves, we used to use XCR0 unmodified for the xfrm attribute. But now advanced matrix extensions (AMX) may lead to larger SSA frames (3 pages) than expected. The elf2sgxs tool by default only selected 1 page for SSA frames. When generating a signature, we need to ensure features are turned off when they would lead to larger SSA frames.
- Turning features off, may conflict with one another. XTILECFG and XTILEDATA need to be either enabled both, or disabled both. This PR sets the xfrm attribute accordingly.

Address #565 