### PR TITLE
[RTE-778] dcap-artifact-retrieval tool must expect StatusCode::Gone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-usercalls"
 version = "0.6.0"
 dependencies = [
@@ -1194,6 +1200,7 @@ dependencies = [
 name = "dcap-artifact-retrieval"
 version = "0.4.2"
 dependencies = [
+ "assert_matches",
  "backoff",
  "clap 2.34.0",
  "lazy_static",

--- a/intel-sgx/dcap-artifact-retrieval/Cargo.toml
+++ b/intel-sgx/dcap-artifact-retrieval/Cargo.toml
@@ -43,6 +43,7 @@ default = ["clap", "reqwest"]
 rustls-tls = ["reqwest?/rustls-tls"]
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 pcs = { version = "0.7", path = "../pcs", features = ["verify"] }
 


### PR DESCRIPTION
The `dcap-artifact-retrieval` tool should expect that PCCS servers may return `StatusCode::Gone` when dcap artifacts with a specific tcb data evaluation number are no longer offered.