### PR TITLE
Bump `enclave-runner` version to 0.7.1 (and `fortanix-sgx-abi` to 0.6.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runner"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "crossbeam",

--- a/intel-sgx/enclave-runner/Cargo.toml
+++ b/intel-sgx/enclave-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runner"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
Changes from 0.7.0:
 - Fixed the issue where tokio would swallow forwarded panics
 - Bumped lazy_static dep from 1.2 to 1.5