### PR TITLE
[RTE-348] Support patched upstream driver

### DIFF
--- a/intel-sgx/sgxs-loaders/src/isgx/ioctl.rs
+++ b/intel-sgx/sgxs-loaders/src/isgx/ioctl.rs
@@ -76,4 +76,12 @@ pub mod augusta {
         pub sigstruct: *const sgx_isa::Sigstruct,
     }
     ioctl_write_ptr!(init, SGX_IOCTL, 0x02, InitData);
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug)]
+    pub struct SgxEnclaveExtend {
+        pub offset: u64,
+    }
+
+    ioctl_write_ptr!(extend, SGX_IOCTL, 0x08, SgxEnclaveExtend);
 }


### PR DESCRIPTION
Fortanix uses a slightly modified upstream Linux SGX driver that adds support for partially measured pages. This PR adds support for that driver to EDP.