### PR TITLE
Bump crates version for xfrm fix 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-retrieve-pckid"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aesm-client",
  "anyhow",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runner"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "report-test"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "enclave-runner",

--- a/intel-sgx/dcap-retrieve-pckid/Cargo.toml
+++ b/intel-sgx/dcap-retrieve-pckid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-retrieve-pckid"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -14,11 +14,11 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 # Project dependencies
-"aesm-client" = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
-"dcap-ql" = { version = "0.4.0", path = "../dcap-ql", default-features = false }
-"report-test" = { version = "0.5.0", path = "../report-test" }
-"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
-"sgxs-loaders" = { version = "0.5.0", path = "../sgxs-loaders" }
+aesm-client = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
+dcap-ql = { version = "0.4.0", path = "../dcap-ql", default-features = false }
+report-test = { version = "0.5.1", path = "../report-test" }
+sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
+sgxs-loaders = { version = "0.5.0", path = "../sgxs-loaders" }
 
 # External dependencies
 anyhow = "1.0"   # MIT/Apache-2.0

--- a/intel-sgx/enclave-runner/Cargo.toml
+++ b/intel-sgx/enclave-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runner"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -27,15 +27,15 @@ insecure-time = { version = "0.1", path = "../insecure-time", features = ["estim
 ipc-queue = { version = "0.4.0", path = "../../ipc-queue" }
 
 # External dependencies
-anyhow = "1.0"                                  # MIT/Apache-2.0
-thiserror = "1.0"                               # MIT/Apache-2.0
-fnv = "1"                                       # MIT/Apache-2.0
-lazy_static = "1.5.0"                           # MIT/Apache-2.0
-libc = "0.2.48"                                 # MIT/Apache-2.0
-nix = "0.13.0"                                  # MIT
-openssl = { version = "0.10", optional = true } # Apache-2.0
-crossbeam = "0.8.2"                             # MIT/Apache-2.0
-num_cpus = "1.10.0"                             # MIT/Apache-2.0
+anyhow = "1.0"                                    # MIT/Apache-2.0
+thiserror = "1.0"                                 # MIT/Apache-2.0
+fnv = "1"                                         # MIT/Apache-2.0
+lazy_static = "1.5.0"                             # MIT/Apache-2.0
+libc = "0.2.48"                                   # MIT/Apache-2.0
+nix = "0.13.0"                                    # MIT
+openssl = { version = "0.10", optional = true }   # Apache-2.0
+crossbeam = "0.8.2"                               # MIT/Apache-2.0
+num_cpus = "1.10.0"                               # MIT/Apache-2.0
 tokio = { version = "1.35", features = ["full"] } # MIT
 futures = { version = "0.3", features = ["compat", "io-compat"] } # MIT/Apache-2.0
 

--- a/intel-sgx/report-test/Cargo.toml
+++ b/intel-sgx/report-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "report-test"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -16,7 +16,7 @@ categories = ["development-tools"]
 
 [dependencies]
 # Project dependencies
-"enclave-runner" = { version = "0.7.0", path = "../enclave-runner" }
+"enclave-runner" = { version = "0.7.2", path = "../enclave-runner" }
 "sgxs" = { version = "0.8.0", path = "../sgxs" }
 "sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
 


### PR DESCRIPTION
- Bump enclave-runner version to have new version to include https://github.com/fortanix/rust-sgx/pull/694/
- Bump report-test version & its dependent version  on enclave-runner
- Bump dcap-retrieve-pckid version & its dependent  version on report-test