### PR TITLE
Ignore mismatched_lifetime_syntaxes lint warning in nightly

### DIFF
--- a/intel-sgx/aesm-client/src/lib.rs
+++ b/intel-sgx/aesm-client/src/lib.rs
@@ -20,6 +20,10 @@
 // To fix this error, which appears in generated code:
 // "lint `box_pointers` has been removed: it does not detect other kinds of allocations, and existed only for historical reasons."
 #![allow(renamed_and_removed_lints)]
+// (nightly only) To fix this error appears in generated code:
+// `error: lifetime flowing from input to output with different syntax can be confusing`
+#![allow(unknown_lints)]
+#![allow(mismatched_lifetime_syntaxes)]
 
 extern crate byteorder;
 pub extern crate anyhow;


### PR DESCRIPTION
Allow `mismatched_lifetime_syntaxes` lint warning to fix erros in nightly

```
error: lifetime flowing from input to output with different syntax can be confusing
   --> /home/yuxiangcao/github_ws/fortanix/rust-sgx/target/x86_64-fortanix-unknown-sgx/debug/build/aesm-client-7553ee8116cfb248/out/aesm_proto.rs:952:15
    |
952 |     fn as_ref(&self) -> ::protobuf::reflect::ReflectValueRef {
    |               ^^^^^     ------------------------------------ the lifetime gets resolved as `'_`
    |               |
    |               this lifetime flows to the output
    |
note: the lint level is defined here
   --> intel-sgx/aesm-client/src/lib.rs:19:9
    |
19  | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(mismatched_lifetime_syntaxes)]` implied by `#[deny(warnings)]`
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
```