### PR TITLE
[RTE-608] Remove `mopa` crate from the cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,12 +2044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mopa"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a785740271256c230f57462d3b83e52f998433a7062fc18f96d5999474a9f915"
-
-[[package]]
 name = "native-tls"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs-tools"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "aesm-client",
  "anyhow",
@@ -3375,7 +3369,6 @@ dependencies = [
  "fnv",
  "lazy_static",
  "log 0.4.21",
- "mopa",
  "num",
  "openssl",
  "petgraph",

--- a/intel-sgx/sgxs-tools/Cargo.toml
+++ b/intel-sgx/sgxs-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-tools"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -50,7 +50,6 @@ atty = "0.2"                                     # MIT
 quote = "0.6"                                    # MIT/Apache-2.0
 proc-macro2 = "0.4"                              # MIT/Apache-2.0
 petgraph = "0.7"                                 # MIT/Apache-2.0
-mopa = "0.2"                                     # MIT/Apache-2.0
 syn = { version = "0.15", features = ["full"] }  # MIT/Apache-2.0
 fnv = "1"                                        # MIT/Apache-2.0
 proc-mounts = "0.3.0"                            # MIT

--- a/intel-sgx/sgxs-tools/src/sgx_detect/main.rs
+++ b/intel-sgx/sgxs-tools/src/sgx_detect/main.rs
@@ -36,8 +36,6 @@ extern crate log;
 extern crate anyhow;
 extern crate thiserror;
 #[macro_use]
-extern crate mopa;
-#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate clap;

--- a/intel-sgx/sgxs-tools/src/sgx_detect/tests/mod.rs
+++ b/intel-sgx/sgxs-tools/src/sgx_detect/tests/mod.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::cell::Cell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -1154,8 +1155,8 @@ fn update<T: DetectItem, U: Dependency<T>>(
     support: &SgxSupport,
     hidden: &Cell<bool>,
 ) {
-    let dependent = dependent.downcast_mut::<U>().unwrap();
-    let dependency = dependency.downcast_ref::<T>().unwrap();
+    let dependent = (dependent as &mut dyn Any).downcast_mut::<U>().unwrap();
+    let dependency = (dependency as &dyn Any).downcast_ref::<T>().unwrap();
     dependent.update_dependency(dependency, support);
 
     let hiddenval = if U::CONTROL_VISIBILITY {

--- a/intel-sgx/sgxs-tools/src/sgx_detect/tests/scaffold.rs
+++ b/intel-sgx/sgxs-tools/src/sgx_detect/tests/scaffold.rs
@@ -1,4 +1,4 @@
-use std::any::TypeId;
+use std::any::{Any, TypeId};
 use std::cell::Cell;
 use std::cmp::Ordering;
 use std::fmt;
@@ -11,10 +11,11 @@ use yansi::Paint;
 use crate::{paintalt, SgxSupport};
 use super::debug;
 
-pub trait DetectItem: Print + DebugSupport + Update + mopa::Any {
-    fn default() -> Box<dyn DetectItem> where Self: Sized;
+pub trait DetectItem: Print + DebugSupport + Update + Any {
+    fn default() -> Box<dyn DetectItem>
+    where
+        Self: Sized;
 }
-mopafy!(DetectItem);
 
 pub trait Update {
     fn update(&mut self, _support: &SgxSupport) {}
@@ -121,7 +122,7 @@ impl DetectItemMap {
             Ordering::Greater => {},
         }
 
-        assert_eq!(v, <dyn DetectItem as mopa::Any>::get_type_id(&*self.store[idx as usize]));
+        assert_eq!(v, (&*self.store[idx as usize] as &dyn Any).type_id());
 
         idx
     }
@@ -135,7 +136,9 @@ impl DetectItemMap {
     }
 
     pub fn lookup<T: DetectItem>(&self) -> &T {
-        self.store[self.map[&TypeId::of::<T>()] as usize].downcast_ref().unwrap()
+        (&*self.store[self.map[&TypeId::of::<T>()] as usize] as &dyn Any)
+            .downcast_ref()
+            .unwrap()
     }
 }
 


### PR DESCRIPTION
`mopa` is used only in `sgx-detect` tool, as a legacy workaround on generic programming with polymorphic types. Newer Rust now supports type upcasting, allowing `std::any::Any` to be used instead of using `mopa::Any`.

This should fix the Dependabot alert related to `mopa` crate: 
- [https://github.com/fortanix/rust-sgx/security/dependabot/5](https://github.com/fortanix/rust-sgx/security/dependabot/5)
- [https://github.com/fortanix/rust-sgx/security/dependabot/40](https://github.com/fortanix/rust-sgx/security/dependabot/40)

Credit fo solution: @tvsfx

Verified the tools are working on the SGX machine.