### PR TITLE
Fix compile error introduced by the new toolchain

### DIFF
--- a/intel-sgx/fortanix-sgx-abi/src/lib.rs
+++ b/intel-sgx/fortanix-sgx-abi/src/lib.rs
@@ -881,7 +881,7 @@ invoke_with_abi_spec!(types);
 // function declarations inside all `impl Usercalls` blocks.
 macro_rules! define_invoke_with_usercalls {
     // collect all usercall function declarations in a list
-    (@ [$($accumulated:tt)*] $(#[$meta1:meta])* impl Usercalls { $($(#[$meta2:meta])* pub fn $f:ident($($n:ident: $t:ty),*) $(-> $r:ty)* { unimplemented!() } )* } $($remainder:tt)* ) =>
+    (@ [$($accumulated:tt)*] $(#[$meta1:meta])* impl Usercalls { $($(#[$meta2:meta])* pub fn $f:ident($($n:ident: $t:ty),*) $(-> $r:tt)* { unimplemented!() } )* } $($remainder:tt)* ) =>
         { define_invoke_with_usercalls!(@ [$($accumulated)* $(fn $f($($n: $t),*) $(-> $r)*;)*] $($remainder)*); };
     // visit modules
     (@ $accumulated:tt $(#[$meta:meta])* pub mod $modname:ident { $($contents:tt)* } $($remainder:tt)*) =>


### PR DESCRIPTION
The error is related to captured metavariables in macros:

```
error: no rules expected `ty` metavariable
  --> intel-sgx/async-usercalls/src/callback.rs:67:1
   |
23 | macro_rules! cbfn_type {
   | ---------------------- when calling this macro
...
67 | invoke_with_usercalls!(define_callback);
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no rules expected this token in macro call
   |
note: while trying to match `!`
  --> intel-sgx/async-usercalls/src/callback.rs:25:10
   |
25 |     ( -> ! )                              => { () };
   |          ^
   = note: captured metavariables except for `:tt`, `:ident` and `:lifetime` cannot be compared to other tokens
   = note: see <https://doc.rust-lang.org/nightly/reference/macros-by-example.html#forwarding-a-matched-fragment> for more information
   = help: try using `:tt` instead in the macro definition
   = note: this error originates in the macro `invoke_with_usercalls` (in Nightly builds, run with -Z macro-backtrace for more info)

```

It appears that because the `invoke_with_usercalls!` macro (from `fortanix-sgx-abi`) is itself produced by invoking `invoke_with_abi_spec!(define_invoke_with_usercalls);`, some tokens inside the macro become opaque (they become `ty` nodes), and are not matched against `tt`, which is strange, and possibly a compiler bug.

I wasn't able to come up with a minimal reproducible example of this, but I'll keep trying. 

In any case, the change in this PR should unblock CI, and is harmless. 