### PR TITLE
Bump `async-usercalls` version to `0.6.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "async-usercalls"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crossbeam-channel",
  "fnv",

--- a/intel-sgx/async-usercalls/Cargo.toml
+++ b/intel-sgx/async-usercalls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-usercalls"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
Because its dependencies have been bumped:
- ipc-queue: 0.3 -> 0.4
- fortanix-sgx-abi: 0.5 -> 0.6