### PR TITLE
Update Cargo.toml files for publish new versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "pcs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "b64-ct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-artifact-retrieval"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "backoff",
  "clap 2.34.0",

--- a/intel-sgx/dcap-artifact-retrieval/Cargo.toml
+++ b/intel-sgx/dcap-artifact-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-artifact-retrieval"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/dcap-artifact-retrieval/Cargo.toml
+++ b/intel-sgx/dcap-artifact-retrieval/Cargo.toml
@@ -28,7 +28,7 @@ mbedtls = { version = "0.12.3", features = [
     "std",
 ], default-features = false }
 num_enum = { version = "0.7", features = ["complex-expressions"] }
-pcs = { version = "0.3.0", path = "../pcs" }
+pcs = { version = "0.4.0", path = "../pcs" }
 percent-encoding = "2.1.0"
 pkix = "0.2.0"
 quick-error = "1.1.0"
@@ -44,7 +44,7 @@ rustls-tls = ["reqwest?/rustls-tls"]
 
 [dev-dependencies]
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
-pcs = { version = "0.3.0", path = "../pcs", features = ["verify"] }
+pcs = { version = "0.4.0", path = "../pcs", features = ["verify"] }
 
 [build-dependencies]
 mbedtls = { version = "0.12.3", features = ["ssl", "x509"] }

--- a/intel-sgx/insecure-time/Cargo.toml
+++ b/intel-sgx/insecure-time/Cargo.toml
@@ -5,9 +5,12 @@ authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2021"
 description = """
-Insecure time computation based on rdtsc
+Insecure time computation based on rdtsc.
 """
 repository = "https://github.com/fortanix/rust-sgx"
+documentation = "https://edp.fortanix.com/docs/api/insecure_time/"
+keywords = ["sgx", "enclave", "time"]
+categories = ["os", "hardware-support"]
 
 [dependencies]
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }

--- a/intel-sgx/insecure-time/Cargo.toml
+++ b/intel-sgx/insecure-time/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "insecure-time"
 version = "0.1.0"
+authors = ["Fortanix, Inc."]
+license = "MPL-2.0"
 edition = "2021"
+description = """
+Insecure time computation based on rdtsc
+"""
+repository = "https://github.com/fortanix/rust-sgx"
 
 [dependencies]
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }

--- a/intel-sgx/pcs/Cargo.toml
+++ b/intel-sgx/pcs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcs"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
To publish new version of crates in https://github.com/fortanix/rust-sgx/pull/690
There are still some work to do:
- Publish `insecure-time`

Also this PR bump version of `dcap-artifact-retrieval` to publish new version that include bug fix.