### PR TITLE
[RTE-422] Bump pcs and dcap-artifact-retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-artifact-retrieval"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "backoff",
  "clap 2.34.0",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "pcs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "b64-ct",

--- a/intel-sgx/dcap-artifact-retrieval/Cargo.toml
+++ b/intel-sgx/dcap-artifact-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-artifact-retrieval"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -28,7 +28,7 @@ mbedtls = { version = "0.12.3", features = [
     "std",
 ], default-features = false }
 num_enum = { version = "0.7", features = ["complex-expressions"] }
-pcs = { version = "0.5.0", path = "../pcs" }
+pcs = { version = "0.6.0", path = "../pcs" }
 percent-encoding = "2.1.0"
 pkix = "0.2.0"
 quick-error = "1.1.0"
@@ -44,7 +44,7 @@ rustls-tls = ["reqwest?/rustls-tls"]
 
 [dev-dependencies]
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
-pcs = { version = "0.5.0", path = "../pcs", features = ["verify"] }
+pcs = { version = "0.6.0", path = "../pcs", features = ["verify"] }
 
 [build-dependencies]
 mbedtls = { version = "0.12.3", features = ["ssl", "x509"] }

--- a/intel-sgx/pcs/Cargo.toml
+++ b/intel-sgx/pcs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcs"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
#731 (just merged) bumped the versions of `pcs` and `dcap-artifact-retrieval`. Unfortunately, in parallel these values were already bumped to the same value, and published. This PR rectifies the situation by bumping the versions again for these crates to account for changes made in #731 