### PR TITLE
[RTE-305] Add support for `TcbEvaluationDataNumbers` API endpoint in dcap-artifact-retrieval

### DIFF
--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use std::time::Duration;
 
 use super::common::PckCertsApiNotSupported;
-use super::intel::{PckCrlApi, QeIdApi, TcbInfoApi};
+use super::intel::{INTEL_BASE_URL, TcbEvaluationDataNumbersApi, PckCrlApi, QeIdApi, TcbInfoApi};
 use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PcsVersion, ProvisioningServiceApi,
     StatusCode,
@@ -47,8 +47,9 @@ impl AzureProvisioningClientBuilder {
         let pck_crl = PckCrlApi::new(self.api_version.clone());
         let qeid = QeIdApi::new(self.api_version.clone());
         let tcbinfo = TcbInfoApi::new(self.api_version.clone());
+        let evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
         self.client_builder
-            .build(pck_certs, pck_cert, pck_crl, qeid, tcbinfo, fetcher)
+            .build(pck_certs, pck_cert, pck_crl, qeid, tcbinfo, evaluation_data_numbers, fetcher)
     }
 }
 
@@ -291,5 +292,13 @@ mod tests {
 
             assert_eq!(format!("{:?}", selected.sgx_extension().unwrap()), format!("{:?}", pck.sgx_extension().unwrap()));
         }
+    }
+
+    #[test]
+    pub fn tcb_evaluation_data_numbers() {
+        let client = AzureProvisioningClientBuilder::new(PcsVersion::V3)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT)
+            .build(reqwest_client());
+        assert!(client.tcb_evaluation_data_numbers().is_ok());
     }
 }

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
@@ -17,7 +17,7 @@ pub const PCK_CRL_ISSUER_CHAIN_HEADER: &'static str = "SGX-PCK-CRL-Issuer-Chain"
 pub const TCB_INFO_ISSUER_CHAIN_HEADER_V3: &'static str = "SGX-TCB-Info-Issuer-Chain";
 pub const TCB_INFO_ISSUER_CHAIN_HEADER_V4: &'static str = "TCB-Info-Issuer-Chain";
 pub const ENCLAVE_ID_ISSUER_CHAIN_HEADER: &'static str = "SGX-Enclave-Identity-Issuer-Chain";
-pub const TCB_EVALUATION_DATA_NUMBERS: &'static str = "TCB-Evaluation-Data-Numbers-Issuer-Chain";
+pub const TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN: &'static str = "TCB-Evaluation-Data-Numbers-Issuer-Chain";
 
 pub struct PckCertsApiNotSupported;
 

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
@@ -17,6 +17,7 @@ pub const PCK_CRL_ISSUER_CHAIN_HEADER: &'static str = "SGX-PCK-CRL-Issuer-Chain"
 pub const TCB_INFO_ISSUER_CHAIN_HEADER_V3: &'static str = "SGX-TCB-Info-Issuer-Chain";
 pub const TCB_INFO_ISSUER_CHAIN_HEADER_V4: &'static str = "TCB-Info-Issuer-Chain";
 pub const ENCLAVE_ID_ISSUER_CHAIN_HEADER: &'static str = "SGX-Enclave-Identity-Issuer-Chain";
+pub const TCB_EVALUATION_DATA_NUMBERS: &'static str = "TCB-Evaluation-Data-Numbers-Issuer-Chain";
 
 pub struct PckCertsApiNotSupported;
 

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -533,7 +533,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for TcbEvaluationDataNumbersApi {
         response_headers: Vec<(String, String)>,
         _api_version: PcsVersion,
     ) -> Result<Self::Output, Error> {
-        let _ca_chain = parse_issuer_header(&response_headers, TCB_EVALUATION_DATA_NUMBERS)?;
+        let _ca_chain = parse_issuer_header(&response_headers, TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN)?;
         Ok(response_body)
     }
 }

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
@@ -24,6 +24,7 @@ use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PckCrlIn, PckCrlService, PcsVersion,
     ProvisioningServiceApi, QeIdIn, QeIdService, StatusCode, TcbInfoIn, TcbInfoService,
 };
+use super::intel::TcbEvaluationDataNumbersApi;
 use crate::Error;
 
 pub struct PccsProvisioningClientBuilder {
@@ -52,8 +53,9 @@ impl PccsProvisioningClientBuilder {
         let pck_crl = PckCrlApi::new(self.base_url.clone(), self.api_version);
         let qeid = QeIdApi::new(self.base_url.clone(), self.api_version);
         let tcbinfo = TcbInfoApi::new(self.base_url.clone(), self.api_version);
+        let evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(self.base_url.clone());
         self.client_builder
-            .build(pck_certs, pck_cert, pck_crl, qeid, tcbinfo, fetcher)
+            .build(pck_certs, pck_cert, pck_crl, qeid, tcbinfo, evaluation_data_numbers, fetcher)
     }
 }
 
@@ -723,5 +725,12 @@ mod tests {
 
             assert_eq!(qe_id, qeid_from_service);
         }
+    }
+
+    #[ignore = "PCCS service needs an update to support the new endpoint"]
+    #[test]
+    pub fn tcb_evaluation_data_numbers() {
+        let client = make_client(PcsVersion::V4);
+        client.tcb_evaluation_data_numbers().unwrap();
     }
 }


### PR DESCRIPTION
Intel recently added the new `TcbEvaluationDataNumbers` API endpoint to their [PCS service](https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-retrieve-tcbevalnumbers-v4). This PR adds support to call this endpoint. Parsing the result is left for a future PR for clarity. Also retrieving TcbInfo for a specific evaluation data number is left for a future PR.