### PR TITLE
Bump pcs to version 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "pcs"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "b64-ct",

--- a/intel-sgx/pcs/Cargo.toml
+++ b/intel-sgx/pcs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcs"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
#745 updates the `pcs` crate, but forgot to bump the version. This PR fixes that.