### PR TITLE
[RTE-775] Supporting older compiler with new and renamed IOError values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,6 +1488,7 @@ dependencies = [
  "libc",
  "nix 0.13.1",
  "openssl",
+ "rustc_version",
  "sgx-isa 0.4.1",
  "sgxs",
  "thiserror",

--- a/intel-sgx/enclave-runner-sgx/Cargo.toml
+++ b/intel-sgx/enclave-runner-sgx/Cargo.toml
@@ -42,3 +42,7 @@ futures = { version = "0.3", features = ["compat", "io-compat"] } # MIT/Apache-2
 [features]
 default = ["crypto-openssl"]
 crypto-openssl = ["openssl", "sgxs/crypto-openssl"]
+err-compat = ["default"]
+
+[build-dependencies]
+rustc_version = { version = "0.4" }               # MIT/Apache-2.0

--- a/intel-sgx/enclave-runner-sgx/build.rs
+++ b/intel-sgx/enclave-runner-sgx/build.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+use rustc_version::{Version, version, version_meta};
 
 fn main() {
     if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "linux" {
@@ -16,5 +17,9 @@ fn main() {
 
         println!("cargo:rustc-link-lib=dylib={}", LIBNAME);
         println!("cargo:rustc-link-search=native={}", out_dir);
+    }
+
+    if version().unwrap() <= Version::parse("1.84.0").unwrap() {
+        println!("cargo::rustc-cfg=feature=\"err-compat\"");
     }
 }

--- a/intel-sgx/enclave-runner-sgx/src/lib.rs
+++ b/intel-sgx/enclave-runner-sgx/src/lib.rs
@@ -3,7 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
+#![cfg_attr(feature = "err-compat", feature(io_error_more))]
 #![allow(non_local_definitions)] // Required by failure
 #![deny(warnings)]
 #![doc(

--- a/intel-sgx/enclave-runner-sgx/src/usercalls/interface.rs
+++ b/intel-sgx/enclave-runner-sgx/src/usercalls/interface.rs
@@ -17,7 +17,6 @@ use super::{EnclaveAbort, IOHandlerInput};
 use futures::future::Future;
 use futures::FutureExt;
 use tokio::io::ReadBuf;
-
 pub(super) struct Handler<'ioinput, 'tcs>(pub &'ioinput mut IOHandlerInput<'tcs>);
 
 impl<'future, 'ioinput: 'future, 'tcs: 'ioinput> Usercalls<'future> for Handler<'ioinput, 'tcs> {
@@ -341,6 +340,7 @@ impl<'a, T: Into<Vec<u8>>> Drop for OutputBuffer<'a, T> {
 }
 
 fn result_from_io_error(err: IoError) -> Result {
+
     let ret = match err.kind() {
         IoErrorKind::PermissionDenied => Error::PermissionDenied,
         IoErrorKind::NotFound => Error::NotFound,
@@ -376,7 +376,10 @@ fn result_from_io_error(err: IoError) -> Result {
         IoErrorKind::ConnectionRefused => Error::ConnectionRefused,
         IoErrorKind::HostUnreachable => Error::HostUnreachable,
         IoErrorKind::StaleNetworkFileHandle => Error::StaleNetworkFileHandle,
+        #[cfg(not(feature = "err-compat"))]
         IoErrorKind::QuotaExceeded => Error::QuotaExceeded,
+        #[cfg(feature = "err-compat")]
+        IoErrorKind::FilesystemQuotaExceeded => Error::QuotaExceeded,
         IoErrorKind::InvalidData => Error::InvalidData,
         IoErrorKind::WriteZero => Error::WriteZero,
         IoErrorKind::UnexpectedEof => Error::UnexpectedEof,


### PR DESCRIPTION
The new stabilized IOError that is added through this PR https://github.com/fortanix/rust-sgx/pull/845 introduces build error when compiling with older rust compiler. This PR adds a compatibility feature to keep supporting using this safely in older compilers.