### PR TITLE
[PROD-8063] Release new version of em-app 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "em-app"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "b64-ct",
@@ -940,7 +940,7 @@ dependencies = [
  "hyper 0.10.16",
  "lazy_static",
  "log 0.3.9",
- "mbedtls 0.12.4",
+ "mbedtls 0.12.5",
  "mime 0.2.6",
  "serde",
  "serde_derive 1.0.219",
@@ -2026,9 +2026,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mbedtls"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1efe2473e6d09d35cc527af979509e5b3678c9c33c9a9b6261239608483c224"
+checksum = "85518d7740ddc73c8d4d07b1be49a73ab2f4b7658f05ee266bf1827c2b8e801a"
 dependencies = [
  "bitflags 1.2.1",
  "byteorder 1.3.4",
@@ -2037,6 +2037,7 @@ dependencies = [
  "mbedtls-platform-support",
  "mbedtls-sys-auto",
  "rs-libc 0.2.3",
+ "rustc_version",
  "serde",
  "serde_derive 1.0.219",
  "yasna 0.2.2",
@@ -2915,7 +2916,7 @@ version = "2.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6653d384a260fedff0a466e894e05c5b8d75e261a14e9f93e81e43ef86cad23"
 dependencies = [
- "log 0.4.21",
+ "log 0.3.9",
  "which",
 ]
 

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "em-app"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["fortanix.com"]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
Bump em-app version from 0.5.0 to 0.5.1.
This is needed to have an `em-app` that support mbedtls 0.13.X

Change log of new release:
- Updates b64-ct from 0.1.0 to 0.1.3
- Updates mbedtls from 0.12 to `>=0.12.0, <0.14.0`
- Updates serde from 1.0.123 to 1.0
- Updates serde_derive from 1.0.123 to 1.0