### PR TITLE
sgxs: reduce build time: less `time` features, no `thiserror`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,15 +3310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4914,9 +4905,7 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4510,7 +4510,6 @@ dependencies = [
  "openssl-sys",
  "sgx-isa 0.4.1",
  "sha2 0.10.9",
- "thiserror 1.0.59",
  "time 0.3.41",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4497,7 +4497,6 @@ dependencies = [
  "openssl-sys",
  "sgx-isa",
  "sha2 0.10.9",
- "thiserror 1.0.59",
  "time 0.3.41",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,15 +3310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4927,9 +4918,7 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",

--- a/intel-sgx/sgxs/Cargo.toml
+++ b/intel-sgx/sgxs/Cargo.toml
@@ -19,7 +19,6 @@ sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 # External dependencies
 byteorder = "1.0"                                     # Unlicense/MIT
 time = { version = "0.3", features = ["std"] }        # MIT/Apache-2.0
-thiserror = "1.0"                                     # MIT/Apache-2.0
 anyhow = "1.0"                                        # MIT/Apache-2.0
 openssl = { version = "0.10", optional = true }       # Apache-2.0
 openssl-sys = { version = "0.9.24", optional = true } # Apache-2.0

--- a/intel-sgx/sgxs/Cargo.toml
+++ b/intel-sgx/sgxs/Cargo.toml
@@ -18,7 +18,7 @@ sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
 
 # External dependencies
 byteorder = "1.0"                                     # Unlicense/MIT
-time = { version = "0.3", features = ["formatting", "local-offset", "macros", "std"] } # MIT/Apache-2.0
+time = { version = "0.3", features = ["std"] }        # MIT/Apache-2.0
 thiserror = "1.0"                                     # MIT/Apache-2.0
 anyhow = "1.0"                                        # MIT/Apache-2.0
 openssl = { version = "0.10", optional = true }       # Apache-2.0

--- a/intel-sgx/sgxs/Cargo.toml
+++ b/intel-sgx/sgxs/Cargo.toml
@@ -19,7 +19,6 @@ sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
 # External dependencies
 byteorder = "1.0"                                     # Unlicense/MIT
 time = { version = "0.3", features = ["std"] }        # MIT/Apache-2.0
-thiserror = "1.0"                                     # MIT/Apache-2.0
 anyhow = "1.0"                                        # MIT/Apache-2.0
 openssl = { version = "0.10", optional = true }       # Apache-2.0
 openssl-sys = { version = "0.9.24", optional = true } # Apache-2.0

--- a/intel-sgx/sgxs/Cargo.toml
+++ b/intel-sgx/sgxs/Cargo.toml
@@ -18,7 +18,7 @@ sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 
 # External dependencies
 byteorder = "1.0"                                     # Unlicense/MIT
-time = { version = "0.3", features = ["formatting", "local-offset", "macros", "std"] } # MIT/Apache-2.0
+time = { version = "0.3", features = ["std"] }        # MIT/Apache-2.0
 thiserror = "1.0"                                     # MIT/Apache-2.0
 anyhow = "1.0"                                        # MIT/Apache-2.0
 openssl = { version = "0.10", optional = true }       # Apache-2.0

--- a/intel-sgx/sgxs/src/lib.rs
+++ b/intel-sgx/sgxs/src/lib.rs
@@ -9,7 +9,6 @@
        html_root_url = "https://edp.fortanix.com/docs/api/")]
 
 extern crate byteorder;
-extern crate thiserror;
 #[cfg(feature = "crypto-openssl")]
 extern crate foreign_types;
 #[cfg(feature = "crypto-openssl")]

--- a/intel-sgx/sgxs/src/sgxs.rs
+++ b/intel-sgx/sgxs/src/sgxs.rs
@@ -5,22 +5,31 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use abi::*;
-use thiserror::Error as ThisError;
 
+use std::fmt::{self, Display};
 use std::io::{self, Error as IoError, ErrorKind as IoErrorKind, Read, Result as IoResult, Write};
 use std::result::Result as StdResult;
 
-#[derive(ThisError, Debug)]
+#[derive(Debug)]
 pub enum Error {
-    #[error("The stream is not canonical.")]
     StreamNotCanonical,
-    #[error("An invalid measurement tag {:016x} was encountered.", _0)]
     InvalidMeasTag(u64),
-    #[error("The given offset is not a multiple of the page size.")]
     InvalidPageOffset,
-    #[error("An unsized stream was encountered but a sized stream was expected.")]
     StreamUnsized,
 }
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::StreamNotCanonical => f.write_str("The stream is not canonical."),
+            Self::InvalidMeasTag(tag) => write!(f, "An invalid measurement tag {tag:016x} was encountered."),
+            Self::InvalidPageOffset => f.write_str("The given offset is not a multiple of the page size."),
+            Self::StreamUnsized => f.write_str("An unsized stream was encountered but a sized stream was expected."),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 pub type Result<T> = StdResult<T, anyhow::Error>;
 

