### PR TITLE
Fix dcap_artifact_retrieval tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
       - master
   # This CI will be triggered on any merge_group events
   merge_group:
+  schedule:
+    - cron: "0 0 * * *"  # Run CI on Daily, so we can track changes from nightly rust & Intel PCS
 
 env:
   RUST_BACKTRACE: 1

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -881,10 +881,15 @@ mod tests {
                 .unwrap();
 
             for number in evaluation_data_numbers.numbers() {
-                assert!(client
-                    .tcbinfo(&fmspc, Some(number.number()))
-                    .and_then(|tcb| { Ok(tcb.store(OUTPUT_TEST_DIR).unwrap()) })
-                    .is_ok());
+                let tcb = match client.tcbinfo(&fmspc, Some(number.number())) {
+                    Ok(tcb) => tcb,
+                    // API query with update="standard" will return QE Identity with TCB Evaluation Data Number M.
+                    // A 410 Gone response is returned when the inputted TCB Evaluation Data Number is < M,
+                    // so we ignore these TCB Evaluation Data Numbers.
+                    Err(super::Error::PCSError(status_code, _)) if status_code == super::StatusCode::Gone => continue,
+                    res @Err(_) => res.unwrap(),
+                };
+                tcb.store(OUTPUT_TEST_DIR).unwrap();
             }
         }
     }
@@ -1104,12 +1109,18 @@ mod tests {
         let eval_numbers: TcbEvaluationDataNumbers =
             eval_numbers.verify(&root_cas, Platform::SGX).unwrap();
         for number in eval_numbers.numbers().map(|n| n.number()) {
-            let qe_id = client
-                .qe_identity(Some(number))
-                .unwrap()
+            let qe_identity = match client.qe_identity(Some(number)) {
+                Ok(id) => id,
+                // API query with update="standard" will return QE Identity with TCB Evaluation Data Number M.
+                // A 410 Gone response is returned when the inputted TCB Evaluation Data Number is < M,
+                // so we ignore these TCB Evaluation Data Numbers.
+                Err(super::Error::PCSError(status_code, _)) if status_code == super::StatusCode::Gone => continue,
+                res @Err(_) => res.unwrap(),
+            };
+            let verified_qe_id = qe_identity
                 .verify(&root_cas, EnclaveIdentity::QE)
                 .unwrap();
-            assert_eq!(qe_id.tcb_evaluation_data_number(), u64::from(number));
+            assert_eq!(verified_qe_id.tcb_evaluation_data_number(), u64::from(number));
 
             let tcb_info = client
                     .tcbinfo(&fmspc, Some(number))


### PR DESCRIPTION
Now TcbEvaluationDataNumbers API will return "outdated" numbers, so tests need to ignore these numbers in following test logic.
From https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-enclave-identity-v4:
```
Information about the TCB Evaluation Data Number:
    At any point in time
        update="standard" will return QE Identity with TCB Evaluation Data Number M,
        update="early" will return QE Identity with TCB Evaluation Data Number N,
        M <= N.
    If the inputted TCB Evaluation Data Number is between M and N, i.e., M <= inputted TCB Evaluation Data Number <= N, the corresponding QE Identity is returned.
    If the inputted TCB Evaluation Data Number is < M, a 410 Gone response is returned.
    If the inputted TCB Evaluation Data Number is > N, a 404 Not Found response is returned.
```
This PR also update GitHub action to run main CI  daily to help track similar issue in future.
See failed case: https://github.com/fortanix/rust-sgx/actions/runs/17575745778/job/49920844294?pr=809