### PR TITLE
[RET-680] Add intel tdx report verify support

### DIFF
--- a/intel-sgx/sgx-isa/src/arch.rs
+++ b/intel-sgx/sgx-isa/src/arch.rs
@@ -3,9 +3,9 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use core::mem::MaybeUninit;
-use core::arch::asm;
 use super::Enclu;
+use core::arch::asm;
+use core::mem::MaybeUninit;
 
 /// Wrapper struct to force 16-byte alignment.
 #[repr(align(16))]

--- a/intel-sgx/sgx-isa/src/lib.rs
+++ b/intel-sgx/sgx-isa/src/lib.rs
@@ -223,6 +223,7 @@ macro_rules! struct_def {
     (@align bytes 128 name $name:ident) => {
         struct_def!(@align type Align128 name $name);
     };
+
     (@align bytes 512 name $name:ident) => {
         struct_def!(@align type Align512 name $name);
     };
@@ -266,14 +267,15 @@ enum_def! {
 #[derive(Clone,Copy,Debug,PartialEq,Eq)]
 #[repr(u32)]
 pub enum Enclu {
-    EReport     = 0,
-    EGetkey     = 1,
-    EEnter      = 2,
-    EResume     = 3,
-    EExit       = 4,
-    EAccept     = 5,
-    EModpe      = 6,
-    EAcceptcopy = 7,
+    EReport        = 0,
+    EGetkey        = 1,
+    EEnter         = 2,
+    EResume        = 3,
+    EExit          = 4,
+    EAccept        = 5,
+    EModpe         = 6,
+    EAcceptcopy    = 7,
+    EVerifyReport2 = 8,
 }
 }
 


### PR DESCRIPTION
This PR add intel tdx report verify API through adding `EVERIFYREPORT2` instruction  support.

Ref: [Intel CPU Architectural Extensions Specification](https://cdrdv2.intel.com/v1/dl/getContent/733582) section 3.1