### PR TITLE
[RTE-422] Verify identities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "pcs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "b64-ct",

--- a/intel-sgx/dcap-artifact-retrieval/Cargo.toml
+++ b/intel-sgx/dcap-artifact-retrieval/Cargo.toml
@@ -28,7 +28,7 @@ mbedtls = { version = "0.12.3", features = [
     "std",
 ], default-features = false }
 num_enum = { version = "0.7", features = ["complex-expressions"] }
-pcs = { version = "0.4.0", path = "../pcs" }
+pcs = { version = "0.5.0", path = "../pcs" }
 percent-encoding = "2.1.0"
 pkix = "0.2.0"
 quick-error = "1.1.0"
@@ -44,7 +44,7 @@ rustls-tls = ["reqwest?/rustls-tls"]
 
 [dev-dependencies]
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
-pcs = { version = "0.4.0", path = "../pcs", features = ["verify"] }
+pcs = { version = "0.5.0", path = "../pcs", features = ["verify"] }
 
 [build-dependencies]
 mbedtls = { version = "0.12.3", features = ["ssl", "x509"] }

--- a/intel-sgx/pcs/Cargo.toml
+++ b/intel-sgx/pcs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcs"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/pcs/src/tcb_info.rs
+++ b/intel-sgx/pcs/src/tcb_info.rs
@@ -131,8 +131,8 @@ pub enum Platform {
 impl Display for Platform {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            Platform::SGX =>  write!(f, "SGX"),
-            Platform::TDX =>  write!(f, "TDX"),
+            Platform::SGX => write!(f, "SGX"),
+            Platform::TDX => write!(f, "TDX"),
         }
     }
 }


### PR DESCRIPTION
The [Intel PCS](https://api.portal.trustedservices.intel.com/content/documentation.html#pcs) services offers various DCAP artifacts. The TcbInfo comes with an ID that can be used to differentiate TCB info for the SGX and TDX platforms. This ID should be checked during verification. This didn't happen. For the SGX platform, that's not a security issue as for all available FMSPCs the TCB info of TDX is a superset of SGX. It is the other way around.
For QE Identities something similar needs to happen.