### PR TITLE
Remove `compiler-builtins` from `rustc-dep-of-std` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.152"
+version = "0.1.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2153cf213eb259361567720ce55f6446f17acd0ccca87fb6dc05360578228a58"
+checksum = "6376049cfa92c0aa8b9ac95fae22184b981c658208d4ed8a1dc553cd83612895"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -1181,7 +1181,6 @@ dependencies = [
 name = "fortanix-sgx-abi"
 version = "0.6.0"
 dependencies = [
- "compiler_builtins",
  "rustc-std-workspace-core",
 ]
 
@@ -1210,7 +1209,6 @@ dependencies = [
 name = "fortanix-vme-abi"
 version = "0.1.0"
 dependencies = [
- "compiler_builtins",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
  "serde",
@@ -1836,7 +1834,6 @@ name = "insecure-time"
 version = "0.1.0"
 dependencies = [
  "clap 4.5.20",
- "compiler_builtins",
  "rand 0.8.5",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",

--- a/fortanix-vme/fortanix-vme-abi/Cargo.toml
+++ b/fortanix-vme/fortanix-vme-abi/Cargo.toml
@@ -9,7 +9,6 @@ authors = ["Fortanix, Inc."]
 [dependencies]
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
-compiler_builtins = { version = "0.1.152", optional = true }
 # Avoid using patch section due to https://github.com/rust-lang/cargo/issues/10031
 serde = { git = "https://github.com/fortanix/serde.git", branch = "master", default-features = false, features = ["derive", "alloc"] }
 vsock = { version = "0.2.4", optional = true }
@@ -18,4 +17,4 @@ vsock = { version = "0.2.4", optional = true }
 std = ["serde/std", "vsock"]
 default = ["std"]
 docs = []
-rustc-dep-of-std = ["core", "alloc", "compiler_builtins/rustc-dep-of-std", "serde/rustc-dep-of-std"]
+rustc-dep-of-std = ["core", "alloc", "serde/rustc-dep-of-std"]

--- a/intel-sgx/fortanix-sgx-abi/Cargo.toml
+++ b/intel-sgx/fortanix-sgx-abi/Cargo.toml
@@ -23,11 +23,10 @@ categories = ["os"]
 
 [dependencies]
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1.152", optional = true }
 
 [features]
 docs = []
-rustc-dep-of-std = ["core", "compiler_builtins/rustc-dep-of-std"]
+rustc-dep-of-std = ["core"]
 
 [package.metadata.docs.rs]
 features = ["docs"]

--- a/intel-sgx/insecure-time/Cargo.toml
+++ b/intel-sgx/insecure-time/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["os", "hardware-support"]
 [dependencies]
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1.152", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 
 [dev-dependencies]
@@ -24,7 +23,7 @@ rand = "0.8"
 [features]
 default = ["std", "clap"]
 estimate_crystal_clock_freq = []
-rustc-dep-of-std = ["alloc", "core", "compiler_builtins/rustc-dep-of-std"]
+rustc-dep-of-std = ["alloc", "core"]
 std = []
 
 # Features only available during testing:


### PR DESCRIPTION
Since [1], this will come automatically from `rustc-std-workspace-core` and the crates.io dependency should no longer be specified.

[1]: https://github.com/rust-lang/rust/pull/141993