### PR TITLE
Do not let tokio swallow forwarded panics

### DIFF
--- a/intel-sgx/enclave-runner/src/usercalls/mod.rs
+++ b/intel-sgx/enclave-runner/src/usercalls/mod.rs
@@ -880,10 +880,9 @@ impl EnclaveState {
             .expect("failed to create tokio Runtime");
         let local_set = tokio::task::LocalSet::new();
 
-        let forward_panics = enclave.forward_panics;
         let return_future = async move {
             while let Some((my_result, mode)) = rx_return_channel.recv().await {
-                if forward_panics {
+                if enclave_clone.forward_panics {
                     if let Err(EnclaveAbort::Exit { panic: Some(panic) }) = &my_result {
                         panic!("{}", panic);
                     }


### PR DESCRIPTION
We forward enclave panics (i.e., panic if the enclave panics) inside a tokio task, which results in tokio eating up the panic. This is the exact opposite of the intended behavior of `forward_panics`. This PR makes the runner panic outside tokio tasks, so the panic won't be caught by tokio.

Closes #763 