### PR TITLE
[RTE-445] Ensure Rust SGX CI works against latest rust nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,15 +51,12 @@ jobs:
         rustup toolchain add nightly
         rustup target add x86_64-fortanix-unknown-sgx --toolchain nightly
         rustup update
-        # nightly-2025-02-22 and following are buggy which causes some crates not to compile
-        rustup install nightly-2025-02-22
-        rustup +nightly-2025-02-22 target add x86_64-fortanix-unknown-sgx
 
     - name: Cargo test --all --exclude sgxs-loaders
       run: cargo test --verbose --locked --all --exclude sgxs-loaders --exclude async-usercalls && [ "$(echo $(nm -D target/debug/sgx-detect|grep __vdso_sgx_enter_enclave))" = "w __vdso_sgx_enter_enclave" ]
 
     - name: cargo test -p async-usercalls --target x86_64-fortanix-unknown-sgx --no-run
-      run: cargo +nightly-2025-02-22 test --verbose --locked -p async-usercalls --target x86_64-fortanix-unknown-sgx --no-run
+      run: cargo +nightly test --verbose --locked -p async-usercalls --target x86_64-fortanix-unknown-sgx --no-run
 
     - name: Nightly test -p dcap-artifact-retrieval --target x86_64-fortanix-unknown-sgx --no-default-features --no-run
       run: cargo +nightly test --verbose --locked -p dcap-artifact-retrieval --target x86_64-fortanix-unknown-sgx --no-default-features --no-run

--- a/doc/generate-api-docs.sh
+++ b/doc/generate-api-docs.sh
@@ -61,7 +61,7 @@ for LIB in $LIBS_SORTED; do
         if grep -q 'feature(sgx_platform)' ./src/lib.rs; then
             ARGS+=" --target x86_64-fortanix-unknown-sgx"
         fi
-        cargo +nightly-2025-02-22 doc --no-deps --lib $ARGS
+        cargo +nightly doc --no-deps --lib $ARGS
         popd
     fi
 done

--- a/intel-sgx/fortanix-sgx-abi/src/lib.rs
+++ b/intel-sgx/fortanix-sgx-abi/src/lib.rs
@@ -881,7 +881,7 @@ invoke_with_abi_spec!(types);
 // function declarations inside all `impl Usercalls` blocks.
 macro_rules! define_invoke_with_usercalls {
     // collect all usercall function declarations in a list
-    (@ [$($accumulated:tt)*] $(#[$meta1:meta])* impl Usercalls { $($(#[$meta2:meta])* pub fn $f:ident($($n:ident: $t:ty),*) $(-> $r:ty)* { unimplemented!() } )* } $($remainder:tt)* ) =>
+    (@ [$($accumulated:tt)*] $(#[$meta1:meta])* impl Usercalls { $($(#[$meta2:meta])* pub fn $f:ident($($n:ident: $t:ty),*) $(-> $r:tt)* { unimplemented!() } )* } $($remainder:tt)* ) =>
         { define_invoke_with_usercalls!(@ [$($accumulated)* $(fn $f($($n: $t),*) $(-> $r)*;)*] $($remainder)*); };
     // visit modules
     (@ $accumulated:tt $(#[$meta:meta])* pub mod $modname:ident { $($contents:tt)* } $($remainder:tt)*) =>


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/138975#issuecomment-2755866121 concluded that the breakage described and fixed in https://github.com/fortanix/rust-sgx/pull/708 was an issue with our macros being used cross-crate and using nested macros, and that the fix proposed in https://github.com/fortanix/rust-sgx/pull/708 is indeed the right one

This PR cherry-picks https://github.com/fortanix/rust-sgx/pull/708 and reverts the compiler pinning we required in https://github.com/fortanix/rust-sgx/pull/713.

The PR has already been tested to compile locally with the following compilers:
* `nightly-2025-02-22` (compiler version used in https://github.com/fortanix/rust-sgx/issues/725, which turned out to be a `deranged` crate issue)
* `nightly-2025-04-17` (testing with a recent nightly)
* `dev-2024-11-21-x86_64-unknown-linux-gnu` (used internally in Roche)
