### PR TITLE
RTE-709: Correct ftxvme-runner-cargo and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,6 +1784,7 @@ dependencies = [
  "fortanix-vme-eif",
  "log 0.4.28",
  "serde",
+ "tempfile",
  "thiserror",
 ]
 
@@ -3946,9 +3947,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -4640,14 +4641,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.3",
  "windows-sys 0.59.0",
 ]
 
@@ -5544,7 +5545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.2",
+ "rustix 1.1.3",
 ]
 
 [[package]]

--- a/fortanix-vme/fortanix-vme-tools/Cargo.toml
+++ b/fortanix-vme/fortanix-vme-tools/Cargo.toml
@@ -15,3 +15,6 @@ fortanix-vme-eif = { path = "../fortanix-vme-eif" }
 log = "0.4.21"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
- Correct it to be able accept trailing hyphen values.
- Correct it to not pass executable_name to nitro, this arg is only available to amd subcommand in vme runner.
- Add unit tests

Tested with
```
CARGO_MANIFEST_DIR="$(pwd)" PATH="$(pwd):$PATH" ftxvme-runner-cargo --verbose --simulate aws-nitro ~/github_ws/std-unit-test -Z unstable-options --format json
CARGO_MANIFEST_DIR="$(pwd)" PATH="$(pwd):$PATH" ftxvme-runner-cargo --verbose --simulate amd-sev-snp ~/github_ws/std-unit-test -Z unstable-options --format json
```
you can replace `~/github_ws/std-unit-test` with any rust test binary.