### PR TITLE
[RTE-427] Ensure minimual Cmake policy of 3.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
       # PCS_API_KEY: Raoul Strackx' personal access key. Only used here, and only provides access to the Intel PCS service, which is public anyway
       PCS_API_KEY: ${{ secrets.PCS_API_KEY }}
       PCCS_URL: ${{ vars.PCCS_URL }}
+      CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
CI fails with:
```
  running: cd "/home/runner/work/rust-sgx/rust-sgx/target/debug/build/mbedtls-sys-auto-c66539428ec212d0/out/build" && CMAKE_PREFIX_PATH="" "cmake" "/home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mbedtls-sys-auto-2.28.10/vendor" "-DENABLE_PROGRAMS=OFF" "-DENABLE_TESTING=OFF" "-DGEN_FILES=ON" "-DPython3_FIND_FRAMEWORK=LAST" "-DLIB_INSTALL_DIR=lib" "-DCMAKE_INSTALL_PREFIX=/home/runner/work/rust-sgx/rust-sgx/target/debug/build/mbedtls-sys-auto-c66539428ec212d0/out" "-DCMAKE_C_FLAGS= -DMBEDTLS_CONFIG_FILE=\"\\\"/home/runner/work/rust-sgx/rust-sgx/target/debug/build/mbedtls-sys-auto-c66539428ec212d0/out/config.h\\\"\" -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-unknown-linux-gnu" "-DCMAKE_C_COMPILER=/usr/bin/clang-18" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-unknown-linux-gnu" "-DCMAKE_CXX_COMPILER=/usr/bin/clang-18" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-unknown-linux-gnu" "-DCMAKE_ASM_COMPILER=/usr/bin/clang-18" "-DCMAKE_BUILD_TYPE=Debug"
  -- Configuring incomplete, errors occurred!

  --- stderr
  CMake Error at CMakeLists.txt:23 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.

    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.



  thread 'main' panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cmake-0.1.44/src/lib.rs:885:5:

  command did not execute successfully, got: exit status: 1
```
Currently cmake version 4.0.0 is installed in the CI. This PR fixes the issue by explicitly overwriting the minimum Cmake policy through an environment variable.