### PR TITLE
[RTE-381] Pin to `nightly-2025-02-22` compiler for some CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,12 +51,15 @@ jobs:
         rustup toolchain add nightly
         rustup target add x86_64-fortanix-unknown-sgx --toolchain nightly
         rustup update
+        # nightly-2025-02-22 and following are buggy which causes some crates not to compile
+        rustup install nightly-2025-02-22
+        rustup +nightly-2025-02-22 target add x86_64-fortanix-unknown-sgx
 
     - name: Cargo test --all --exclude sgxs-loaders
       run: cargo test --verbose --locked --all --exclude sgxs-loaders --exclude async-usercalls && [ "$(echo $(nm -D target/debug/sgx-detect|grep __vdso_sgx_enter_enclave))" = "w __vdso_sgx_enter_enclave" ]
 
     - name: cargo test -p async-usercalls --target x86_64-fortanix-unknown-sgx --no-run
-      run: cargo +nightly test --verbose --locked -p async-usercalls --target x86_64-fortanix-unknown-sgx --no-run
+      run: cargo +nightly-2025-02-22 test --verbose --locked -p async-usercalls --target x86_64-fortanix-unknown-sgx --no-run
 
     - name: Nightly test -p dcap-artifact-retrieval --target x86_64-fortanix-unknown-sgx --no-default-features --no-run
       run: cargo +nightly test --verbose --locked -p dcap-artifact-retrieval --target x86_64-fortanix-unknown-sgx --no-default-features --no-run

--- a/doc/generate-api-docs.sh
+++ b/doc/generate-api-docs.sh
@@ -61,7 +61,7 @@ for LIB in $LIBS_SORTED; do
         if grep -q 'feature(sgx_platform)' ./src/lib.rs; then
             ARGS+=" --target x86_64-fortanix-unknown-sgx"
         fi
-        cargo +nightly doc --no-deps --lib $ARGS
+        cargo +nightly-2025-02-22 doc --no-deps --lib $ARGS
         popd
     fi
 done

--- a/intel-sgx/fortanix-sgx-abi/src/lib.rs
+++ b/intel-sgx/fortanix-sgx-abi/src/lib.rs
@@ -881,7 +881,7 @@ invoke_with_abi_spec!(types);
 // function declarations inside all `impl Usercalls` blocks.
 macro_rules! define_invoke_with_usercalls {
     // collect all usercall function declarations in a list
-    (@ [$($accumulated:tt)*] $(#[$meta1:meta])* impl Usercalls { $($(#[$meta2:meta])* pub fn $f:ident($($n:ident: $t:ty),*) $(-> $r:tt)* { unimplemented!() } )* } $($remainder:tt)* ) =>
+    (@ [$($accumulated:tt)*] $(#[$meta1:meta])* impl Usercalls { $($(#[$meta2:meta])* pub fn $f:ident($($n:ident: $t:ty),*) $(-> $r:ty)* { unimplemented!() } )* } $($remainder:tt)* ) =>
         { define_invoke_with_usercalls!(@ [$($accumulated)* $(fn $f($($n: $t),*) $(-> $r)*;)*] $($remainder)*); };
     // visit modules
     (@ $accumulated:tt $(#[$meta:meta])* pub mod $modname:ident { $($contents:tt)* } $($remainder:tt)*) =>


### PR DESCRIPTION
Compiling `async-usercalls` triggers an upstream compiler bug in `nightly-2025-02-23` or subsequent compilers. This PR pins some CI tests to the `nightly-2025-02-22` compiler until the bug is resolved upstream. A minimal PoC still needs to be created and a bug report still needs to be filed.