### PR TITLE
Bump version for tools that need release binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-artifact-retrieval"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "backoff",
  "clap 2.34.0",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "fortanix-sgx-tools"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aesm-client",
  "anyhow",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs-tools"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aesm-client",
  "anyhow",

--- a/intel-sgx/dcap-artifact-retrieval/Cargo.toml
+++ b/intel-sgx/dcap-artifact-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-artifact-retrieval"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -15,7 +15,7 @@ documentation = "https://edp.fortanix.com/docs/api/dcap_artifact_retrieval/"
 homepage = "https://edp.fortanix.com/"
 keywords = ["sgx", "enclave", "dcap"]
 categories = ["os", "hardware-support"]
-
+readme = "Readme.md"
 
 [dependencies]
 backoff = "0.4.0"

--- a/intel-sgx/fortanix-sgx-tools/Cargo.toml
+++ b/intel-sgx/fortanix-sgx-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortanix-sgx-tools"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -16,6 +16,7 @@ homepage = "https://edp.fortanix.com/"
 keywords = ["sgx", "enclave", "ftxsgx-runner"]
 categories = ["development-tools::build-utils", "command-line-utilities"]
 edition = "2018"
+readme = "../../README.md"
 
 [dependencies]
 # Project dependencies

--- a/intel-sgx/sgxs-tools/Cargo.toml
+++ b/intel-sgx/sgxs-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-tools"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -25,12 +25,12 @@ path = "src/sgx_detect/main.rs"
 
 [dependencies]
 # Project dependencies
-"sgxs" = { version = "0.8.0", path = "../sgxs", features = ["crypto-openssl"] }
-"sgxs-loaders" = { version = "0.5.0", path = "../sgxs-loaders" }
-"aesm-client" = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
-"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
-"report-test" = { version = "0.5.0", path = "../report-test" }
-"enclave-runner" = { version = "0.7.0", path = "../enclave-runner" }
+sgxs = { version = "0.8.0", path = "../sgxs", features = ["crypto-openssl"] }
+sgxs-loaders = { version = "0.5.0", path = "../sgxs-loaders" }
+aesm-client = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
+sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
+report-test = { version = "0.5.0", path = "../report-test" }
+enclave-runner = { version = "0.7.0", path = "../enclave-runner" }
 
 # External dependencies
 lazy_static = "1"                                # MIT/Apache-2.0
@@ -59,7 +59,7 @@ serde_derive = "1.0.84"                          # MIT/Apache-2.0
 serde_yaml = "0.8.8"                             # MIT/Apache-2.0
 
 [target.'cfg(unix)'.dependencies]
-"dcap-ql" = { version = "0.4.0", path = "../dcap-ql" }
+dcap-ql = { version = "0.4.0", path = "../dcap-ql" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.7", features = ["winbase"] }


### PR DESCRIPTION
- This PR bumps version of following crates to prepare binary release:
  - dcap-artifact-retrieval
  - fortanix-sgx-tools
  - sgxs-tools
- This PR also fixes the readme path issue in Cargo.toml

After bump version, we can use this newly added GitHub Action to create release with binary + crates.io new version: https://github.com/fortanix/rust-sgx/actions/workflows/release.yml