### PR TITLE
Fix dependabot CI failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,7 @@
 name: CI
 
 on:
-  pull_request:
-    paths-ignore:
-      - '*.md'
-      - 'LICENSE'
+  pull_request_target:
     branches:
       - master
   # This CI will be triggered on any merge_group events


### PR DESCRIPTION
## Background

Because of https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions, dependabot cannot access secrets when action event type is `pull_request`.

## Solution

Update event type to `pull_request_target` so that dependabot is able to access secrets.

## Note

It's is safe, because any PR from forked repo will require an approval from maintainer before running CI.

Fix: #703 