### PR TITLE
Update dcap-artifact-retrieval patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-artifact-retrieval"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "backoff",
  "clap 2.34.0",

--- a/intel-sgx/dcap-artifact-retrieval/Cargo.toml
+++ b/intel-sgx/dcap-artifact-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-artifact-retrieval"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
I recently updated the pcs version in [PR](https://github.com/fortanix/rust-sgx/pull/722). Updating patch version here to publish and sort version mismatch issue.