### PR TITLE
Fix CI for 3rd party

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,19 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      # PCS_API_KEY: Raoul Strackx' personal access key. Only used here, and only provides access to the Intel PCS service, which is public anyway
-      PCS_API_KEY: ${{ secrets.PCS_API_KEY }}
-      PCCS_URL: ${{ vars.PCCS_URL }}
       CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Conditionally export PCS_API_KEY and PCCS_URL
+      run: |
+        if [ -n "${{ secrets.PCS_API_KEY }}" ]; then
+          echo "PCS_API_KEY=${{ secrets.PCS_API_KEY }}" >> $GITHUB_ENV
+        fi
+        if [ -n "${{ vars.PCCS_URL }}" ]; then
+          echo "PCCS_URL=${{ vars.PCCS_URL }}" >> $GITHUB_ENV
+        fi
 
     - name: Install additional dependencies
       run: |


### PR DESCRIPTION
1. Intel SGX PCS version 3 is scheduled to end of life not later than October 31, 2025.  So we no longer force to test it.
2. PCCS tests default to use production PCCS url.
3. Update GitHub action to avoid empty string for PCS_API_KEY and PCCS_URL when CI is running from fork.