### PR TITLE
Fix releae job for crates targeting SGX target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
         run: |
           # Extract the crate name from the GITHUB_REF_NAME environment variable
           # GITHUB_REF_NAME contains the Tag name (e.g. rs-lic_v0.2.4) associated with the event
+          export CRATE_NAME=$(python3 -c "print('$GITHUB_REF_NAME'.rsplit('_v', 1)[0])")
+          echo "CRATE_NAME=$CRATE_NAME" >> $GITHUB_ENV
+
       - name: Set per-crate config (toolchain/target)
         run: |
           source ./crate-publish-config.sh "$CRATE_NAME"

--- a/crate-publish-config.sh
+++ b/crate-publish-config.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
   echo "Usage: source \$0 <crate_name>" >&2
-  return 1 2>/dev/null || exit 1
+  exit 1
 fi
 
 CRATE_NAME="$1"
@@ -33,7 +33,7 @@ CRATE_NAME="$1"
 for tool in "rustup"; do
   if ! command -v "$tool" >/dev/null 2>&1; then
     echo "Error: Required tool '$tool' not found in PATH." >&2
-    return 1 2>/dev/null || exit 1
+    exit 1
   fi
 done
 


### PR DESCRIPTION
## Summary

Fix CI release workflow so crates that target Fortanix SGX build correctly for publishing.
Added a per-crate configuration script to set toolchain and cargo build target for special crates (e.g. `async-usercalls`).

## What changed

- `.github/workflows/release.yml` — modified
- `crate-publish-config.sh` — added

## Test

Changed CI is tested at commit f429cbe, here is test run: https://github.com/fortanix/rust-sgx/actions/runs/19047187924/job/54398188480
