### PR TITLE
Revert patch version aesm-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aesm-client"
-version = "0.6.2"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "byteorder 1.3.4",

--- a/intel-sgx/aesm-client/Cargo.toml
+++ b/intel-sgx/aesm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesm-client"
-version = "0.6.2"
+version = "0.6.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """


### PR DESCRIPTION
The `aesm-client` is currently on 0.6.2, but 0.6.1 has never been published. This PR reverts the patch number so we can publish it (see #851 and #819)