### PR TITLE
Bump `fortanix-sgx-abi` to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "fortanix-sgx-abi"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/intel-sgx/enclave-runner/Cargo.toml
+++ b/intel-sgx/enclave-runner/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["fake-vdso/.gitignore", "fake-vdso/Makefile", "fake-vdso/main.S"]
 [dependencies]
 # Project dependencies
 sgxs = { version = "0.8.0", path = "../sgxs" }
-fortanix-sgx-abi = { version = "0.6.0", path = "../fortanix-sgx-abi" }
+fortanix-sgx-abi = { version = "0.6.1", path = "../fortanix-sgx-abi" }
 sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
 insecure-time = { version = "0.1", path = "../insecure-time", features = ["estimate_crystal_clock_freq"] }
 ipc-queue = { version = "0.4.0", path = "../../ipc-queue" }

--- a/intel-sgx/fortanix-sgx-abi/Cargo.toml
+++ b/intel-sgx/fortanix-sgx-abi/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "fortanix-sgx-abi"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
 An interface for Intel SGX enclaves. This is the interface for the
 `x86_64-fortanix-unknown-sgx` target.
 
-This is a small yet functional interface suitable for writing larger enclaves. 
-In contrast to other enclave interfaces, this interface is primarly designed 
+This is a small yet functional interface suitable for writing larger enclaves.
+In contrast to other enclave interfaces, this interface is primarly designed
 for running entire applications in an enclave.
 
-This crate fully describes the type-level interface complete with 
+This crate fully describes the type-level interface complete with
 documentation. For implementors, this crate contains all the type definitions
 and a macro with the function definitions.
 """


### PR DESCRIPTION
Changes since 0.6.0:
 - Fix compile error introduced by new rustc