--- a/intel-sgx/sgxs/src/sigstruct.rs
+++ b/intel-sgx/sgxs/src/sigstruct.rs
@@ -7,10 +7,9 @@
 use std::io::{Read, Result as IoResult, Write};
 
 use time::OffsetDateTime;
-use time::macros::format_description;
 
-use abi::{SIGSTRUCT_HEADER1, SIGSTRUCT_HEADER2};
 pub use abi::{Attributes, AttributesFlags, Miscselect, Sigstruct};
+use abi::{SIGSTRUCT_HEADER1, SIGSTRUCT_HEADER2};
 use crypto::{Hash, SgxHashOps, SgxRsaOps, SgxRsaPubOps};
 use sgxs::{copy_measured, SgxsRead};
 
@@ -75,12 +74,10 @@ impl Signer {
     /// Create a new `Signer` with default attributes (64-bit, XFRM: `0x3`) and
     /// today's date.
     pub fn new(enclavehash: EnclaveHash) -> Signer {
-        let format = format_description!("[Year][month][day]");
         // Unfortunately `OffsetDateTime::now_local()` doesn't work inside an SGX enclave
-        let now = OffsetDateTime::now_utc()
-            .format(&format)
-            .unwrap()
-            .to_string();
+        let now = OffsetDateTime::now_utc();
+        let (yyyy, mm, dd) = (now.year(), u8::from(now.month()), now.day());
+        let now = format!("{yyyy:04}{mm:02}{dd:02}");
 
         Signer {
             date: u32::from_str_radix(&now, 16).unwrap(),


### PR DESCRIPTION
Hey all,

I noticed the `sgxs` crate is on the critical path in one of our `build.rs` scripts in CI, and so I took a pass at improving that. After some slight refactoring to remove `thiserror` and `time` crate's proc-macro usage, the build time for just `sgxs` is down ~3.4x, without many downsides:

Before:

```bash
$ cargo tree -p sgxs
sgxs v0.8.1 (/home/phlip9/dev/rust-sgx/intel-sgx/sgxs)
├── anyhow v1.0.100
├── byteorder v1.5.0
├── sgx-isa v0.4.1 (/home/phlip9/dev/rust-sgx/intel-sgx/sgx-isa)
│   └── bitflags v1.2.1
├── thiserror v1.0.59
│   └── thiserror-impl v1.0.59 (proc-macro)
│       ├── proc-macro2 v1.0.95
│       │   └── unicode-ident v1.0.12
│       ├── quote v1.0.41
│       │   └── proc-macro2 v1.0.95 (*)
│       └── syn v2.0.115
│           ├── proc-macro2 v1.0.95 (*)
│           ├── quote v1.0.41 (*)
│           └── unicode-ident v1.0.12
└── time v0.3.41
    ├── deranged v0.4.0
    │   └── powerfmt v0.2.0
    ├── itoa v1.0.1
    ├── libc v0.2.180
    ├── num-conv v0.1.0
    ├── num_threads v0.1.6
    ├── powerfmt v0.2.0
    ├── time-core v0.1.4
    └── time-macros v0.2.22 (proc-macro)
        ├── num-conv v0.1.0
        └── time-core v0.1.4

# force the build to run on one core, like in a GitHub Actions CI runner
$ taskset -c 0 cargo build --target-dir /tmp/cargo-target-1 -p sgxs --lib
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.36s
```

After:

```bash
$ cargo tree -p sgxs
sgxs v0.8.1 (/home/phlip9/dev/rust-sgx/intel-sgx/sgxs)
├── anyhow v1.0.100
├── byteorder v1.5.0
├── sgx-isa v0.4.1 (/home/phlip9/dev/rust-sgx/intel-sgx/sgx-isa)
│   └── bitflags v1.2.1
└── time v0.3.41
    ├── deranged v0.4.0
    │   └── powerfmt v0.2.0
    ├── num-conv v0.1.0
    ├── powerfmt v0.2.0
    └── time-core v0.1.4

# force the build to run on one core, like in a GitHub Actions CI runner
$ taskset -c 0 cargo build --target-dir /tmp/cargo-target-2 -p sgxs --lib
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.57s
```
