### PR TITLE
RTE-839, RTE-840, RTE-841, RTE-842: Initial refactor of dcap-artifact-retrieval-tool

### DIFF
--- a/intel-sgx/dcap-artifact-retrieval/src/cli.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/cli.rs
@@ -8,16 +8,16 @@
 use std::path::{Path, PathBuf};
 
 use clap::clap_app;
-use pcs::{PckID, DcapArtifactIssuer, WriteOptionsBuilder};
+use pcs::{DcapArtifactIssuer, PckID, WriteOptionsBuilder};
 use reqwest::Url;
 use rustc_serialize::hex::ToHex;
 use serde::de::{value, IntoDeserializer};
 use serde::Deserialize;
 
 use crate::{
-    // AzureProvisioningClientBuilder,
+    AzureProvisioningClientBuilder,
     Error, IntelProvisioningClientBuilder,
-    // PccsProvisioningClientBuilder,
+    PccsProvisioningClientBuilder,
     PcsVersion, ProvisioningClient, StatusCode,
 };
 
@@ -72,7 +72,7 @@ fn download_dcap_artifacts(
 
         // Fetch pckcerts, note that Azure and PCCS do not support this API,
         // instead we mimic it using pckcert API.
-        let pckcerts = prov_client.pckcerts_with_fallback(&None, &pckid)?;
+        let pckcerts = prov_client.pckcerts(&pckid)?;
 
         let pckcerts_file = pckcerts.write_to_file(output_dir, pckid.qe_id.as_slice(), WriteOptionsBuilder::new().build())?;
 
@@ -257,23 +257,23 @@ pub fn main() {
             };
 
             let client: Box<dyn ProvisioningClient> = match origin {
-                // Origin::Intel => {
-                _ => {
+                Origin::Intel => {
                     let mut client_builder = IntelProvisioningClientBuilder::new(api_version);
-                    if let Some(api_key) = matches.value_of("API_KEY") {
-                        client_builder.set_api_key(api_key.into());
+                    let api_key = matches.value_of("API_KEY");
+                    if api_key.is_some() {
+                        client_builder.set_api_key(api_key.unwrap().into());
                     }
                     Box::new(client_builder.build(fetcher))
                 }
-                // Origin::Azure => {
-                //     let client_builder = AzureProvisioningClientBuilder::new(api_version);
-                //     Box::new(client_builder.build(fetcher))
-                // }
-                // Origin::Pccs => {
-                //     let pccs_url = matches.value_of("PCCS_URL").expect("validated").to_owned();
-                //     let client_builder = PccsProvisioningClientBuilder::new(api_version, pccs_url);
-                //     Box::new(client_builder.build(fetcher))
-                // }
+                Origin::Azure => {
+                    let client_builder = AzureProvisioningClientBuilder::new(api_version);
+                    Box::new(client_builder.build(fetcher))
+                }
+                Origin::Pccs => {
+                    let pccs_url = matches.value_of("PCCS_URL").expect("validated").to_owned();
+                    let client_builder = PccsProvisioningClientBuilder::new(api_version, pccs_url);
+                    Box::new(client_builder.build(fetcher))
+                }
             };
             download_dcap_artifacts(&*client, pckid_file, output_dir, 0 < verboseness)
         }

--- a/intel-sgx/dcap-artifact-retrieval/src/cli.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/cli.rs
@@ -15,8 +15,10 @@ use serde::de::{value, IntoDeserializer};
 use serde::Deserialize;
 
 use crate::{
-    AzureProvisioningClientBuilder, Error, IntelProvisioningClientBuilder,
-    PccsProvisioningClientBuilder, PcsVersion, ProvisioningClient, StatusCode,
+    // AzureProvisioningClientBuilder,
+    Error, IntelProvisioningClientBuilder,
+    // PccsProvisioningClientBuilder,
+    PcsVersion, ProvisioningClient, StatusCode,
 };
 
 // NOTE: unfortunately these default values need to be repeated in arg
@@ -70,7 +72,7 @@ fn download_dcap_artifacts(
 
         // Fetch pckcerts, note that Azure and PCCS do not support this API,
         // instead we mimic it using pckcert API.
-        let pckcerts = prov_client.pckcerts_with_fallback(&pckid)?;
+        let pckcerts = prov_client.pckcerts_with_fallback(&None, &pckid)?;
 
         let pckcerts_file = pckcerts.write_to_file(output_dir, pckid.qe_id.as_slice(), WriteOptionsBuilder::new().build())?;
 
@@ -255,22 +257,23 @@ pub fn main() {
             };
 
             let client: Box<dyn ProvisioningClient> = match origin {
-                Origin::Intel => {
+                // Origin::Intel => {
+                _ => {
                     let mut client_builder = IntelProvisioningClientBuilder::new(api_version);
                     if let Some(api_key) = matches.value_of("API_KEY") {
                         client_builder.set_api_key(api_key.into());
                     }
                     Box::new(client_builder.build(fetcher))
                 }
-                Origin::Azure => {
-                    let client_builder = AzureProvisioningClientBuilder::new(api_version);
-                    Box::new(client_builder.build(fetcher))
-                }
-                Origin::Pccs => {
-                    let pccs_url = matches.value_of("PCCS_URL").expect("validated").to_owned();
-                    let client_builder = PccsProvisioningClientBuilder::new(api_version, pccs_url);
-                    Box::new(client_builder.build(fetcher))
-                }
+                // Origin::Azure => {
+                //     let client_builder = AzureProvisioningClientBuilder::new(api_version);
+                //     Box::new(client_builder.build(fetcher))
+                // }
+                // Origin::Pccs => {
+                //     let pccs_url = matches.value_of("PCCS_URL").expect("validated").to_owned();
+                //     let client_builder = PccsProvisioningClientBuilder::new(api_version, pccs_url);
+                //     Box::new(client_builder.build(fetcher))
+                // }
             };
             download_dcap_artifacts(&*client, pckid_file, output_dir, 0 < verboseness)
         }

--- a/intel-sgx/dcap-artifact-retrieval/src/main.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/main.rs
@@ -7,5 +7,5 @@
 
 #[cfg(all(not(target_env = "sgx"), feature = "reqwest"))]
 fn main() {
-    // dcap_artifact_retrieval::cli::main()
+    dcap_artifact_retrieval::cli::main()
 }

--- a/intel-sgx/dcap-artifact-retrieval/src/main.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/main.rs
@@ -7,5 +7,5 @@
 
 #[cfg(all(not(target_env = "sgx"), feature = "reqwest"))]
 fn main() {
-    dcap_artifact_retrieval::cli::main()
+    // dcap_artifact_retrieval::cli::main()
 }

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
@@ -17,7 +17,7 @@ use super::{
     StatusCode,
 };
 use crate::intel::IntelPCSClient;
-use crate::provisioning_client::{BackoffService, CachedService, PcsService};
+use crate::provisioning_client::{BackoffService, CachedService};
 use crate::{Error, IntelProvisioningClientBuilder, ProvisioningClient, WithApiVersion};
 
 /// A Provisioning Certificate client builder for Azure. It is based on the internal logic of the Azure DCAP
@@ -26,14 +26,12 @@ use crate::{Error, IntelProvisioningClientBuilder, ProvisioningClient, WithApiVe
 /// field in the past (see PROD-5800).
 /// For info on the Azure DCAP provider: <https://github.com/microsoft/Azure-DCAP-Client>
 pub struct AzureProvisioningClientBuilder {
-    api_version: PcsVersion,
     client_builder: IntelProvisioningClientBuilder,
 }
 
 impl AzureProvisioningClientBuilder {
     pub fn new(api_version: PcsVersion) -> Self {
         Self {
-            api_version,
             client_builder: IntelProvisioningClientBuilder::new(api_version),
         }
     }
@@ -44,7 +42,6 @@ impl AzureProvisioningClientBuilder {
     }
 
     pub fn build<F: for<'a> Fetcher<'a>>(&self, fetcher: F) -> AzureClient<F> {
-        let pckcert_service = PckCertService;
         let client = self.client_builder.build(
             fetcher,
         );
@@ -54,7 +51,6 @@ impl AzureProvisioningClientBuilder {
             azure_api_id: PckCertApi::API_VERSION_07_2021.to_owned(),
             pckcert_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(pckcert_service),
                     self.client_builder.client_builder.retry_timeout.clone(),
                 ),
                 self.client_builder.client_builder.cache_capacity.clone(),
@@ -201,7 +197,7 @@ impl ProvisioningServiceApi for PckCertService {
     type Input<'a> = PckCertIn<'a>;
     type Output = PckCert<Unverified>;
 
-    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         // Re-implements `build_pck_cert_url` from Azure's DCAP Client
         // https://github.com/microsoft/Azure-DCAP-Client/blob/master/src/dcap_provider.cpp#L677
         // Constants from the Azure DCAP client:
@@ -217,7 +213,7 @@ impl ProvisioningServiceApi for PckCertService {
         Ok((url, Vec::new()))
     }
 
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+    fn validate_response(status_code: StatusCode) -> Result<(), Error> {
         match &status_code {
             StatusCode::Ok => Ok(()),
             StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
@@ -249,7 +245,6 @@ impl ProvisioningServiceApi for PckCertService {
     }
 
     fn parse_response(
-        &self,
         response_body: String,
         _response_headers: Vec<(String, String)>,
         _api_version: PcsVersion,

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
@@ -10,16 +10,15 @@ use rustc_serialize::hex::ToHex;
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 use std::time::Duration;
 
 use super::{
-    Client, ClientBuilder, Fetcher, PcsVersion, ProvisioningServiceApi,
+    Fetcher, PcsVersion, ProvisioningServiceApi,
     StatusCode,
 };
 use crate::intel::IntelPCSClient;
-use crate::provisioning_client::{BackoffService, CachedService, PcsService, QeIdService, TcbEvaluationDataNumbersService, TcbInfoService};
-use crate::{Error, IntelProvisioningClientBuilder, WithApiVersion};
+use crate::provisioning_client::{BackoffService, CachedService, PcsService};
+use crate::{Error, IntelProvisioningClientBuilder, ProvisioningClient, WithApiVersion};
 
 /// A Provisioning Certificate client builder for Azure. It is based on the internal logic of the Azure DCAP
 /// provider. Only the PCK certificates are downloaded from Azure. For others Intel is contacted.
@@ -46,12 +45,6 @@ impl AzureProvisioningClientBuilder {
 
     pub fn build<F: for<'a> Fetcher<'a>>(&self, fetcher: F) -> AzureClient<F> {
         let pckcert_service = PckCertService;
-        let qeid = QeIdService;
-        let sgx_tcbinfo = TcbInfoService::<platform::SGX> {_type: PhantomData};
-        let tdx_tcbinfo = TcbInfoService::<platform::TDX> {_type: PhantomData};
-        let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::SGX> { _type: PhantomData };
-        let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::TDX> { _type: PhantomData };
-
         let client = self.client_builder.build(
             fetcher,
         );
@@ -72,7 +65,7 @@ impl AzureProvisioningClientBuilder {
     }
 }
 
-struct AzureClient<F: for<'b> Fetcher<'b>> {
+pub struct AzureClient<F: for<'b> Fetcher<'b>> {
     azure_base_url: String,
     azure_client_id: String,
     azure_api_id: String,
@@ -80,30 +73,28 @@ struct AzureClient<F: for<'b> Fetcher<'b>> {
     client: IntelPCSClient<F>,
 }
 
-impl<F: for<'a> Fetcher<'a>> AzureClient<F> {
+impl<F: for<'a> Fetcher<'a>> ProvisioningClient for AzureClient<F> {
     fn pckcert(
         &self,
+        api_key: &Option<String>,
         encrypted_ppid: Option<&EncPpid>,
         pce_id: &PceId,
         cpu_svn: &CpuSvn,
         pce_isvsvn: PceIsvsvn,
-        qe_id: &QeId,
+        qe_id: Option<&QeId>,
     ) -> Result<PckCert<Unverified>, Error> {
-        let input = PckCertIn { encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id: Some(&qe_id), api_version: self.client.client.api_version, api_key: &None, azure_client_id: &self.azure_client_id, azure_api_version: &self.azure_api_id };
+        let input = PckCertIn { encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id, api_version: self.client.client.api_version, api_key, azure_client_id: &self.azure_client_id, azure_api_version: &self.azure_api_id };
         self.pckcert_service.call_service(&self.client.client.fetcher, &self.azure_base_url, &input)
     }
-
     fn pckcerts(&self, pck_id: &PckID) -> Result<PckCerts, Error> {
-        // let input = PckCertsIn { api_version: self.client.api_version, pck_id: &pck_id };
-        // self.pckcerts_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
-
         let get_and_collect = |collection: &mut BTreeMap<([u8; 16], u16), PckCert<Unverified>>, cpu_svn: &[u8; 16], pce_svn: u16| -> Result<PckCert<Unverified>, Error> {
             let pck_cert = self.pckcert(
+                &None,
                 Some(&pck_id.enc_ppid),
                 &pck_id.pce_id,
                 cpu_svn,
                 pce_svn,
-                &pck_id.qe_id,
+                Some(&pck_id.qe_id),
             )?;
 
             // Getting PCK cert using CPUSVN from PCKID
@@ -151,12 +142,33 @@ impl<F: for<'a> Fetcher<'a>> AzureClient<F> {
             .try_into()
             .map_err(|e| Error::PCSDecodeError(format!("{}", e).into()))
     }
+
+    fn sgx_tcbinfo(&self, fmspc: &pcs::Fmspc, evaluation_data_number: Option<u16>) -> Result<pcs::TcbInfo<platform::SGX>, Error> {
+        self.client.sgx_tcbinfo(fmspc, evaluation_data_number)
+    }
+
+    fn tdx_tcbinfo(&self, fmspc: &pcs::Fmspc, evaluation_data_number: Option<u16>) -> Result<pcs::TcbInfo<platform::TDX>, Error> {
+        self.client.tdx_tcbinfo(fmspc, evaluation_data_number)
+    }
+
+    fn pckcrl(&self, ca: pcs::DcapArtifactIssuer) -> Result<pcs::PckCrl<Unverified>, Error> {
+        self.client.pckcrl(ca)
+    }
+
+    fn qe_identity(&self, evaluation_data_number: Option<u16>) -> Result<pcs::QeIdentitySigned, Error> {
+        self.client.qe_identity(evaluation_data_number)
+    }
+
+    fn sgx_tcb_evaluation_data_numbers(&self) -> Result<pcs::RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
+        self.client.sgx_tcb_evaluation_data_numbers()
+    }
+
+    fn tdx_tcb_evaluation_data_numbers(&self) -> Result<pcs::RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
+        self.client.tdx_tcb_evaluation_data_numbers()
+    }
 }
 
-pub struct PckCertApi {
-    api_version: PcsVersion,
-}
-
+pub struct PckCertApi;
 impl PckCertApi {
     // Constants from the Azure DCAP client:
     // (host of primary URL is down)
@@ -302,11 +314,12 @@ mod tests {
             {
                 let pck = client
                     .pckcert(
+                        &None,
                         None,
                         &pckid.pce_id,
                         &pckid.cpu_svn,
                         pckid.pce_isvsvn,
-                        &pckid.qe_id
+                        Some(&pckid.qe_id)
                     )
                     .unwrap();
 
@@ -321,7 +334,7 @@ mod tests {
                 );
 
                 let fmspc: Fmspc = pck.fmspc().unwrap();
-                assert!(client.client.sgx_tcbinfo(&fmspc, None).is_ok());
+                assert!(client.sgx_tcbinfo(&fmspc, None).is_ok());
             }
         }
     }
@@ -332,8 +345,8 @@ mod tests {
             let client = AzureProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT)
                 .build(reqwest_client());
-            assert!(client.client.pckcrl(DcapArtifactIssuer::PCKProcessorCA).is_ok());
-            assert!(client.client.pckcrl(DcapArtifactIssuer::PCKPlatformCA).is_ok());
+            assert!(client.pckcrl(DcapArtifactIssuer::PCKProcessorCA).is_ok());
+            assert!(client.pckcrl(DcapArtifactIssuer::PCKPlatformCA).is_ok());
         }
     }
 
@@ -343,7 +356,7 @@ mod tests {
             let client = AzureProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT)
                 .build(reqwest_client());
-            assert!(client.client.qe_identity(None).is_ok());
+            assert!(client.qe_identity(None).is_ok());
         }
     }
 
@@ -355,11 +368,11 @@ mod tests {
                 .build(reqwest_client());
             let fmspc = Fmspc::try_from("90806f000000").unwrap();
             assert_matches!(
-                client.client.qe_identity(Some(15)),
+                client.qe_identity(Some(15)),
                 Err(Error::PCSError(StatusCode::Gone, _))
             );
             assert_matches!(
-                client.client.sgx_tcbinfo(&fmspc, Some(15)),
+                client.sgx_tcbinfo(&fmspc, Some(15)),
                 Err(Error::PCSError(StatusCode::Gone, _))
             );
         }
@@ -379,7 +392,7 @@ mod tests {
                 let pckcerts = client.pckcerts(&pckid).unwrap();
                 println!("Found {} PCK certs.", pckcerts.as_pck_certs().len());
 
-                let tcb_info = client.client
+                let tcb_info = client
                     .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
                     .unwrap();
                 let tcb_data = tcb_info.data().unwrap();
@@ -390,11 +403,12 @@ mod tests {
 
                 let pck = client
                     .pckcert(
+                        &None,
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
                         pckid.pce_isvsvn,
-                        &pckid.qe_id,
+                        Some(&pckid.qe_id),
                     )
                     .unwrap();
 
@@ -412,7 +426,7 @@ mod tests {
             let client = AzureProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT)
                 .build(reqwest_client());
-            assert!(client.client.sgx_tcb_evaluation_data_numbers().is_ok());
+            assert!(client.sgx_tcb_evaluation_data_numbers().is_ok());
         }
     }
 }

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
@@ -5,18 +5,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-use pcs::{CpuSvn, EncPpid, PceId, PceIsvsvn, PckCert, QeId, Unverified};
+use pcs::{CpuSvn, EncPpid, PceId, PceIsvsvn, PckCert, PckCerts, PckID, QeId, TcbComponentType, Unverified, platform};
 use rustc_serialize::hex::ToHex;
 use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::convert::TryInto;
+use std::marker::PhantomData;
 use std::time::Duration;
 
-use super::common::PckCertsApiNotSupported;
-use super::intel::{PckCrlApi, QeIdApi, TcbEvaluationDataNumbersApi, TcbInfoApi, INTEL_BASE_URL};
 use super::{
-    Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PcsVersion, ProvisioningServiceApi,
+    Client, ClientBuilder, Fetcher, PcsVersion, ProvisioningServiceApi,
     StatusCode,
 };
-use crate::Error;
+use crate::intel::IntelPCSClient;
+use crate::provisioning_client::{BackoffService, CachedService, PcsService, QeIdService, TcbEvaluationDataNumbersService, TcbInfoService};
+use crate::{Error, IntelProvisioningClientBuilder, WithApiVersion};
 
 /// A Provisioning Certificate client builder for Azure. It is based on the internal logic of the Azure DCAP
 /// provider. Only the PCK certificates are downloaded from Azure. For others Intel is contacted.
@@ -25,14 +28,14 @@ use crate::Error;
 /// For info on the Azure DCAP provider: <https://github.com/microsoft/Azure-DCAP-Client>
 pub struct AzureProvisioningClientBuilder {
     api_version: PcsVersion,
-    client_builder: ClientBuilder,
+    client_builder: IntelProvisioningClientBuilder,
 }
 
 impl AzureProvisioningClientBuilder {
     pub fn new(api_version: PcsVersion) -> Self {
         Self {
             api_version,
-            client_builder: ClientBuilder::new(),
+            client_builder: IntelProvisioningClientBuilder::new(api_version),
         }
     }
 
@@ -41,27 +44,112 @@ impl AzureProvisioningClientBuilder {
         self
     }
 
-    pub fn build<F: for<'a> Fetcher<'a>>(self, fetcher: F) -> Client<F> {
-        let pck_certs = PckCertsApiNotSupported;
-        let pck_cert = PckCertApi::new(self.api_version.clone());
-        let pck_crl = PckCrlApi::new(self.api_version.clone());
-        let qeid = QeIdApi::new(self.api_version.clone());
-        let sgx_tcbinfo = TcbInfoApi::new(self.api_version.clone());
-        let tdx_tcbinfo = TcbInfoApi::new(self.api_version.clone());
-        let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
-        let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
+    pub fn build<F: for<'a> Fetcher<'a>>(&self, fetcher: F) -> AzureClient<F> {
+        let pckcert_service = PckCertService;
+        let qeid = QeIdService;
+        let sgx_tcbinfo = TcbInfoService::<platform::SGX> {_type: PhantomData};
+        let tdx_tcbinfo = TcbInfoService::<platform::TDX> {_type: PhantomData};
+        let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::SGX> { _type: PhantomData };
+        let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::TDX> { _type: PhantomData };
 
-        self.client_builder.build(
-            pck_certs,
-            pck_cert,
-            pck_crl,
-            qeid,
-            sgx_tcbinfo,
-            tdx_tcbinfo,
-            sgx_evaluation_data_numbers,
-            tdx_evaluation_data_numbers,
+        let client = self.client_builder.build(
             fetcher,
-        )
+        );
+        AzureClient {
+            azure_base_url: PckCertApi::SECONDARY_CERT_URL.to_owned(),
+            azure_client_id: PckCertApi::DEFAULT_CLIENT_ID.to_owned(),
+            azure_api_id: PckCertApi::API_VERSION_07_2021.to_owned(),
+            pckcert_service: CachedService::new(
+                BackoffService::new(
+                    PcsService::new(pckcert_service),
+                    self.client_builder.client_builder.retry_timeout.clone(),
+                ),
+                self.client_builder.client_builder.cache_capacity.clone(),
+                self.client_builder.client_builder.cache_shelf_time.clone(),
+            ),
+            client,
+        }
+    }
+}
+
+struct AzureClient<F: for<'b> Fetcher<'b>> {
+    azure_base_url: String,
+    azure_client_id: String,
+    azure_api_id: String,
+    pckcert_service: CachedService<PckCertService>,
+    client: IntelPCSClient<F>,
+}
+
+impl<F: for<'a> Fetcher<'a>> AzureClient<F> {
+    fn pckcert(
+        &self,
+        encrypted_ppid: Option<&EncPpid>,
+        pce_id: &PceId,
+        cpu_svn: &CpuSvn,
+        pce_isvsvn: PceIsvsvn,
+        qe_id: &QeId,
+    ) -> Result<PckCert<Unverified>, Error> {
+        let input = PckCertIn { encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id: Some(&qe_id), api_version: self.client.client.api_version, api_key: &None, azure_client_id: &self.azure_client_id, azure_api_version: &self.azure_api_id };
+        self.pckcert_service.call_service(&self.client.client.fetcher, &self.azure_base_url, &input)
+    }
+
+    fn pckcerts(&self, pck_id: &PckID) -> Result<PckCerts, Error> {
+        // let input = PckCertsIn { api_version: self.client.api_version, pck_id: &pck_id };
+        // self.pckcerts_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
+
+        let get_and_collect = |collection: &mut BTreeMap<([u8; 16], u16), PckCert<Unverified>>, cpu_svn: &[u8; 16], pce_svn: u16| -> Result<PckCert<Unverified>, Error> {
+            let pck_cert = self.pckcert(
+                Some(&pck_id.enc_ppid),
+                &pck_id.pce_id,
+                cpu_svn,
+                pce_svn,
+                &pck_id.qe_id,
+            )?;
+
+            // Getting PCK cert using CPUSVN from PCKID
+            let ptcb = pck_cert.platform_tcb()?;
+            collection.insert((ptcb.cpusvn, ptcb.tcb_components.pce_svn()), pck_cert.clone());
+            Ok(pck_cert)
+        };
+
+        // Use BTreeMap to have an ordered PckCerts at the end
+        let mut pckcerts_map = BTreeMap::new();
+
+        // 1. Use PCK ID to get best available PCK Cert
+        let pck_cert = get_and_collect(&mut pckcerts_map, &pck_id.cpu_svn, pck_id.pce_isvsvn)?;
+
+        // 2. Getting PCK cert using CPUSVN all 1's
+        let _ign_err = get_and_collect(&mut pckcerts_map, &[u8::MAX; 16], pck_id.pce_isvsvn);
+
+        let fmspc = pck_cert.sgx_extension()?.fmspc;
+        let tcb_info = self.client.sgx_tcbinfo(&fmspc, None)?;
+        let tcb_data = tcb_info.data()?;
+        for (cpu_svn, pce_isvsvn) in tcb_data.iter_tcb_components() {
+            // 3. Get PCK based on TCB levels
+            let _ = get_and_collect(&mut pckcerts_map, &cpu_svn, pce_isvsvn)?;
+
+            // 4. If late loaded microcode version is higher than early loaded microcode,
+            //    also try with highest microcode version of both components. We found cases where
+            //    fetching the PCK Cert that exactly matched the TCB level, did not result in a PCK
+            //    Cert for that level
+            let early_ucode_idx = tcb_data.tcb_component_index(TcbComponentType::EarlyMicrocodeUpdate);
+            let late_ucode_idx = tcb_data.tcb_component_index(TcbComponentType::LateMicrocodeUpdate);
+            if let (Some(early_ucode_idx), Some(late_ucode_idx)) = (early_ucode_idx, late_ucode_idx) {
+                let early_ucode = cpu_svn[early_ucode_idx];
+                let late_ucode = cpu_svn[late_ucode_idx];
+                if early_ucode < late_ucode {
+                    let mut cpu_svn = cpu_svn.clone();
+                    cpu_svn[early_ucode_idx] = late_ucode;
+                    let _ign_err = get_and_collect(&mut pckcerts_map, &cpu_svn, pce_isvsvn);
+                }
+            }
+        }
+
+        // BTreeMap by default is Ascending
+        let pck_certs: Vec<_> = pckcerts_map.into_iter().rev().map(|(_, v)| v).collect();
+        pck_certs
+            .try_into()
+            .map_err(|e| Error::PCSDecodeError(format!("{}", e).into()))
     }
 }
 
@@ -77,68 +165,43 @@ impl PckCertApi {
     const API_VERSION_07_2021: &'static str = "2021-07-22-preview";
 }
 
-impl PckCertApi {
-    pub(crate) fn new(api_version: PcsVersion) -> PckCertApi {
-        PckCertApi { api_version }
+#[derive(Hash)]
+struct PckCertIn<'a> {
+    encrypted_ppid: Option<&'a EncPpid>,
+    pce_id: &'a PceId,
+    cpu_svn: &'a CpuSvn,
+    pce_isvsvn: PceIsvsvn,
+    qe_id: Option<&'a QeId>,
+    api_version: PcsVersion,
+    api_key: &'a Option<String>,
+    azure_client_id: &'a str,
+    azure_api_version: &'a str,
+}
+
+impl<'a> WithApiVersion for PckCertIn<'a> {
+    fn api_version(&self) -> PcsVersion {
+        PcsVersion::V4
     }
 }
 
-impl<'inp> PckCertService<'inp> for PckCertApi {
-    fn build_input(
-        &'inp self,
-        encrypted_ppid: Option<&'inp EncPpid>,
-        pce_id: &'inp PceId,
-        cpu_svn: &'inp CpuSvn,
-        pce_isvsvn: PceIsvsvn,
-        qe_id: Option<&'inp QeId>,
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        PckCertIn {
-            encrypted_ppid,
-            pce_id,
-            cpu_svn,
-            pce_isvsvn,
-            qe_id,
-            api_version: self.api_version,
-            api_key: &None,
-        }
-    }
-}
-
-impl<'inp> ProvisioningServiceApi<'inp> for PckCertApi {
-    type Input = PckCertIn<'inp>;
+struct PckCertService;
+impl ProvisioningServiceApi for PckCertService {
+    type Input<'a> = PckCertIn<'a>;
     type Output = PckCert<Unverified>;
 
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         // Re-implements `build_pck_cert_url` from Azure's DCAP Client
         // https://github.com/microsoft/Azure-DCAP-Client/blob/master/src/dcap_provider.cpp#L677
-        fn build_pck_cert_url(
-            pce_id: &PceId,
-            cpu_svn: &CpuSvn,
-            pce_isvsvn: PceIsvsvn,
-            qe_id: &QeId,
-            api_version: PcsVersion,
-        ) -> String {
-            // Constants from the Azure DCAP client:
-            // (host of primary URL is down)
-            let base_url = PckCertApi::SECONDARY_CERT_URL;
-            let version = api_version as u8;
-            let qeid = qe_id.to_hex();
-            let cpusvn = cpu_svn.to_hex();
-            let pcesvn = pce_isvsvn.to_le_bytes().to_hex();
-            let pceid = pce_id.to_le_bytes().to_hex();
-            let clientid = PckCertApi::DEFAULT_CLIENT_ID;
-            let api_version = PckCertApi::API_VERSION_07_2021;
-            format!("{base_url}/v{version}/pckcert?qeid={qeid}&cpusvn={cpusvn}&pcesvn={pcesvn}&pceid={pceid}&clientid={clientid}&api-version={api_version}")
-        }
-
-        let qe_id = input.qe_id.ok_or(Error::NoQeID)?;
-        let url = build_pck_cert_url(
-            input.pce_id,
-            input.cpu_svn,
-            input.pce_isvsvn,
-            qe_id,
-            input.api_version,
-        );
+        // Constants from the Azure DCAP client:
+        // (host of primary URL is down)
+        let version = input.api_version as u8;
+        let qeid =  input.qe_id.ok_or(Error::NoQeID)?.to_hex();
+        let cpusvn = input.cpu_svn.to_hex();
+        let pcesvn = input.pce_isvsvn.to_le_bytes().to_hex();
+        let pceid = input.pce_id.to_le_bytes().to_hex();
+        let clientid =  input.azure_client_id;
+        let api_version = input.azure_api_version;
+        let url = format!("{base_url}/v{version}/pckcert?qeid={qeid}&cpusvn={cpusvn}&pcesvn={pcesvn}&pceid={pceid}&clientid={clientid}&api-version={api_version}");
         Ok((url, Vec::new()))
     }
 
@@ -218,7 +281,7 @@ mod tests {
         test_helpers, AzureProvisioningClientBuilder, DcapArtifactIssuer, PcsVersion,
         ProvisioningClient,
     };
-    use crate::{reqwest_client, Error, StatusCode};
+    use crate::{Error, StatusCode, reqwest_client};
 
     const PCKID_TEST_FILE: &str = "./tests/data/azure_icelake_pckid.csv";
 
@@ -243,7 +306,7 @@ mod tests {
                         &pckid.pce_id,
                         &pckid.cpu_svn,
                         pckid.pce_isvsvn,
-                        Some(&pckid.qe_id),
+                        &pckid.qe_id
                     )
                     .unwrap();
 
@@ -257,8 +320,8 @@ mod tests {
                     "Intel SGX PCK Certificate"
                 );
 
-                let fmspc = pck.fmspc().unwrap();
-                assert!(client.sgx_tcbinfo(&fmspc, None).is_ok());
+                let fmspc: Fmspc = pck.fmspc().unwrap();
+                assert!(client.client.sgx_tcbinfo(&fmspc, None).is_ok());
             }
         }
     }
@@ -269,8 +332,8 @@ mod tests {
             let client = AzureProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT)
                 .build(reqwest_client());
-            assert!(client.pckcrl(DcapArtifactIssuer::PCKProcessorCA).is_ok());
-            assert!(client.pckcrl(DcapArtifactIssuer::PCKPlatformCA).is_ok());
+            assert!(client.client.pckcrl(DcapArtifactIssuer::PCKProcessorCA).is_ok());
+            assert!(client.client.pckcrl(DcapArtifactIssuer::PCKPlatformCA).is_ok());
         }
     }
 
@@ -280,7 +343,7 @@ mod tests {
             let client = AzureProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT)
                 .build(reqwest_client());
-            assert!(client.qe_identity(None).is_ok());
+            assert!(client.client.qe_identity(None).is_ok());
         }
     }
 
@@ -292,11 +355,11 @@ mod tests {
                 .build(reqwest_client());
             let fmspc = Fmspc::try_from("90806f000000").unwrap();
             assert_matches!(
-                client.qe_identity(Some(15)),
+                client.client.qe_identity(Some(15)),
                 Err(Error::PCSError(StatusCode::Gone, _))
             );
             assert_matches!(
-                client.sgx_tcbinfo(&fmspc, Some(15)),
+                client.client.sgx_tcbinfo(&fmspc, Some(15)),
                 Err(Error::PCSError(StatusCode::Gone, _))
             );
         }
@@ -313,10 +376,10 @@ mod tests {
                 .unwrap()
                 .iter()
             {
-                let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
+                let pckcerts = client.pckcerts(&pckid).unwrap();
                 println!("Found {} PCK certs.", pckcerts.as_pck_certs().len());
 
-                let tcb_info = client
+                let tcb_info = client.client
                     .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
                     .unwrap();
                 let tcb_data = tcb_info.data().unwrap();
@@ -331,7 +394,7 @@ mod tests {
                         &pckid.pce_id,
                         &pckid.cpu_svn,
                         pckid.pce_isvsvn,
-                        Some(&pckid.qe_id),
+                        &pckid.qe_id,
                     )
                     .unwrap();
 
@@ -349,7 +412,7 @@ mod tests {
             let client = AzureProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT)
                 .build(reqwest_client());
-            assert!(client.sgx_tcb_evaluation_data_numbers().is_ok());
+            assert!(client.client.sgx_tcb_evaluation_data_numbers().is_ok());
         }
     }
 }

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
@@ -19,48 +19,6 @@ pub const TCB_INFO_ISSUER_CHAIN_HEADER_V4: &'static str = "TCB-Info-Issuer-Chain
 pub const ENCLAVE_ID_ISSUER_CHAIN_HEADER: &'static str = "SGX-Enclave-Identity-Issuer-Chain";
 pub const TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN: &'static str = "TCB-Evaluation-Data-Numbers-Issuer-Chain";
 
-pub struct PckCertsApiNotSupported;
-
-// impl<'inp> PckCertsService<'inp> for PckCertsApiNotSupported {
-//     fn build_input(
-//         &'inp self,
-//         enc_ppid: &'inp EncPpid,
-//         pce_id: PceId,
-//     ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-//         PckCertsIn {
-//             enc_ppid,
-//             pce_id,
-//             api_key: &None,
-//             api_version: PcsVersion::V3, // does not matter, this API is not supported!
-//         }
-//     }
-// }
-
-// impl<'inp> ProvisioningServiceApi<'inp> for PckCertsApiNotSupported {
-//     type Input = PckCertsIn<'inp>;
-//     type Output = PckCerts;
-
-//     fn build_request(
-//         &self,
-//         _input: &Self::Input,
-//     ) -> Result<(String, Vec<(String, String)>), Error> {
-//         Err(Error::RequestNotSupported)
-//     }
-
-//     fn validate_response(&self, _status_code: StatusCode) -> Result<(), Error> {
-//         Err(Error::RequestNotSupported)
-//     }
-
-//     fn parse_response(
-//         &self,
-//         _response_body: String,
-//         _response_headers: Vec<(String, String)>,
-//         _api_version: PcsVersion,
-//     ) -> Result<Self::Output, Error> {
-//         Err(Error::RequestNotSupported)
-//     }
-// }
-
 /// Returns the certificate chain starting from the leaf CA.
 pub fn parse_issuer_header(
     headers: &Vec<(String, String)>,

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
@@ -5,11 +5,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-use pcs::{EncPpid, PceId, PckCerts};
 use percent_encoding::percent_decode;
 use pkix::pem::PemBlock;
 
-use super::{PckCertsIn, PckCertsService, PcsVersion, ProvisioningServiceApi, StatusCode};
 use crate::Error;
 
 pub const PCK_CERTIFICATE_ISSUER_CHAIN_HEADER: &'static str = "SGX-PCK-Certificate-Issuer-Chain";

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
@@ -21,45 +21,45 @@ pub const TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN: &'static str = "TCB-Evaluati
 
 pub struct PckCertsApiNotSupported;
 
-impl<'inp> PckCertsService<'inp> for PckCertsApiNotSupported {
-    fn build_input(
-        &'inp self,
-        enc_ppid: &'inp EncPpid,
-        pce_id: PceId,
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        PckCertsIn {
-            enc_ppid,
-            pce_id,
-            api_key: &None,
-            api_version: PcsVersion::V3, // does not matter, this API is not supported!
-        }
-    }
-}
+// impl<'inp> PckCertsService<'inp> for PckCertsApiNotSupported {
+//     fn build_input(
+//         &'inp self,
+//         enc_ppid: &'inp EncPpid,
+//         pce_id: PceId,
+//     ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
+//         PckCertsIn {
+//             enc_ppid,
+//             pce_id,
+//             api_key: &None,
+//             api_version: PcsVersion::V3, // does not matter, this API is not supported!
+//         }
+//     }
+// }
 
-impl<'inp> ProvisioningServiceApi<'inp> for PckCertsApiNotSupported {
-    type Input = PckCertsIn<'inp>;
-    type Output = PckCerts;
+// impl<'inp> ProvisioningServiceApi<'inp> for PckCertsApiNotSupported {
+//     type Input = PckCertsIn<'inp>;
+//     type Output = PckCerts;
 
-    fn build_request(
-        &self,
-        _input: &Self::Input,
-    ) -> Result<(String, Vec<(String, String)>), Error> {
-        Err(Error::RequestNotSupported)
-    }
+//     fn build_request(
+//         &self,
+//         _input: &Self::Input,
+//     ) -> Result<(String, Vec<(String, String)>), Error> {
+//         Err(Error::RequestNotSupported)
+//     }
 
-    fn validate_response(&self, _status_code: StatusCode) -> Result<(), Error> {
-        Err(Error::RequestNotSupported)
-    }
+//     fn validate_response(&self, _status_code: StatusCode) -> Result<(), Error> {
+//         Err(Error::RequestNotSupported)
+//     }
 
-    fn parse_response(
-        &self,
-        _response_body: String,
-        _response_headers: Vec<(String, String)>,
-        _api_version: PcsVersion,
-    ) -> Result<Self::Output, Error> {
-        Err(Error::RequestNotSupported)
-    }
-}
+//     fn parse_response(
+//         &self,
+//         _response_body: String,
+//         _response_headers: Vec<(String, String)>,
+//         _api_version: PcsVersion,
+//     ) -> Result<Self::Output, Error> {
+//         Err(Error::RequestNotSupported)
+//     }
+// }
 
 /// Returns the certificate chain starting from the leaf CA.
 pub fn parse_issuer_header(

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -11,6 +11,7 @@
 //! - <https://api.portal.trustedservices.intel.com/provisioning-certification>
 //! - <https://download.01.org/intel-sgx/dcap-1.1/linux/docs/Intel_SGX_PCK_Certificate_CRL_Spec-1.1.pdf>
 
+use pcs::platform::{self, SGX};
 use pcs::{
     CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl,
     PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers,
@@ -60,16 +61,28 @@ impl IntelProvisioningClientBuilder {
     }
 
     pub fn build<F: for<'a> Fetcher<'a>>(self, fetcher: F) -> Client<F> {
-        let pck_certs = PckCertsApi::new(self.api_version.clone(), self.api_key.clone());
-        let pck_cert = PckCertApi::new(self.api_version.clone(), self.api_key.clone());
-        let pck_crl = PckCrlApi::new(self.api_version.clone());
-        let qeid = QeIdApi::new(self.api_version.clone());
-        let sgx_tcbinfo = TcbInfoApi::new(self.api_version.clone());
-        let tdx_tcbinfo = TcbInfoApi::new(self.api_version.clone());
-        let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
-        let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
+        // let pck_certs = PckCertsApi::new(self.api_version.clone(), self.api_key.clone());
+        // let pck_certs = PckCertsService{};
+        // let pck_cert = PckCertApi::new(self.api_version.clone(), self.api_key.clone());
+        // let pck_crl = PckCrlApi::new(self.api_version.clone());
+        // let qeid = QeIdApi::new(self.api_version.clone());
+        // let sgx_tcbinfo = TcbInfoApi::new(self.api_version.clone());
+        // let tdx_tcbinfo = TcbInfoApi::new(self.api_version.clone());
+        // let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
+        // let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
+
+        let pck_certs = PckCertsService;
+        let pck_certs = PckCertsService;
+        let pck_cert = PckCertService;
+        let pck_crl = PckCrlService;
+        let qeid = QeIdService;
+        let sgx_tcbinfo = TcbInfoService::<platform::SGX> {_type: PhantomData};
+        let tdx_tcbinfo = TcbInfoService::<platform::TDX> {_type: PhantomData};
+        let sgx_evaluation_data_numbers: TcbEvaluationDataNumbersService<SGX> = TcbEvaluationDataNumbersService::<platform::SGX> { _type: PhantomData, base_url: INTEL_BASE_URL.to_owned() };
+        let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::TDX> { _type: PhantomData, base_url: INTEL_BASE_URL.to_owned() };
 
         self.client_builder.build(
+            self.api_version,
             pck_certs,
             pck_cert,
             pck_crl,
@@ -97,49 +110,51 @@ impl PckCertsApi {
     }
 }
 
-impl<'inp> PckCertsService<'inp> for PckCertsApi {
-    fn build_input(
-        &'inp self,
-        enc_ppid: &'inp EncPpid,
-        pce_id: PceId,
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        PckCertsIn {
-            enc_ppid,
-            pce_id,
-            api_key: &self.api_key,
-            api_version: self.api_version.clone(),
-        }
-    }
-}
+// impl PckCertsService for PckCertsApi {
+//     fn build_input<'inp>(
+//         &self,
+//         api_key: &'inp Option<String>,
+//         enc_ppid: &'inp EncPpid,
+//         pce_id: PceId,
+//     ) -> <Self as ProvisioningServiceApi>::Input<'inp> {
+//         PckCertsIn {
+//             enc_ppid,
+//             pce_id,
+//             api_key,
+//             api_version: self.api_version.clone(),
+//         }
+//     }
+// }
 
-impl<'inp> PckCertService<'inp> for PckCertApi {
-    fn build_input(
-        &'inp self,
-        encrypted_ppid: Option<&'inp EncPpid>,
-        pce_id: &'inp PceId,
-        cpu_svn: &'inp CpuSvn,
-        pce_isvsvn: PceIsvsvn,
-        qe_id: Option<&'inp QeId>,
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        PckCertIn {
-            encrypted_ppid,
-            pce_id,
-            cpu_svn,
-            pce_isvsvn,
-            qe_id,
-            api_key: &self.api_key,
-            api_version: self.api_version,
-        }
-    }
-}
+// impl PckCertService for PckCertApi {
+//     fn build_input<'inp>(
+//         &self,
+//         api_key: &'inp Option<String>,
+//         encrypted_ppid: Option<&'inp EncPpid>,
+//         pce_id: &'inp PceId,
+//         cpu_svn: &'inp CpuSvn,
+//         pce_isvsvn: PceIsvsvn,
+//         qe_id: Option<&'inp QeId>,
+//     ) -> <Self as ProvisioningServiceApi>::Input<'inp> {
+//         PckCertIn {
+//             encrypted_ppid,
+//             pce_id,
+//             cpu_svn,
+//             pce_isvsvn,
+//             qe_id,
+//             api_key,
+//             api_version: self.api_version,
+//         }
+//     }
+// }
 
 /// Implementation of pckcerts
 /// <https://api.portal.trustedservices.intel.com/documentation#pcs-certificates-v4>
-impl<'inp> ProvisioningServiceApi<'inp> for PckCertsApi {
-    type Input = PckCertsIn<'inp>;
+impl ProvisioningServiceApi for PckCertsApi {
+    type Input<'a> = PckCertsIn<'a>;
     type Output = PckCerts;
 
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let encrypted_ppid = input.enc_ppid.to_hex();
         let pce_id = input.pce_id.to_le_bytes().to_hex();
@@ -210,11 +225,11 @@ impl PckCertApi {
 
 /// Implementation of pckcert
 /// <https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-certificate-v4>
-impl<'inp> ProvisioningServiceApi<'inp> for PckCertApi {
-    type Input = PckCertIn<'inp>;
+impl ProvisioningServiceApi for PckCertApi {
+    type Input<'a> = PckCertIn<'a>;
     type Output = PckCert<Unverified>;
 
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let encrypted_ppid = input
             .encrypted_ppid
@@ -284,25 +299,25 @@ impl PckCrlApi {
     }
 }
 
-impl<'inp> PckCrlService<'inp> for PckCrlApi {
-    fn build_input(
-        &'inp self,
-        ca: DcapArtifactIssuer,
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        PckCrlIn {
-            api_version: self.api_version.clone(),
-            ca,
-        }
-    }
-}
+// impl PckCrlService for PckCrlApi {
+//     fn build_input(
+//         &self,
+//         ca: DcapArtifactIssuer,
+//     ) -> <Self as ProvisioningServiceApi>::Input<'_> {
+//         PckCrlIn {
+//             api_version: self.api_version.clone(),
+//             ca,
+//         }
+//     }
+// }
 
 /// Implementation of pckcrl
 /// See: <https://api.portal.trustedservices.intel.com/documentation#pcs-revocation-v4>
-impl<'inp> ProvisioningServiceApi<'inp> for PckCrlApi {
-    type Input = PckCrlIn;
+impl ProvisioningServiceApi for PckCrlApi {
+    type Input<'a> = PckCrlIn;
     type Output = PckCrl<Unverified>;
 
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let ca = match input.ca {
             DcapArtifactIssuer::PCKProcessorCA => "processor",
             DcapArtifactIssuer::PCKPlatformCA => "platform",
@@ -369,31 +384,31 @@ impl<T: PlatformType> TcbInfoApi<T> {
     }
 }
 
-impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> TcbInfoService<'inp, T>
-    for TcbInfoApi<T>
-{
-    fn build_input(
-        &'inp self,
-        fmspc: &'inp Fmspc,
-        tcb_evaluation_data_number: Option<u16>,
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        TcbInfoIn {
-            api_version: self.api_version.clone(),
-            fmspc,
-            tcb_evaluation_data_number,
-        }
-    }
-}
+// impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> TcbInfoService<T>
+//     for TcbInfoApi<T>
+// {
+//     fn build_input(
+//         &'inp self,
+//         fmspc: &'inp Fmspc,
+//         tcb_evaluation_data_number: Option<u16>,
+//     ) -> <Self as ProvisioningServiceApi>::Input<'_> {
+//         TcbInfoIn {
+//             api_version: self.api_version.clone(),
+//             fmspc,
+//             tcb_evaluation_data_number,
+//         }
+//     }
+// }
 
 // Implementation of Get TCB Info
 // <https://api.portal.trustedservices.intel.com/documentation#pcs-tcb-info-v4>>
-impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi<'inp>
+impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi
     for TcbInfoApi<T>
 {
-    type Input = TcbInfoIn<'inp>;
+    type Input<'a> = TcbInfoIn<'a>;
     type Output = TcbInfo<T>;
 
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let fmspc = input.fmspc.as_bytes().to_hex();
         let url = if let Some(evaluation_data_number) = input.tcb_evaluation_data_number {
@@ -468,25 +483,25 @@ impl QeIdApi {
     }
 }
 
-impl<'inp> QeIdService<'inp> for QeIdApi {
-    fn build_input(
-        &'inp self,
-        tcb_evaluation_data_number: Option<u16>,
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        QeIdIn {
-            api_version: self.api_version.clone(),
-            tcb_evaluation_data_number,
-        }
-    }
-}
+// impl QeIdService for QeIdApi {
+//     fn build_input(
+//         &self,
+//         tcb_evaluation_data_number: Option<u16>,
+//     ) -> <Self as ProvisioningServiceApi>::Input<'_> {
+//         QeIdIn {
+//             api_version: self.api_version.clone(),
+//             tcb_evaluation_data_number,
+//         }
+//     }
+// }
 
 /// Implementation of qe/identity
 /// <https://api.portal.trustedservices.intel.com/documentation#pcs-certificates-v://api.portal.trustedservices.intel.com/documentation#pcs-qe-identity-v4>
-impl<'inp> ProvisioningServiceApi<'inp> for QeIdApi {
-    type Input = QeIdIn;
+impl ProvisioningServiceApi for QeIdApi {
+    type Input<'a> = QeIdIn;
     type Output = QeIdentitySigned;
 
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let url = if let Some(tcb_evaluation_data_number) = input.tcb_evaluation_data_number {
             format!(
@@ -554,23 +569,23 @@ impl<T: PlatformTypeForTcbInfo> TcbEvaluationDataNumbersApi<T> {
     }
 }
 
-impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> TcbEvaluationDataNumbersService<'inp, T>
-    for TcbEvaluationDataNumbersApi<T>
-{
-    fn build_input(&self) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        TcbEvaluationDataNumbersIn
-    }
-}
+// impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> TcbEvaluationDataNumbersService<T>
+//     for TcbEvaluationDataNumbersApi<T>
+// {
+//     fn build_input(&self) -> <Self as ProvisioningServiceApi>::Input<'_> {
+//         TcbEvaluationDataNumbersIn
+//     }
+// }
 
 /// Implementation of TCB Evaluation Data Numbers endpoint
 /// <https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-retrieve-tcbevalnumbers-v4>
-impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi<'inp>
+impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi
     for TcbEvaluationDataNumbersApi<T>
 {
-    type Input = TcbEvaluationDataNumbersIn;
+    type Input<'a> = TcbEvaluationDataNumbersIn;
     type Output = RawTcbEvaluationDataNumbers<T>;
 
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let url = format!(
             "{}/{}/certification/v{}/tcbevaluationdatanumbers",
             self.base_url,
@@ -626,6 +641,11 @@ mod tests {
         WriteOptionsBuilder,
     };
 
+    use crate::PckCertIn;
+    use crate::PckCertsIn;
+    use crate::PckCrlIn;
+    use crate::QeIdIn;
+    use crate::TcbInfoIn;
     use crate::provisioning_client::{
         test_helpers, ProvisioningClientFuncSelector, IntelProvisioningClientBuilder, PcsVersion, ProvisioningClient,
     };
@@ -665,7 +685,7 @@ mod tests {
                 .iter()
             {
                 let pcks = client
-                    .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
+                    .pckcerts(&pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                     .unwrap();
                 assert_eq!(
                     test_helpers::get_cert_subject(pcks.ca_chain().last().unwrap()),
@@ -703,7 +723,7 @@ mod tests {
                 .iter()
             {
                 let pcks = client
-                    .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
+                    .pckcerts( &pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                     .unwrap();
 
                 // The cache should be populated after initial service call
@@ -714,10 +734,11 @@ mod tests {
 
                     let (cached_pcks, _) = {
                         let mut hasher = DefaultHasher::new();
-                        let input = client
-                            .pckcerts_service
-                            .pcs_service()
-                            .build_input(&pckid.enc_ppid, pckid.pce_id.clone());
+                        // let input = client
+                        //     .pckcerts_service
+                        //     .pcs_service()
+                        //     .build_input(&pckid.enc_ppid, pckid.pce_id.clone());
+                        let input = PckCertsIn { enc_ppid: &pckid.enc_ppid, pce_id: pckid.pce_id, api_key: &pcs_api_key(), api_version };
                         input.hash(&mut hasher);
 
                         cache
@@ -732,7 +753,7 @@ mod tests {
 
                 // Second service call should return value from cache
                 let pcks_from_service = client
-                    .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
+                    .pckcerts(&pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                     .unwrap();
 
                 assert_eq!(pcks, pcks_from_service);
@@ -746,7 +767,7 @@ mod tests {
         for api_version in [PcsVersion::V3, PcsVersion::V4] {
             let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            if api_version == PcsVersion::V3 {
+            // if api_version == PcsVersion::V3 {
                 if let Some(pcs_api_key) = pcs_api_key() {
                     intel_builder.set_api_key(pcs_api_key);
                 } else {
@@ -754,7 +775,7 @@ mod tests {
                     // So we no longer force to test it.
                     continue;
                 }
-            }
+            // }
             let client = intel_builder.build(reqwest_client());
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
                 .unwrap()
@@ -762,6 +783,7 @@ mod tests {
             {
                 let pck = client
                     .pckcert(
+                        &pcs_api_key(),
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
@@ -810,6 +832,7 @@ mod tests {
             {
                 let pck = client
                     .pckcert(
+                        &pcs_api_key(),
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
@@ -831,13 +854,14 @@ mod tests {
 
                     let (cached_pck, _) = {
                         let mut hasher = DefaultHasher::new();
-                        let input = client.pckcert_service.pcs_service().build_input(
-                            Some(&pckid.enc_ppid),
-                            &pckid.pce_id,
-                            &pckid.cpu_svn,
-                            pckid.pce_isvsvn,
-                            None,
-                        );
+                        // let input = client.pckcert_service.pcs_service().build_input(
+                        //     Some(&pckid.enc_ppid),
+                        //     &pckid.pce_id,
+                        //     &pckid.cpu_svn,
+                        //     pckid.pce_isvsvn,
+                        //     None,
+                        // );
+                        let input = PckCertIn { encrypted_ppid: Some(&pckid.enc_ppid), pce_id: &pckid.pce_id, cpu_svn: &pckid.cpu_svn, pce_isvsvn: pckid.pce_isvsvn, qe_id: None, api_version, api_key: &pcs_api_key() };
                         input.hash(&mut hasher);
 
                         cache
@@ -861,6 +885,7 @@ mod tests {
                 // Second service call should return value from cache
                 let pck_from_service = client
                     .pckcert(
+                        &pcs_api_key(),
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
@@ -903,7 +928,7 @@ mod tests {
                 .iter()
             {
                 let pckcerts = client
-                    .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
+                    .pckcerts(&pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                     .unwrap();
                 assert!(client
                     .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
@@ -962,7 +987,7 @@ mod tests {
             .iter()
         {
             let pckcerts = client
-                .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
+                .pckcerts(&pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                 .unwrap();
             let fmspc = pckcerts.fmspc().unwrap();
 
@@ -1011,7 +1036,7 @@ mod tests {
                 .iter()
             {
                 let pckcerts = client
-                    .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
+                    .pckcerts(&pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                     .unwrap();
                 let fmspc = pckcerts.fmspc().unwrap();
                 let tcb_info = client.sgx_tcbinfo(&fmspc, None).unwrap();
@@ -1024,10 +1049,11 @@ mod tests {
 
                     let (cached_tcb_info, _) = {
                         let mut hasher = DefaultHasher::new();
-                        let input = client
-                            .sgx_tcbinfo_service
-                            .pcs_service()
-                            .build_input(&fmspc, None);
+                        // let input = client
+                        //     .sgx_tcbinfo_service
+                        //     .pcs_service()
+                        //     .build_input(&fmspc, None);
+                        let input = TcbInfoIn { api_version, fmspc: &fmspc, tcb_evaluation_data_number: None };
                         input.hash(&mut hasher);
 
                         cache
@@ -1107,7 +1133,8 @@ mod tests {
 
                     let (cached_pckcrl, _) = {
                         let mut hasher = DefaultHasher::new();
-                        let input = client.pckcrl_service.pcs_service().build_input(ca);
+                        // let input = client.pckcrl_service.pcs_service().build_input(ca);
+                        let input = PckCrlIn { api_version, ca };
                         input.hash(&mut hasher);
 
                         cache
@@ -1174,7 +1201,8 @@ mod tests {
 
                 let (cached_qeid, _) = {
                     let mut hasher = DefaultHasher::new();
-                    let input = client.qeid_service.pcs_service().build_input(None);
+                    // let input = client.qeid_service.pcs_service().build_input(None);
+                    let input = QeIdIn{ api_version, tcb_evaluation_data_number: None };
                     input.hash(&mut hasher);
 
                     cache

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -16,16 +16,14 @@ use pcs::{
     CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PckID, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, TcbInfo, Unverified
 };
 use rustc_serialize::hex::ToHex;
-use std::marker::PhantomData;
 use std::time::Duration;
 
 use super::common::*;
 use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PckCertsIn,
-    PckCrlIn, PckCrlService, PcsVersion, ProvisioningServiceApi, QeIdService, StatusCode,
-    TcbEvaluationDataNumbersService, TcbInfoService,
+    PckCrlIn, PckCrlService, PcsVersion, ProvisioningServiceApi, StatusCode,
 };
-use crate::provisioning_client::{BackoffService, CachedService, PcsService};
+use crate::provisioning_client::{BackoffService, CachedService};
 use crate::{Error, ProvisioningClient};
 
 pub(crate) const INTEL_BASE_URL: &'static str = "https://api.trustedservices.intel.com";
@@ -57,29 +55,14 @@ impl IntelProvisioningClientBuilder {
     }
 
     pub fn build<F: for<'a> Fetcher<'a>>(&self, fetcher: F) -> IntelPCSClient<F> {
-        let pckcerts_service = PckCertsService;
-        let pckcert_service = PckCertService;
-        let pckcrl_service = PckCrlService;
-        let qeid = QeIdService;
-        let sgx_tcbinfo = TcbInfoService::<platform::SGX> {_type: PhantomData};
-        let tdx_tcbinfo = TcbInfoService::<platform::TDX> {_type: PhantomData};
-        let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::SGX> { _type: PhantomData };
-        let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::TDX> { _type: PhantomData };
-
         let client = self.client_builder.build(
             INTEL_BASE_URL,
             self.api_version,
-            qeid,
-            sgx_tcbinfo,
-            tdx_tcbinfo,
-            sgx_evaluation_data_numbers,
-            tdx_evaluation_data_numbers,
             fetcher,
         );
         IntelPCSClient {
             pckcerts_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(pckcerts_service),
                     self.client_builder.retry_timeout.clone(),
                 ),
                 self.client_builder.cache_capacity.clone(),
@@ -87,7 +70,6 @@ impl IntelProvisioningClientBuilder {
             ),
             pckcert_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(pckcert_service),
                     self.client_builder.retry_timeout.clone(),
                 ),
                 self.client_builder.cache_capacity.clone(),
@@ -95,7 +77,6 @@ impl IntelProvisioningClientBuilder {
             ),
             pckcrl_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(pckcrl_service),
                     self.client_builder.retry_timeout.clone(),
                 ),
                 self.client_builder.cache_capacity.clone(),
@@ -189,7 +170,7 @@ impl ProvisioningServiceApi for PckCertsService {
     type Input<'a> = PckCertsIn<'a>;
     type Output = PckCerts;
 
-    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let encrypted_ppid = input.enc_ppid.to_hex();
         let pce_id = input.pce_id.to_le_bytes().to_hex();
@@ -205,7 +186,7 @@ impl ProvisioningServiceApi for PckCertsService {
         Ok((url, headers))
     }
 
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+    fn validate_response(status_code: StatusCode) -> Result<(), Error> {
         match status_code {
             StatusCode::Ok => Ok(()),
             StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
@@ -234,7 +215,6 @@ impl ProvisioningServiceApi for PckCertsService {
     }
 
     fn parse_response(
-        &self,
         response_body: String,
         response_headers: Vec<(String, String)>,
         _api_version: PcsVersion,

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -29,7 +29,7 @@ use super::{
     TcbEvaluationDataNumbersIn, TcbEvaluationDataNumbersService, TcbInfoIn, TcbInfoService,
     WithApiVersion,
 };
-use crate::provisioning_client::PlatformApiTag;
+use crate::provisioning_client::{PCSPckCrlService, PlatformApiTag};
 use crate::Error;
 
 pub(crate) const INTEL_BASE_URL: &'static str = "https://api.trustedservices.intel.com";
@@ -60,28 +60,18 @@ impl IntelProvisioningClientBuilder {
         self
     }
 
-    pub fn build<F: for<'a> Fetcher<'a>>(self, fetcher: F) -> Client<F> {
-        // let pck_certs = PckCertsApi::new(self.api_version.clone(), self.api_key.clone());
-        // let pck_certs = PckCertsService{};
-        // let pck_cert = PckCertApi::new(self.api_version.clone(), self.api_key.clone());
-        // let pck_crl = PckCrlApi::new(self.api_version.clone());
-        // let qeid = QeIdApi::new(self.api_version.clone());
-        // let sgx_tcbinfo = TcbInfoApi::new(self.api_version.clone());
-        // let tdx_tcbinfo = TcbInfoApi::new(self.api_version.clone());
-        // let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
-        // let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
-
-        let pck_certs = PckCertsService;
+    pub fn build<F: for<'a> Fetcher<'a>, PC: PckCrlService>(self, fetcher: F) -> Client<F, PC> {
         let pck_certs = PckCertsService;
         let pck_cert = PckCertService;
-        let pck_crl = PckCrlService;
+        let pck_crl = PC::new();
         let qeid = QeIdService;
         let sgx_tcbinfo = TcbInfoService::<platform::SGX> {_type: PhantomData};
         let tdx_tcbinfo = TcbInfoService::<platform::TDX> {_type: PhantomData};
-        let sgx_evaluation_data_numbers: TcbEvaluationDataNumbersService<SGX> = TcbEvaluationDataNumbersService::<platform::SGX> { _type: PhantomData, base_url: INTEL_BASE_URL.to_owned() };
-        let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::TDX> { _type: PhantomData, base_url: INTEL_BASE_URL.to_owned() };
+        let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::SGX> { _type: PhantomData };
+        let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::TDX> { _type: PhantomData };
 
         self.client_builder.build(
+            INTEL_BASE_URL,
             self.api_version,
             pck_certs,
             pck_cert,
@@ -96,532 +86,13 @@ impl IntelProvisioningClientBuilder {
     }
 }
 
-pub struct PckCertsApi {
-    api_key: Option<String>,
-    api_version: PcsVersion,
-}
-
-impl PckCertsApi {
-    pub(crate) fn new(api_version: PcsVersion, api_key: Option<String>) -> PckCertsApi {
-        PckCertsApi {
-            api_version,
-            api_key,
-        }
+impl PckCrlService for PCSPckCrlService {
+    fn build_input(&self, api_version: PcsVersion, ca: DcapArtifactIssuer) -> <Self as ProvisioningServiceApi>::Input<'_> {
+        PckCrlIn { api_version, ca }
     }
-}
-
-// impl PckCertsService for PckCertsApi {
-//     fn build_input<'inp>(
-//         &self,
-//         api_key: &'inp Option<String>,
-//         enc_ppid: &'inp EncPpid,
-//         pce_id: PceId,
-//     ) -> <Self as ProvisioningServiceApi>::Input<'inp> {
-//         PckCertsIn {
-//             enc_ppid,
-//             pce_id,
-//             api_key,
-//             api_version: self.api_version.clone(),
-//         }
-//     }
-// }
-
-// impl PckCertService for PckCertApi {
-//     fn build_input<'inp>(
-//         &self,
-//         api_key: &'inp Option<String>,
-//         encrypted_ppid: Option<&'inp EncPpid>,
-//         pce_id: &'inp PceId,
-//         cpu_svn: &'inp CpuSvn,
-//         pce_isvsvn: PceIsvsvn,
-//         qe_id: Option<&'inp QeId>,
-//     ) -> <Self as ProvisioningServiceApi>::Input<'inp> {
-//         PckCertIn {
-//             encrypted_ppid,
-//             pce_id,
-//             cpu_svn,
-//             pce_isvsvn,
-//             qe_id,
-//             api_key,
-//             api_version: self.api_version,
-//         }
-//     }
-// }
-
-/// Implementation of pckcerts
-/// <https://api.portal.trustedservices.intel.com/documentation#pcs-certificates-v4>
-impl ProvisioningServiceApi for PckCertsApi {
-    type Input<'a> = PckCertsIn<'a>;
-    type Output = PckCerts;
-
-    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
-        let api_version = input.api_version as u8;
-        let encrypted_ppid = input.enc_ppid.to_hex();
-        let pce_id = input.pce_id.to_le_bytes().to_hex();
-        let url = format!(
-            "{}/sgx/certification/v{}/pckcerts?encrypted_ppid={}&pceid={}",
-            INTEL_BASE_URL, api_version, encrypted_ppid, pce_id,
-        );
-        let headers = if let Some(api_key) = &input.api_key {
-            vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
-        } else {
-            Vec::new()
-        };
-        Ok((url, headers))
-    }
-
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
-        match status_code {
-            StatusCode::Ok => Ok(()),
-            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
-            StatusCode::Unauthorized => Err(Error::PCSError(
-                status_code,
-                "Failed to authenticate or authorize the request (check your PCS key)",
-            )),
-            StatusCode::NotFound => Err(Error::PCSError(
-                status_code,
-                "Cannot find the requested certificate",
-            )),
-            StatusCode::TooManyRequests => Err(Error::PCSError(status_code, "Too many requests")),
-            StatusCode::InternalServerError => Err(Error::PCSError(
-                status_code,
-                "PCS suffered from an internal server error",
-            )),
-            StatusCode::ServiceUnavailable => Err(Error::PCSError(
-                status_code,
-                "PCS is temporarily unavailable",
-            )),
-            _ => Err(Error::PCSError(
-                status_code,
-                "Unexpected response from PCS server",
-            )),
-        }
-    }
-
-    fn parse_response(
-        &self,
-        response_body: String,
-        response_headers: Vec<(String, String)>,
-        _api_version: PcsVersion,
-    ) -> Result<Self::Output, Error> {
-        let ca_chain = parse_issuer_header(&response_headers, PCK_CERTIFICATE_ISSUER_CHAIN_HEADER)?;
-        PckCerts::parse(&response_body, ca_chain).map_err(|e| Error::OfflineAttestationError(e))
-    }
-}
-
-pub struct PckCertApi {
-    api_key: Option<String>,
-    api_version: PcsVersion,
-}
-
-impl PckCertApi {
-    pub(crate) fn new(api_version: PcsVersion, api_key: Option<String>) -> PckCertApi {
-        PckCertApi {
-            api_version,
-            api_key,
-        }
-    }
-}
-
-/// Implementation of pckcert
-/// <https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-certificate-v4>
-impl ProvisioningServiceApi for PckCertApi {
-    type Input<'a> = PckCertIn<'a>;
-    type Output = PckCert<Unverified>;
-
-    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
-        let api_version = input.api_version as u8;
-        let encrypted_ppid = input
-            .encrypted_ppid
-            .ok_or(Error::NoEncPPID)
-            .map(|e_ppid| e_ppid.to_hex())?;
-        let cpusvn = input.cpu_svn.to_hex();
-        let pce_isvsvn = input.pce_isvsvn.to_le_bytes().to_hex();
-        let pce_id = input.pce_id.to_le_bytes().to_hex();
-        let url = format!(
-            "{}/sgx/certification/v{}/pckcert?encrypted_ppid={}&cpusvn={}&pcesvn={}&pceid={}",
-            INTEL_BASE_URL, api_version, encrypted_ppid, cpusvn, pce_isvsvn, pce_id,
-        );
-        let headers = if let Some(api_key) = input.api_key {
-            vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
-        } else {
-            Vec::new()
-        };
-        Ok((url, headers))
-    }
-
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
-        match status_code {
-            StatusCode::Ok => Ok(()),
-            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
-            StatusCode::Unauthorized => Err(Error::PCSError(
-                status_code,
-                "Failed to authenticate or authorize the request (check your PCS key)",
-            )),
-            StatusCode::NotFound => Err(Error::PCSError(
-                status_code,
-                "Cannot find the requested certificate",
-            )),
-            StatusCode::TooManyRequests => Err(Error::PCSError(status_code, "Too many requests")),
-            StatusCode::InternalServerError => Err(Error::PCSError(
-                status_code,
-                "PCS suffered from an internal server error",
-            )),
-            StatusCode::ServiceUnavailable => Err(Error::PCSError(
-                status_code,
-                "PCS is temporarily unavailable",
-            )),
-            _ => Err(Error::PCSError(
-                status_code,
-                "Unexpected response from PCS server",
-            )),
-        }
-    }
-
-    fn parse_response(
-        &self,
-        response_body: String,
-        response_headers: Vec<(String, String)>,
-        _api_version: PcsVersion,
-    ) -> Result<Self::Output, Error> {
-        let ca_chain = parse_issuer_header(&response_headers, PCK_CERTIFICATE_ISSUER_CHAIN_HEADER)?;
-        Ok(PckCert::new(response_body, ca_chain))
-    }
-}
-
-pub struct PckCrlApi {
-    api_version: PcsVersion,
-}
-
-impl PckCrlApi {
-    pub fn new(api_version: PcsVersion) -> Self {
-        PckCrlApi { api_version }
-    }
-}
-
-// impl PckCrlService for PckCrlApi {
-//     fn build_input(
-//         &self,
-//         ca: DcapArtifactIssuer,
-//     ) -> <Self as ProvisioningServiceApi>::Input<'_> {
-//         PckCrlIn {
-//             api_version: self.api_version.clone(),
-//             ca,
-//         }
-//     }
-// }
-
-/// Implementation of pckcrl
-/// See: <https://api.portal.trustedservices.intel.com/documentation#pcs-revocation-v4>
-impl ProvisioningServiceApi for PckCrlApi {
-    type Input<'a> = PckCrlIn;
-    type Output = PckCrl<Unverified>;
-
-    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
-        let ca = match input.ca {
-            DcapArtifactIssuer::PCKProcessorCA => "processor",
-            DcapArtifactIssuer::PCKPlatformCA => "platform",
-            DcapArtifactIssuer::SGXRootCA => {
-                return Err(Error::PCSError(
-                    StatusCode::BadRequest,
-                    "Invalid ca parameter",
-                ));
-            }
-        };
-        let url = format!(
-            "{}/sgx/certification/v{}/pckcrl?ca={}&encoding=pem",
-            INTEL_BASE_URL, input.api_version as u8, ca,
-        );
-        Ok((url, Vec::new()))
-    }
-
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
-        match &status_code {
-            StatusCode::Ok => Ok(()),
-            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
-            StatusCode::Unauthorized => Err(Error::PCSError(
-                status_code,
-                "Failed to authenticate or authorize the request (check your PCS key)",
-            )),
-            StatusCode::InternalServerError => Err(Error::PCSError(
-                status_code,
-                "PCS suffered from an internal server error",
-            )),
-            StatusCode::ServiceUnavailable => Err(Error::PCSError(
-                status_code,
-                "PCS is temporarily unavailable",
-            )),
-            __ => Err(Error::PCSError(
-                status_code,
-                "Unexpected response from PCS server",
-            )),
-        }
-    }
-
-    fn parse_response(
-        &self,
-        response_body: String,
-        response_headers: Vec<(String, String)>,
-        _api_version: PcsVersion,
-    ) -> Result<Self::Output, Error> {
-        let ca_chain = parse_issuer_header(&response_headers, PCK_CRL_ISSUER_CHAIN_HEADER)?;
-        let crl = PckCrl::new(response_body, ca_chain)?;
-        Ok(crl)
-    }
-}
-
-pub struct TcbInfoApi<T> {
-    api_version: PcsVersion,
-    _type: PhantomData<T>,
-}
-
-impl<T: PlatformType> TcbInfoApi<T> {
-    pub fn new(api_version: PcsVersion) -> Self {
-        TcbInfoApi {
-            api_version,
-            _type: PhantomData,
-        }
-    }
-}
-
-// impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> TcbInfoService<T>
-//     for TcbInfoApi<T>
-// {
-//     fn build_input(
-//         &'inp self,
-//         fmspc: &'inp Fmspc,
-//         tcb_evaluation_data_number: Option<u16>,
-//     ) -> <Self as ProvisioningServiceApi>::Input<'_> {
-//         TcbInfoIn {
-//             api_version: self.api_version.clone(),
-//             fmspc,
-//             tcb_evaluation_data_number,
-//         }
-//     }
-// }
-
-// Implementation of Get TCB Info
-// <https://api.portal.trustedservices.intel.com/documentation#pcs-tcb-info-v4>>
-impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi
-    for TcbInfoApi<T>
-{
-    type Input<'a> = TcbInfoIn<'a>;
-    type Output = TcbInfo<T>;
-
-    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
-        let api_version = input.api_version as u8;
-        let fmspc = input.fmspc.as_bytes().to_hex();
-        let url = if let Some(evaluation_data_number) = input.tcb_evaluation_data_number {
-            format!(
-                "{}/{}/certification/v{}/tcb?fmspc={}&tcbEvaluationDataNumber={}",
-                INTEL_BASE_URL,
-                T::tag(),
-                api_version,
-                fmspc,
-                evaluation_data_number
-            )
-        } else {
-            format!(
-                "{}/{}/certification/v{}/tcb?fmspc={}&update=early",
-                INTEL_BASE_URL,
-                T::tag(),
-                api_version,
-                fmspc,
-            )
-        };
-        Ok((url, Vec::new()))
-    }
-
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
-        match &status_code {
-            StatusCode::Ok => Ok(()),
-            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
-            StatusCode::Unauthorized => Err(Error::PCSError(
-                status_code,
-                "Failed to authenticate or authorize the request (check your PCS key)",
-            )),
-            StatusCode::NotFound => Err(Error::PCSError(status_code, "TCB info cannot be found")),
-            StatusCode::Gone => Err(Error::PCSError(status_code, "TCB info no longer available")),
-            StatusCode::InternalServerError => Err(Error::PCSError(
-                status_code,
-                "PCS suffered from an internal server error",
-            )),
-            StatusCode::ServiceUnavailable => Err(Error::PCSError(
-                status_code,
-                "PCS is temporarily unavailable",
-            )),
-            __ => Err(Error::PCSError(
-                status_code,
-                "Unexpected response from PCS server",
-            )),
-        }
-    }
-
-    fn parse_response(
-        &self,
-        response_body: String,
-        response_headers: Vec<(String, String)>,
-        api_version: PcsVersion,
-    ) -> Result<Self::Output, Error> {
-        let key = match api_version {
-            PcsVersion::V3 => TCB_INFO_ISSUER_CHAIN_HEADER_V3,
-            PcsVersion::V4 => TCB_INFO_ISSUER_CHAIN_HEADER_V4,
-        };
-        let ca_chain = parse_issuer_header(&response_headers, key)?;
-        let tcb_info = TcbInfo::parse(&response_body, ca_chain)?;
-        Ok(tcb_info)
-    }
-}
-
-pub struct QeIdApi {
-    api_version: PcsVersion,
-}
-
-impl QeIdApi {
-    pub fn new(api_version: PcsVersion) -> Self {
-        QeIdApi { api_version }
-    }
-}
-
-// impl QeIdService for QeIdApi {
-//     fn build_input(
-//         &self,
-//         tcb_evaluation_data_number: Option<u16>,
-//     ) -> <Self as ProvisioningServiceApi>::Input<'_> {
-//         QeIdIn {
-//             api_version: self.api_version.clone(),
-//             tcb_evaluation_data_number,
-//         }
-//     }
-// }
-
-/// Implementation of qe/identity
-/// <https://api.portal.trustedservices.intel.com/documentation#pcs-certificates-v://api.portal.trustedservices.intel.com/documentation#pcs-qe-identity-v4>
-impl ProvisioningServiceApi for QeIdApi {
-    type Input<'a> = QeIdIn;
-    type Output = QeIdentitySigned;
-
-    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
-        let api_version = input.api_version as u8;
-        let url = if let Some(tcb_evaluation_data_number) = input.tcb_evaluation_data_number {
-            format!(
-                "{}/sgx/certification/v{}/qe/identity?tcbEvaluationDataNumber={}",
-                INTEL_BASE_URL, api_version, tcb_evaluation_data_number
-            )
-        } else {
-            format!(
-                "{}/sgx/certification/v{}/qe/identity?update=early",
-                INTEL_BASE_URL, api_version,
-            )
-        };
-        Ok((url, Vec::new()))
-    }
-
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
-        match &status_code {
-            StatusCode::Ok => Ok(()),
-            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
-            StatusCode::Unauthorized => Err(Error::PCSError(
-                status_code,
-                "Failed to authenticate or authorize the request (check your PCS key)",
-            )),
-            StatusCode::NotFound => {
-                Err(Error::PCSError(status_code, "QE identity Cannot be found"))
-            }
-            StatusCode::InternalServerError => Err(Error::PCSError(
-                status_code,
-                "PCS suffered from an internal server error",
-            )),
-            StatusCode::ServiceUnavailable => Err(Error::PCSError(
-                status_code,
-                "PCS is temporarily unavailable",
-            )),
-            __ => Err(Error::PCSError(
-                status_code,
-                "Unexpected response from PCS server",
-            )),
-        }
-    }
-
-    fn parse_response(
-        &self,
-        response_body: String,
-        response_headers: Vec<(String, String)>,
-        _api_version: PcsVersion,
-    ) -> Result<Self::Output, Error> {
-        let ca_chain = parse_issuer_header(&response_headers, ENCLAVE_ID_ISSUER_CHAIN_HEADER)?;
-        let id = QeIdentitySigned::parse(&response_body, ca_chain)?;
-        Ok(id)
-    }
-}
-
-pub struct TcbEvaluationDataNumbersApi<T: PlatformTypeForTcbInfo> {
-    base_url: Cow<'static, str>,
-    _platform: PhantomData<T>,
-}
-
-impl<T: PlatformTypeForTcbInfo> TcbEvaluationDataNumbersApi<T> {
-    pub fn new(base_url: Cow<'static, str>) -> Self {
-        TcbEvaluationDataNumbersApi {
-            base_url,
-            _platform: PhantomData,
-        }
-    }
-}
-
-// impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> TcbEvaluationDataNumbersService<T>
-//     for TcbEvaluationDataNumbersApi<T>
-// {
-//     fn build_input(&self) -> <Self as ProvisioningServiceApi>::Input<'_> {
-//         TcbEvaluationDataNumbersIn
-//     }
-// }
-
-/// Implementation of TCB Evaluation Data Numbers endpoint
-/// <https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-retrieve-tcbevalnumbers-v4>
-impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi
-    for TcbEvaluationDataNumbersApi<T>
-{
-    type Input<'a> = TcbEvaluationDataNumbersIn;
-    type Output = RawTcbEvaluationDataNumbers<T>;
-
-    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
-        let url = format!(
-            "{}/{}/certification/v{}/tcbevaluationdatanumbers",
-            self.base_url,
-            T::tag(),
-            input.api_version() as u8,
-        );
-        Ok((url, Vec::new()))
-    }
-
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
-        match &status_code {
-            StatusCode::Ok => Ok(()),
-            StatusCode::InternalServerError => Err(Error::PCSError(
-                status_code,
-                "PCS suffered from an internal server error",
-            )),
-            StatusCode::ServiceUnavailable => Err(Error::PCSError(
-                status_code,
-                "PCS is temporarily unavailable",
-            )),
-            __ => Err(Error::PCSError(
-                status_code,
-                "Unexpected response from PCS server",
-            )),
-        }
-    }
-
-    fn parse_response(
-        &self,
-        response_body: String,
-        response_headers: Vec<(String, String)>,
-        _api_version: PcsVersion,
-    ) -> Result<Self::Output, Error> {
-        let ca_chain =
-            parse_issuer_header(&response_headers, TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN)?;
-        RawTcbEvaluationDataNumbers::parse(&response_body, ca_chain).map_err(|e| e.into())
+    
+    fn new() -> Self {
+        Self
     }
 }
 
@@ -641,6 +112,7 @@ mod tests {
         WriteOptionsBuilder,
     };
 
+    use crate::PCSPckCrlService;
     use crate::PckCertIn;
     use crate::PckCertsIn;
     use crate::PckCrlIn;
@@ -678,7 +150,7 @@ mod tests {
                     continue;
                 }
             }
-            let client = intel_builder.build(reqwest_client());
+            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
 
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
                 .unwrap()
@@ -716,7 +188,7 @@ mod tests {
                     continue;
                 }
             }
-            let client = intel_builder.build(reqwest_client());
+            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
 
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
                 .unwrap()
@@ -734,10 +206,6 @@ mod tests {
 
                     let (cached_pcks, _) = {
                         let mut hasher = DefaultHasher::new();
-                        // let input = client
-                        //     .pckcerts_service
-                        //     .pcs_service()
-                        //     .build_input(&pckid.enc_ppid, pckid.pce_id.clone());
                         let input = PckCertsIn { enc_ppid: &pckid.enc_ppid, pce_id: pckid.pce_id, api_key: &pcs_api_key(), api_version };
                         input.hash(&mut hasher);
 
@@ -767,7 +235,7 @@ mod tests {
         for api_version in [PcsVersion::V3, PcsVersion::V4] {
             let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            // if api_version == PcsVersion::V3 {
+            if api_version == PcsVersion::V3 {
                 if let Some(pcs_api_key) = pcs_api_key() {
                     intel_builder.set_api_key(pcs_api_key);
                 } else {
@@ -775,8 +243,8 @@ mod tests {
                     // So we no longer force to test it.
                     continue;
                 }
-            // }
-            let client = intel_builder.build(reqwest_client());
+            }
+            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
                 .unwrap()
                 .iter()
@@ -815,7 +283,7 @@ mod tests {
                     continue;
                 }
             }
-            let client = intel_builder.build(reqwest_client());
+            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
             let crl_processor = client
                 .pckcrl(DcapArtifactIssuer::PCKProcessorCA)
                 .unwrap()
@@ -854,13 +322,6 @@ mod tests {
 
                     let (cached_pck, _) = {
                         let mut hasher = DefaultHasher::new();
-                        // let input = client.pckcert_service.pcs_service().build_input(
-                        //     Some(&pckid.enc_ppid),
-                        //     &pckid.pce_id,
-                        //     &pckid.cpu_svn,
-                        //     pckid.pce_isvsvn,
-                        //     None,
-                        // );
                         let input = PckCertIn { encrypted_ppid: Some(&pckid.enc_ppid), pce_id: &pckid.pce_id, cpu_svn: &pckid.cpu_svn, pce_isvsvn: pckid.pce_isvsvn, qe_id: None, api_version, api_key: &pcs_api_key() };
                         input.hash(&mut hasher);
 
@@ -922,7 +383,7 @@ mod tests {
                     continue;
                 }
             }
-            let client = intel_builder.build(reqwest_client());
+            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
                 .unwrap()
                 .iter()
@@ -946,7 +407,7 @@ mod tests {
     pub fn tcb_info_tdx() {
         let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
             .set_retry_timeout(TIME_RETRY_TIMEOUT);
-        let client = intel_builder.build(reqwest_client());
+        let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
         let root_ca = include_bytes!("../../tests/data/root_SGX_CA_der.cert");
         let root_cas = [&root_ca[..]];
 
@@ -981,7 +442,7 @@ mod tests {
     pub fn tcb_info_with_evaluation_data_number() {
         let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
             .set_retry_timeout(TIME_RETRY_TIMEOUT);
-        let client = intel_builder.build(reqwest_client());
+        let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
         for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
             .unwrap()
             .iter()
@@ -1030,7 +491,7 @@ mod tests {
                     continue;
                 }
             }
-            let client = intel_builder.build(reqwest_client());
+            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
                 .unwrap()
                 .iter()
@@ -1049,10 +510,6 @@ mod tests {
 
                     let (cached_tcb_info, _) = {
                         let mut hasher = DefaultHasher::new();
-                        // let input = client
-                        //     .sgx_tcbinfo_service
-                        //     .pcs_service()
-                        //     .build_input(&fmspc, None);
                         let input = TcbInfoIn { api_version, fmspc: &fmspc, tcb_evaluation_data_number: None };
                         input.hash(&mut hasher);
 
@@ -1091,7 +548,7 @@ mod tests {
                         continue;
                     }
                 }
-                let client = intel_builder.build(reqwest_client());
+                let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
                 assert!(client
                     .pckcrl(ca)
                     .and_then(|crl| {
@@ -1122,7 +579,7 @@ mod tests {
                         continue;
                     }
                 }
-                let client = intel_builder.build(reqwest_client());
+                let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
                 let pckcrl = client.pckcrl(ca).unwrap();
 
                 // The cache should be populated after initial service call
@@ -1133,7 +590,6 @@ mod tests {
 
                     let (cached_pckcrl, _) = {
                         let mut hasher = DefaultHasher::new();
-                        // let input = client.pckcrl_service.pcs_service().build_input(ca);
                         let input = PckCrlIn { api_version, ca };
                         input.hash(&mut hasher);
 
@@ -1168,7 +624,7 @@ mod tests {
                     continue;
                 }
             }
-            let client = intel_builder.build(reqwest_client());
+            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
             let qe_id = client.qe_identity(None).unwrap();
             assert!(qe_id
                 .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
@@ -1190,7 +646,7 @@ mod tests {
                     continue;
                 }
             }
-            let client = intel_builder.build(reqwest_client());
+            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
             let qe_id = client.qe_identity(None).unwrap();
 
             // The cache should be populated after initial service call
@@ -1201,7 +657,6 @@ mod tests {
 
                 let (cached_qeid, _) = {
                     let mut hasher = DefaultHasher::new();
-                    // let input = client.qeid_service.pcs_service().build_input(None);
                     let input = QeIdIn{ api_version, tcb_evaluation_data_number: None };
                     input.hash(&mut hasher);
 
@@ -1226,7 +681,7 @@ mod tests {
         for api_version in [PcsVersion::V3, PcsVersion::V4] {
             let intel_builder = IntelProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            let client = intel_builder.build(reqwest_client());
+            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
             let fmspc = Fmspc::try_from("90806f000000").unwrap();
             assert_matches!(client.qe_identity(Some(15)), Err(Error::PCSError(StatusCode::Gone, _)));
             assert_matches!(client.sgx_tcbinfo(&fmspc, Some(15)), Err(Error::PCSError(StatusCode::Gone, _)));
@@ -1241,7 +696,7 @@ mod tests {
         let root_cas = [&root_ca[..]];
         let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
             .set_retry_timeout(TIME_RETRY_TIMEOUT);
-        let client = intel_builder.build(reqwest_client());
+        let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
         let eval_numbers = T::get_tcb_evaluation_data_numbers(&client).unwrap();
 
         let eval_numbers2 = serde_json::ser::to_vec(&eval_numbers)

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -11,24 +11,21 @@
 //! - <https://api.portal.trustedservices.intel.com/provisioning-certification>
 //! - <https://download.01.org/intel-sgx/dcap-1.1/linux/docs/Intel_SGX_PCK_Certificate_CRL_Spec-1.1.pdf>
 
-use pcs::platform::{self, SGX};
+use pcs::platform;
 use pcs::{
-    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl,
-    PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers,
-    TcbInfo, Unverified,
+    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PckID, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, TcbInfo, Unverified
 };
 use rustc_serialize::hex::ToHex;
-use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::time::Duration;
 
 use super::common::*;
 use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PckCertsIn,
-    PckCrlIn, PckCrlService, PcsVersion, ProvisioningServiceApi, QeIdIn, QeIdService, StatusCode,
-    TcbEvaluationDataNumbersService, TcbInfoIn, TcbInfoService,
+    PckCrlIn, PckCrlService, PcsVersion, ProvisioningServiceApi, QeIdService, StatusCode,
+    TcbEvaluationDataNumbersService, TcbInfoService,
 };
-use crate::provisioning_client::{BackoffService, CachedService, PcsService, PlatformApiTag};
+use crate::provisioning_client::{BackoffService, CachedService, PcsService};
 use crate::{Error, ProvisioningClient};
 
 pub(crate) const INTEL_BASE_URL: &'static str = "https://api.trustedservices.intel.com";
@@ -72,9 +69,6 @@ impl IntelProvisioningClientBuilder {
         let client = self.client_builder.build(
             INTEL_BASE_URL,
             self.api_version,
-            // pck_certs,
-            // pck_cert,
-            // pck_crl,
             qeid,
             sgx_tcbinfo,
             tdx_tcbinfo,
@@ -120,8 +114,8 @@ pub struct IntelPCSClient<F: for<'a> Fetcher<'a>> {
 }
 
 impl<F: for<'a> Fetcher<'a>> IntelPCSClient<F> {
-    pub fn pckcerts(&self, api_key: &Option<String>, encrypted_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error> {
-        let input = PckCertsIn { enc_ppid: encrypted_ppid, pce_id, api_key, api_version: self.client.api_version };
+    pub fn pckcerts(&self, api_key: Option<String>, encrypted_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error> {
+        let input = PckCertsIn { enc_ppid: encrypted_ppid, pce_id, api_key: &api_key, api_version: self.client.api_version };
         self.pckcerts_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
     }
 
@@ -138,29 +132,55 @@ impl<F: for<'a> Fetcher<'a>> IntelPCSClient<F> {
         self.pckcert_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
     }
 
-    pub fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl<Unverified>, Error> {
-        let input = PckCrlIn { api_version: self.client.api_version, ca };
-        self.pckcrl_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
-    }
-
-    pub fn qe_identity(&self, evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error> {
-        self.client.qe_identity(evaluation_data_number)
-    }
-
-    pub fn sgx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
-        self.client.sgx_tcbinfo(fmspc, evaluation_data_number)
-    }
-
     pub fn tdx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
         self.client.tdx_tcbinfo(fmspc, evaluation_data_number)
     }
 
-    pub fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
+    pub fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
+        self.client.tdx_tcb_evaluation_data_numbers()
+    }
+}
+
+impl<F: for<'a> Fetcher<'a>> ProvisioningClient for IntelPCSClient<F> {
+    fn pckcert(
+        &self,
+        api_key: &Option<String>,
+        encrypted_ppid: Option<&EncPpid>,
+        pce_id: &PceId,
+        cpu_svn: &CpuSvn,
+        pce_isvsvn: PceIsvsvn,
+        qe_id: Option<&QeId>,
+    ) -> Result<PckCert<Unverified>, Error> {
+        self.client.pckcert(api_key, encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id)
+    }
+
+    fn pckcerts(&self, pck_id: &PckID) -> Result<PckCerts, Error> {
+        self.pckcerts(None, &pck_id.enc_ppid, pck_id.pce_id)
+    }
+
+    fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl<Unverified>, Error> {
+        let input = PckCrlIn { api_version: self.client.api_version, ca };
+        self.pckcrl_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
+    }
+
+    fn sgx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
+        self.client.sgx_tcbinfo(fmspc, evaluation_data_number)
+    }
+
+    fn tdx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
+        todo!()
+    }
+
+    fn qe_identity(&self, evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error> {
+        self.client.qe_identity(evaluation_data_number)
+    }
+
+    fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
         self.client.sgx_tcb_evaluation_data_numbers()
     }
 
-    pub fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
-        self.client.tdx_tcb_evaluation_data_numbers()
+    fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
+        todo!()
     }
 }
 
@@ -286,7 +306,7 @@ mod tests {
                 .iter()
             {
                 let pcks = client
-                    .pckcerts(&pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
+                    .pckcerts(pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                     .unwrap();
                 assert_eq!(
                     test_helpers::get_cert_subject(pcks.ca_chain().last().unwrap()),
@@ -324,7 +344,7 @@ mod tests {
                 .iter()
             {
                 let pcks = client
-                    .pckcerts( &pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
+                    .pckcerts( pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                     .unwrap();
 
                 // The cache should be populated after initial service call
@@ -350,7 +370,7 @@ mod tests {
 
                 // Second service call should return value from cache
                 let pcks_from_service = client
-                    .pckcerts(&pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
+                    .pckcerts(pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                     .unwrap();
 
                 assert_eq!(pcks, pcks_from_service);
@@ -518,7 +538,7 @@ mod tests {
                 .iter()
             {
                 let pckcerts = client
-                    .pckcerts(&pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
+                    .pckcerts(pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                     .unwrap();
                 assert!(client
                     .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
@@ -577,7 +597,7 @@ mod tests {
             .iter()
         {
             let pckcerts = client
-                .pckcerts(&pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
+                .pckcerts(pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                 .unwrap();
             let fmspc = pckcerts.fmspc().unwrap();
 
@@ -626,7 +646,7 @@ mod tests {
                 .iter()
             {
                 let pckcerts = client
-                    .pckcerts(&pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
+                    .pckcerts(pcs_api_key(), &pckid.enc_ppid, pckid.pce_id.clone())
                     .unwrap();
                 let fmspc = pckcerts.fmspc().unwrap();
                 let tcb_info = client.sgx_tcbinfo(&fmspc, None).unwrap();

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -24,13 +24,12 @@ use std::time::Duration;
 
 use super::common::*;
 use super::{
-    Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PckCertsIn, PckCertsService,
+    Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PckCertsIn,
     PckCrlIn, PckCrlService, PcsVersion, ProvisioningServiceApi, QeIdIn, QeIdService, StatusCode,
-    TcbEvaluationDataNumbersIn, TcbEvaluationDataNumbersService, TcbInfoIn, TcbInfoService,
-    WithApiVersion,
+    TcbEvaluationDataNumbersService, TcbInfoIn, TcbInfoService,
 };
-use crate::provisioning_client::{PCSPckCrlService, PlatformApiTag};
-use crate::Error;
+use crate::provisioning_client::{BackoffService, CachedService, PcsService, PlatformApiTag};
+use crate::{Error, ProvisioningClient};
 
 pub(crate) const INTEL_BASE_URL: &'static str = "https://api.trustedservices.intel.com";
 const SUBSCRIPTION_KEY_HEADER: &'static str = "Ocp-Apim-Subscription-Key";
@@ -38,7 +37,7 @@ const SUBSCRIPTION_KEY_HEADER: &'static str = "Ocp-Apim-Subscription-Key";
 pub struct IntelProvisioningClientBuilder {
     api_key: Option<String>,
     api_version: PcsVersion,
-    client_builder: ClientBuilder,
+    pub(crate) client_builder: ClientBuilder,
 }
 
 impl IntelProvisioningClientBuilder {
@@ -60,41 +59,172 @@ impl IntelProvisioningClientBuilder {
         self
     }
 
-    pub fn build<F: for<'a> Fetcher<'a>, PC: PckCrlService>(self, fetcher: F) -> Client<F, PC> {
-        let pck_certs = PckCertsService;
-        let pck_cert = PckCertService;
-        let pck_crl = PC::new();
+    pub fn build<F: for<'a> Fetcher<'a>>(&self, fetcher: F) -> IntelPCSClient<F> {
+        let pckcerts_service = PckCertsService;
+        let pckcert_service = PckCertService;
+        let pckcrl_service = PckCrlService;
         let qeid = QeIdService;
         let sgx_tcbinfo = TcbInfoService::<platform::SGX> {_type: PhantomData};
         let tdx_tcbinfo = TcbInfoService::<platform::TDX> {_type: PhantomData};
         let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::SGX> { _type: PhantomData };
         let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::TDX> { _type: PhantomData };
 
-        self.client_builder.build(
+        let client = self.client_builder.build(
             INTEL_BASE_URL,
             self.api_version,
-            pck_certs,
-            pck_cert,
-            pck_crl,
+            // pck_certs,
+            // pck_cert,
+            // pck_crl,
             qeid,
             sgx_tcbinfo,
             tdx_tcbinfo,
             sgx_evaluation_data_numbers,
             tdx_evaluation_data_numbers,
             fetcher,
-        )
+        );
+        IntelPCSClient {
+            pckcerts_service: CachedService::new(
+                BackoffService::new(
+                    PcsService::new(pckcerts_service),
+                    self.client_builder.retry_timeout.clone(),
+                ),
+                self.client_builder.cache_capacity.clone(),
+                self.client_builder.cache_shelf_time.clone(),
+            ),
+            pckcert_service: CachedService::new(
+                BackoffService::new(
+                    PcsService::new(pckcert_service),
+                    self.client_builder.retry_timeout.clone(),
+                ),
+                self.client_builder.cache_capacity.clone(),
+                self.client_builder.cache_shelf_time.clone(),
+            ),
+            pckcrl_service: CachedService::new(
+                BackoffService::new(
+                    PcsService::new(pckcrl_service),
+                    self.client_builder.retry_timeout.clone(),
+                ),
+                self.client_builder.cache_capacity.clone(),
+                self.client_builder.cache_shelf_time.clone(),
+            ),
+            client
+        }
     }
 }
 
-impl PckCrlService for PCSPckCrlService {
-    fn build_input(&self, api_version: PcsVersion, ca: DcapArtifactIssuer) -> <Self as ProvisioningServiceApi>::Input<'_> {
-        PckCrlIn { api_version, ca }
+pub struct IntelPCSClient<F: for<'a> Fetcher<'a>> {
+    pckcerts_service: CachedService<PckCertsService>,
+    pckcert_service: CachedService<PckCertService>,
+    pckcrl_service: CachedService<PckCrlService>,
+    pub(crate) client: Client<F>
+}
+
+impl<F: for<'a> Fetcher<'a>> IntelPCSClient<F> {
+    pub fn pckcerts(&self, api_key: &Option<String>, encrypted_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error> {
+        let input = PckCertsIn { enc_ppid: encrypted_ppid, pce_id, api_key, api_version: self.client.api_version };
+        self.pckcerts_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
     }
-    
-    fn new() -> Self {
-        Self
+
+    pub fn pckcert(
+        &self,
+        api_key: &Option<String>,
+        encrypted_ppid: Option<&EncPpid>,
+        pce_id: &PceId,
+        cpu_svn: &CpuSvn,
+        pce_isvsvn: PceIsvsvn,
+        qe_id: Option<&QeId>,
+    ) -> Result<PckCert<Unverified>, Error> {
+        let input = PckCertIn { encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id, api_version: self.client.api_version, api_key };
+        self.pckcert_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
+    }
+
+    pub fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl<Unverified>, Error> {
+        let input = PckCrlIn { api_version: self.client.api_version, ca };
+        self.pckcrl_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
+    }
+
+    pub fn qe_identity(&self, evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error> {
+        self.client.qe_identity(evaluation_data_number)
+    }
+
+    pub fn sgx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
+        self.client.sgx_tcbinfo(fmspc, evaluation_data_number)
+    }
+
+    pub fn tdx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
+        self.client.tdx_tcbinfo(fmspc, evaluation_data_number)
+    }
+
+    pub fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
+        self.client.sgx_tcb_evaluation_data_numbers()
+    }
+
+    pub fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
+        self.client.tdx_tcb_evaluation_data_numbers()
     }
 }
+
+pub struct PckCertsService;
+impl ProvisioningServiceApi for PckCertsService {
+    type Input<'a> = PckCertsIn<'a>;
+    type Output = PckCerts;
+
+    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+        let api_version = input.api_version as u8;
+        let encrypted_ppid = input.enc_ppid.to_hex();
+        let pce_id = input.pce_id.to_le_bytes().to_hex();
+        let url = format!(
+            "{}/sgx/certification/v{}/pckcerts?encrypted_ppid={}&pceid={}",
+            base_url, api_version, encrypted_ppid, pce_id,
+        );
+        let headers = if let Some(api_key) = &input.api_key {
+            vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
+        } else {
+            Vec::new()
+        };
+        Ok((url, headers))
+    }
+
+    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+        match status_code {
+            StatusCode::Ok => Ok(()),
+            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
+            StatusCode::Unauthorized => Err(Error::PCSError(
+                status_code,
+                "Failed to authenticate or authorize the request (check your PCS key)",
+            )),
+            StatusCode::NotFound => Err(Error::PCSError(
+                status_code,
+                "Cannot find the requested certificate",
+            )),
+            StatusCode::TooManyRequests => Err(Error::PCSError(status_code, "Too many requests")),
+            StatusCode::InternalServerError => Err(Error::PCSError(
+                status_code,
+                "PCS suffered from an internal server error",
+            )),
+            StatusCode::ServiceUnavailable => Err(Error::PCSError(
+                status_code,
+                "PCS is temporarily unavailable",
+            )),
+            _ => Err(Error::PCSError(
+                status_code,
+                "Unexpected response from PCS server",
+            )),
+        }
+    }
+
+    fn parse_response(
+        &self,
+        response_body: String,
+        response_headers: Vec<(String, String)>,
+        _api_version: PcsVersion,
+    ) -> Result<Self::Output, Error> {
+        let ca_chain = parse_issuer_header(&response_headers, PCK_CERTIFICATE_ISSUER_CHAIN_HEADER)?;
+        PckCerts::parse(&response_body, ca_chain).map_err(|e| Error::OfflineAttestationError(e))
+    }
+}
+
+
 
 #[cfg(all(test, feature = "reqwest"))]
 mod tests {
@@ -112,7 +242,6 @@ mod tests {
         WriteOptionsBuilder,
     };
 
-    use crate::PCSPckCrlService;
     use crate::PckCertIn;
     use crate::PckCertsIn;
     use crate::PckCrlIn;
@@ -150,7 +279,7 @@ mod tests {
                     continue;
                 }
             }
-            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+            let client = intel_builder.build(reqwest_client());
 
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
                 .unwrap()
@@ -188,7 +317,7 @@ mod tests {
                     continue;
                 }
             }
-            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+            let client = intel_builder.build(reqwest_client());
 
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
                 .unwrap()
@@ -244,7 +373,7 @@ mod tests {
                     continue;
                 }
             }
-            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+            let client = intel_builder.build(reqwest_client());
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
                 .unwrap()
                 .iter()
@@ -283,7 +412,7 @@ mod tests {
                     continue;
                 }
             }
-            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+            let client = intel_builder.build(reqwest_client());
             let crl_processor = client
                 .pckcrl(DcapArtifactIssuer::PCKProcessorCA)
                 .unwrap()
@@ -322,7 +451,7 @@ mod tests {
 
                     let (cached_pck, _) = {
                         let mut hasher = DefaultHasher::new();
-                        let input = PckCertIn { encrypted_ppid: Some(&pckid.enc_ppid), pce_id: &pckid.pce_id, cpu_svn: &pckid.cpu_svn, pce_isvsvn: pckid.pce_isvsvn, qe_id: None, api_version, api_key: &pcs_api_key() };
+                        let input = PckCertIn { encrypted_ppid: Some(&pckid.enc_ppid), pce_id: &pckid.pce_id, cpu_svn: &pckid.cpu_svn, pce_isvsvn: pckid.pce_isvsvn, qe_id: None, api_version, api_key: &pcs_api_key()};
                         input.hash(&mut hasher);
 
                         cache
@@ -383,7 +512,7 @@ mod tests {
                     continue;
                 }
             }
-            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+            let client = intel_builder.build(reqwest_client());
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
                 .unwrap()
                 .iter()
@@ -407,7 +536,7 @@ mod tests {
     pub fn tcb_info_tdx() {
         let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
             .set_retry_timeout(TIME_RETRY_TIMEOUT);
-        let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+        let client = intel_builder.build(reqwest_client());
         let root_ca = include_bytes!("../../tests/data/root_SGX_CA_der.cert");
         let root_cas = [&root_ca[..]];
 
@@ -442,7 +571,7 @@ mod tests {
     pub fn tcb_info_with_evaluation_data_number() {
         let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
             .set_retry_timeout(TIME_RETRY_TIMEOUT);
-        let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+        let client = intel_builder.build(reqwest_client());
         for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
             .unwrap()
             .iter()
@@ -491,7 +620,7 @@ mod tests {
                     continue;
                 }
             }
-            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+            let client = intel_builder.build(reqwest_client());
             for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
                 .unwrap()
                 .iter()
@@ -504,7 +633,7 @@ mod tests {
 
                 // The cache should be populated after initial service call
                 {
-                    let mut cache = client.sgx_tcbinfo_service.cache.lock().unwrap();
+                    let mut cache = client.client.sgx_tcbinfo_service.cache.lock().unwrap();
 
                     assert!(cache.len() > 0);
 
@@ -548,7 +677,7 @@ mod tests {
                         continue;
                     }
                 }
-                let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+                let client = intel_builder.build(reqwest_client());
                 assert!(client
                     .pckcrl(ca)
                     .and_then(|crl| {
@@ -579,7 +708,7 @@ mod tests {
                         continue;
                     }
                 }
-                let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+                let client = intel_builder.build(reqwest_client());
                 let pckcrl = client.pckcrl(ca).unwrap();
 
                 // The cache should be populated after initial service call
@@ -624,7 +753,7 @@ mod tests {
                     continue;
                 }
             }
-            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+            let client = intel_builder.build(reqwest_client());
             let qe_id = client.qe_identity(None).unwrap();
             assert!(qe_id
                 .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
@@ -646,12 +775,12 @@ mod tests {
                     continue;
                 }
             }
-            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+            let client = intel_builder.build(reqwest_client());
             let qe_id = client.qe_identity(None).unwrap();
 
             // The cache should be populated after initial service call
             {
-                let mut cache = client.qeid_service.cache.lock().unwrap();
+                let mut cache = client.client.qeid_service.cache.lock().unwrap();
 
                 assert!(cache.len() > 0);
 
@@ -681,7 +810,7 @@ mod tests {
         for api_version in [PcsVersion::V3, PcsVersion::V4] {
             let intel_builder = IntelProvisioningClientBuilder::new(api_version)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
+            let client = intel_builder.build(reqwest_client());
             let fmspc = Fmspc::try_from("90806f000000").unwrap();
             assert_matches!(client.qe_identity(Some(15)), Err(Error::PCSError(StatusCode::Gone, _)));
             assert_matches!(client.sgx_tcbinfo(&fmspc, Some(15)), Err(Error::PCSError(StatusCode::Gone, _)));
@@ -696,8 +825,8 @@ mod tests {
         let root_cas = [&root_ca[..]];
         let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
             .set_retry_timeout(TIME_RETRY_TIMEOUT);
-        let client: crate::Client<reqwest::blocking::Client, PCSPckCrlService> = intel_builder.build(reqwest_client());
-        let eval_numbers = T::get_tcb_evaluation_data_numbers(&client).unwrap();
+        let client = intel_builder.build(reqwest_client());
+        let eval_numbers = T::get_tcb_evaluation_data_numbers(&client.client).unwrap();
 
         let eval_numbers2 = serde_json::ser::to_vec(&eval_numbers)
             .and_then(|v| serde_json::from_slice::<RawTcbEvaluationDataNumbers<T>>(&v))
@@ -725,7 +854,7 @@ mod tests {
                 u64::from(number)
             );
 
-            let tcb_info = T::get_tcbinfo(&client, &fmspc, Some(number))
+            let tcb_info = T::get_tcbinfo(&client.client, &fmspc, Some(number))
                 .unwrap()
                 .verify(&root_cas, 2)
                 .unwrap();

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::Read;
+use std::marker::PhantomData;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
 
@@ -19,17 +20,20 @@ use pcs::{
 };
 #[cfg(feature = "reqwest")]
 use reqwest::blocking::{Client as ReqwestClient, Response as ReqwestResponse};
+use rustc_serialize::hex::ToHex;
 
 use crate::Error;
+use crate::intel::{INTEL_BASE_URL, PckCertsApi};
+use crate::provisioning_client::common::{ENCLAVE_ID_ISSUER_CHAIN_HEADER, PCK_CERTIFICATE_ISSUER_CHAIN_HEADER, PCK_CRL_ISSUER_CHAIN_HEADER, TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN, TCB_INFO_ISSUER_CHAIN_HEADER_V3, TCB_INFO_ISSUER_CHAIN_HEADER_V4, parse_issuer_header};
 
-pub mod azure;
+// pub mod azure;
 pub(self) mod common;
 pub mod intel;
-pub mod pccs;
+// pub mod pccs;
 
-pub use self::azure::AzureProvisioningClientBuilder;
+// pub use self::azure::AzureProvisioningClientBuilder;
 pub use self::intel::IntelProvisioningClientBuilder;
-pub use self::pccs::PccsProvisioningClientBuilder;
+// pub use self::pccs::PccsProvisioningClientBuilder;
 
 // Taken from https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 #[derive(Clone, Debug, Eq, PartialEq, TryFromPrimitive)]
@@ -117,6 +121,8 @@ pub enum StatusCode {
     Unassigned = 599,
 }
 
+const SUBSCRIPTION_KEY_HEADER: &'static str = "Ocp-Apim-Subscription-Key";
+
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum PcsVersion {
     V3 = 3,
@@ -163,14 +169,64 @@ impl WithApiVersion for PckCertsIn<'_> {
     }
 }
 
-pub trait PckCertsService<'inp>:
-    ProvisioningServiceApi<'inp, Input = PckCertsIn<'inp>, Output = PckCerts>
-{
-    fn build_input(
-        &'inp self,
-        enc_ppid: &'inp EncPpid,
-        pce_id: PceId,
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input;
+pub struct PckCertsService;
+impl ProvisioningServiceApi for PckCertsService {
+    type Input<'a> = PckCertsIn<'a>;
+    type Output = PckCerts;
+
+        fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+        let api_version = input.api_version as u8;
+        let encrypted_ppid = input.enc_ppid.to_hex();
+        let pce_id = input.pce_id.to_le_bytes().to_hex();
+        let url = format!(
+            "{}/sgx/certification/v{}/pckcerts?encrypted_ppid={}&pceid={}",
+            INTEL_BASE_URL, api_version, encrypted_ppid, pce_id,
+        );
+        let headers = if let Some(api_key) = &input.api_key {
+            vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
+        } else {
+            Vec::new()
+        };
+        Ok((url, headers))
+    }
+
+    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+        match status_code {
+            StatusCode::Ok => Ok(()),
+            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
+            StatusCode::Unauthorized => Err(Error::PCSError(
+                status_code,
+                "Failed to authenticate or authorize the request (check your PCS key)",
+            )),
+            StatusCode::NotFound => Err(Error::PCSError(
+                status_code,
+                "Cannot find the requested certificate",
+            )),
+            StatusCode::TooManyRequests => Err(Error::PCSError(status_code, "Too many requests")),
+            StatusCode::InternalServerError => Err(Error::PCSError(
+                status_code,
+                "PCS suffered from an internal server error",
+            )),
+            StatusCode::ServiceUnavailable => Err(Error::PCSError(
+                status_code,
+                "PCS is temporarily unavailable",
+            )),
+            _ => Err(Error::PCSError(
+                status_code,
+                "Unexpected response from PCS server",
+            )),
+        }
+    }
+
+    fn parse_response(
+        &self,
+        response_body: String,
+        response_headers: Vec<(String, String)>,
+        _api_version: PcsVersion,
+    ) -> Result<Self::Output, Error> {
+        let ca_chain = parse_issuer_header(&response_headers, PCK_CERTIFICATE_ISSUER_CHAIN_HEADER)?;
+        PckCerts::parse(&response_body, ca_chain).map_err(|e| Error::OfflineAttestationError(e))
+    }
 }
 
 #[derive(Hash)]
@@ -190,17 +246,69 @@ impl WithApiVersion for PckCertIn<'_> {
     }
 }
 
-pub trait PckCertService<'inp>:
-    ProvisioningServiceApi<'inp, Input = PckCertIn<'inp>, Output = PckCert<Unverified>>
-{
-    fn build_input(
-        &'inp self,
-        encrypted_ppid: Option<&'inp EncPpid>,
-        pce_id: &'inp PceId,
-        cpu_svn: &'inp CpuSvn,
-        pce_isvsvn: PceIsvsvn,
-        qe_id: Option<&'inp QeId>,
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input;
+struct PckCertService;
+impl ProvisioningServiceApi for PckCertService {
+    type Input<'a> = PckCertIn<'a>;
+    type Output = PckCert<Unverified>;
+
+    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+        let api_version = input.api_version as u8;
+        let encrypted_ppid = input
+            .encrypted_ppid
+            .ok_or(Error::NoEncPPID)
+            .map(|e_ppid| e_ppid.to_hex())?;
+        let cpusvn = input.cpu_svn.to_hex();
+        let pce_isvsvn = input.pce_isvsvn.to_le_bytes().to_hex();
+        let pce_id = input.pce_id.to_le_bytes().to_hex();
+        let url = format!(
+            "{}/sgx/certification/v{}/pckcert?encrypted_ppid={}&cpusvn={}&pcesvn={}&pceid={}",
+            INTEL_BASE_URL, api_version, encrypted_ppid, cpusvn, pce_isvsvn, pce_id,
+        );
+        let headers = if let Some(api_key) = input.api_key {
+            vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
+        } else {
+            Vec::new()
+        };
+        Ok((url, headers))
+    }
+
+    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+        match status_code {
+            StatusCode::Ok => Ok(()),
+            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
+            StatusCode::Unauthorized => Err(Error::PCSError(
+                status_code,
+                "Failed to authenticate or authorize the request (check your PCS key)",
+            )),
+            StatusCode::NotFound => Err(Error::PCSError(
+                status_code,
+                "Cannot find the requested certificate",
+            )),
+            StatusCode::TooManyRequests => Err(Error::PCSError(status_code, "Too many requests")),
+            StatusCode::InternalServerError => Err(Error::PCSError(
+                status_code,
+                "PCS suffered from an internal server error",
+            )),
+            StatusCode::ServiceUnavailable => Err(Error::PCSError(
+                status_code,
+                "PCS is temporarily unavailable",
+            )),
+            _ => Err(Error::PCSError(
+                status_code,
+                "Unexpected response from PCS server",
+            )),
+        }
+    }
+
+    fn parse_response(
+        &self,
+        response_body: String,
+        response_headers: Vec<(String, String)>,
+        _api_version: PcsVersion,
+    ) -> Result<Self::Output, Error> {
+        let ca_chain = parse_issuer_header(&response_headers, PCK_CERTIFICATE_ISSUER_CHAIN_HEADER)?;
+        Ok(PckCert::new(response_body, ca_chain))
+    }
 }
 
 #[derive(Hash)]
@@ -215,10 +323,62 @@ impl WithApiVersion for PckCrlIn {
     }
 }
 
-pub trait PckCrlService<'inp>:
-    ProvisioningServiceApi<'inp, Input = PckCrlIn, Output = PckCrl<Unverified>>
-{
-    fn build_input(&'inp self, ca: DcapArtifactIssuer) -> <Self as ProvisioningServiceApi<'inp>>::Input;
+struct PckCrlService;
+impl ProvisioningServiceApi for PckCrlService {
+    type Input<'a> = PckCrlIn;
+    type Output = PckCrl<Unverified>;
+
+    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+        let ca = match input.ca {
+            DcapArtifactIssuer::PCKProcessorCA => "processor",
+            DcapArtifactIssuer::PCKPlatformCA => "platform",
+            DcapArtifactIssuer::SGXRootCA => {
+                return Err(Error::PCSError(
+                    StatusCode::BadRequest,
+                    "Invalid ca parameter",
+                ));
+            }
+        };
+        let url = format!(
+            "{}/sgx/certification/v{}/pckcrl?ca={}&encoding=pem",
+            INTEL_BASE_URL, input.api_version as u8, ca,
+        );
+        Ok((url, Vec::new()))
+    }
+
+    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+        match &status_code {
+            StatusCode::Ok => Ok(()),
+            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
+            StatusCode::Unauthorized => Err(Error::PCSError(
+                status_code,
+                "Failed to authenticate or authorize the request (check your PCS key)",
+            )),
+            StatusCode::InternalServerError => Err(Error::PCSError(
+                status_code,
+                "PCS suffered from an internal server error",
+            )),
+            StatusCode::ServiceUnavailable => Err(Error::PCSError(
+                status_code,
+                "PCS is temporarily unavailable",
+            )),
+            __ => Err(Error::PCSError(
+                status_code,
+                "Unexpected response from PCS server",
+            )),
+        }
+    }
+
+    fn parse_response(
+        &self,
+        response_body: String,
+        response_headers: Vec<(String, String)>,
+        _api_version: PcsVersion,
+    ) -> Result<Self::Output, Error> {
+        let ca_chain = parse_issuer_header(&response_headers, PCK_CRL_ISSUER_CHAIN_HEADER)?;
+        let crl = PckCrl::new(response_body, ca_chain)?;
+        Ok(crl)
+    }
 }
 
 #[derive(Hash)]
@@ -233,16 +393,69 @@ impl WithApiVersion for QeIdIn {
     }
 }
 
-pub trait QeIdService<'inp>:
-    ProvisioningServiceApi<'inp, Input = QeIdIn, Output = QeIdentitySigned>
-{
-    fn build_input(&'inp self, tcb_evaluation_data_number: Option<u16>) -> <Self as ProvisioningServiceApi<'inp>>::Input;
+struct QeIdService;
+impl ProvisioningServiceApi for QeIdService {
+    type Input<'a> = QeIdIn;
+    type Output = QeIdentitySigned;
+
+    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+        let api_version = input.api_version as u8;
+        let url = if let Some(tcb_evaluation_data_number) = input.tcb_evaluation_data_number {
+            format!(
+                "{}/sgx/certification/v{}/qe/identity?tcbEvaluationDataNumber={}",
+                INTEL_BASE_URL, api_version, tcb_evaluation_data_number
+            )
+        } else {
+            format!(
+                "{}/sgx/certification/v{}/qe/identity?update=early",
+                INTEL_BASE_URL, api_version,
+            )
+        };
+        Ok((url, Vec::new()))
+    }
+
+    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+        match &status_code {
+            StatusCode::Ok => Ok(()),
+            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
+            StatusCode::Unauthorized => Err(Error::PCSError(
+                status_code,
+                "Failed to authenticate or authorize the request (check your PCS key)",
+            )),
+            StatusCode::NotFound => {
+                Err(Error::PCSError(status_code, "QE identity Cannot be found"))
+            }
+            StatusCode::InternalServerError => Err(Error::PCSError(
+                status_code,
+                "PCS suffered from an internal server error",
+            )),
+            StatusCode::ServiceUnavailable => Err(Error::PCSError(
+                status_code,
+                "PCS is temporarily unavailable",
+            )),
+            __ => Err(Error::PCSError(
+                status_code,
+                "Unexpected response from PCS server",
+            )),
+        }
+    }
+
+    fn parse_response(
+        &self,
+        response_body: String,
+        response_headers: Vec<(String, String)>,
+        _api_version: PcsVersion,
+    ) -> Result<Self::Output, Error> {
+        let ca_chain = parse_issuer_header(&response_headers, ENCLAVE_ID_ISSUER_CHAIN_HEADER)?;
+        let id = QeIdentitySigned::parse(&response_body, ca_chain)?;
+        Ok(id)
+    }
 }
 
 #[derive(Hash)]
-pub struct TcbInfoIn<'i> {
+pub struct TcbInfoIn<'a> {
     pub(crate) api_version: PcsVersion,
-    pub(crate) fmspc: &'i Fmspc,
+    pub(crate) fmspc: &'a Fmspc,
     pub(crate) tcb_evaluation_data_number: Option<u16>,
 }
 
@@ -252,11 +465,76 @@ impl WithApiVersion for TcbInfoIn<'_> {
     }
 }
 
-pub trait TcbInfoService<'inp, T: PlatformTypeForTcbInfo>:
-    ProvisioningServiceApi<'inp, Input = TcbInfoIn<'inp>, Output = TcbInfo<T>>
-{
-    fn build_input(&'inp self, fmspc: &'inp Fmspc, tcb_evaluation_data_number: Option<u16>)
-        -> <Self as ProvisioningServiceApi<'inp>>::Input;
+struct TcbInfoService<T> {
+    _type: PhantomData<T>,
+}
+impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi for TcbInfoService<T> {
+    type Input<'a> = TcbInfoIn<'a>;
+    type Output = TcbInfo<T>;
+
+    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+        let api_version = input.api_version as u8;
+        let fmspc = input.fmspc.as_bytes().to_hex();
+        let url = if let Some(evaluation_data_number) = input.tcb_evaluation_data_number {
+            format!(
+                "{}/{}/certification/v{}/tcb?fmspc={}&tcbEvaluationDataNumber={}",
+                INTEL_BASE_URL,
+                T::tag(),
+                api_version,
+                fmspc,
+                evaluation_data_number
+            )
+        } else {
+            format!(
+                "{}/{}/certification/v{}/tcb?fmspc={}&update=early",
+                INTEL_BASE_URL,
+                T::tag(),
+                api_version,
+                fmspc,
+            )
+        };
+        Ok((url, Vec::new()))
+    }
+
+    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+        match &status_code {
+            StatusCode::Ok => Ok(()),
+            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
+            StatusCode::Unauthorized => Err(Error::PCSError(
+                status_code,
+                "Failed to authenticate or authorize the request (check your PCS key)",
+            )),
+            StatusCode::NotFound => Err(Error::PCSError(status_code, "TCB info cannot be found")),
+            StatusCode::Gone => Err(Error::PCSError(status_code, "TCB info no longer available")),
+            StatusCode::InternalServerError => Err(Error::PCSError(
+                status_code,
+                "PCS suffered from an internal server error",
+            )),
+            StatusCode::ServiceUnavailable => Err(Error::PCSError(
+                status_code,
+                "PCS is temporarily unavailable",
+            )),
+            __ => Err(Error::PCSError(
+                status_code,
+                "Unexpected response from PCS server",
+            )),
+        }
+    }
+
+    fn parse_response(
+        &self,
+        response_body: String,
+        response_headers: Vec<(String, String)>,
+        api_version: PcsVersion,
+    ) -> Result<Self::Output, Error> {
+        let key = match api_version {
+            PcsVersion::V3 => TCB_INFO_ISSUER_CHAIN_HEADER_V3,
+            PcsVersion::V4 => TCB_INFO_ISSUER_CHAIN_HEADER_V4,
+        };
+        let ca_chain = parse_issuer_header(&response_headers, key)?;
+        let tcb_info = TcbInfo::parse(&response_body, ca_chain)?;
+        Ok(tcb_info)
+    }
 }
 
 #[derive(Hash)]
@@ -268,11 +546,52 @@ impl WithApiVersion for TcbEvaluationDataNumbersIn {
     }
 }
 
-pub trait TcbEvaluationDataNumbersService<'inp, T: PlatformTypeForTcbInfo>:
-    ProvisioningServiceApi<'inp, Input = TcbEvaluationDataNumbersIn, Output = RawTcbEvaluationDataNumbers<T>>
-{
-    fn build_input(&self)
-        -> <Self as ProvisioningServiceApi<'inp>>::Input;
+struct TcbEvaluationDataNumbersService<T: PlatformTypeForTcbInfo> {
+    base_url: String,
+    _type: PhantomData<T>
+}
+impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi for TcbEvaluationDataNumbersService<T> {
+    type Input<'a> = TcbEvaluationDataNumbersIn;
+    type Output = RawTcbEvaluationDataNumbers<T>;
+
+    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+        let url = format!(
+            "{}/{}/certification/v{}/tcbevaluationdatanumbers",
+            self.base_url,
+            T::tag(),
+            input.api_version() as u8,
+        );
+        Ok((url, Vec::new()))
+    }
+
+    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+        match &status_code {
+            StatusCode::Ok => Ok(()),
+            StatusCode::InternalServerError => Err(Error::PCSError(
+                status_code,
+                "PCS suffered from an internal server error",
+            )),
+            StatusCode::ServiceUnavailable => Err(Error::PCSError(
+                status_code,
+                "PCS is temporarily unavailable",
+            )),
+            __ => Err(Error::PCSError(
+                status_code,
+                "Unexpected response from PCS server",
+            )),
+        }
+    }
+
+    fn parse_response(
+        &self,
+        response_body: String,
+        response_headers: Vec<(String, String)>,
+        _api_version: PcsVersion,
+    ) -> Result<Self::Output, Error> {
+        let ca_chain =
+            parse_issuer_header(&response_headers, TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN)?;
+        RawTcbEvaluationDataNumbers::parse(&response_body, ca_chain).map_err(|e| e.into())
+    }
 }
 
 pub struct ClientBuilder {
@@ -301,30 +620,32 @@ impl ClientBuilder {
         self
     }
 
-    pub(crate) fn build<PSS, PS, PC, QS, TS, TDS, ES, TES, F>(
+    pub(crate) fn build<F>(
         self,
-        pckcerts_service: PSS,
-        pckcert_service: PS,
-        pckcrl_service: PC,
-        qeid_service: QS,
-        sgx_tcbinfo_service: TS,
-        tdx_tcbinfo_service: TDS,
-        sgx_tcb_evaluation_data_numbers_service: ES,
-        tdx_tcb_evaluation_data_numbers_service: TES,
+        api_version: PcsVersion,
+        pckcerts_service: PckCertsService,
+        pckcert_service: PckCertService,
+        pckcrl_service: PckCrlService,
+        qeid_service: QeIdService,
+        sgx_tcbinfo_service: TcbInfoService<platform::SGX>,
+        tdx_tcbinfo_service: TcbInfoService<platform::TDX>,
+        sgx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::SGX>,
+        tdx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::TDX>,
         fetcher: F,
     ) -> Client<F>
     where
-        PSS: for<'a> PckCertsService<'a> + Sync + Send + 'static,
-        PS: for<'a> PckCertService<'a> + Sync + Send + 'static,
-        PC: for<'a> PckCrlService<'a> + Sync + Send + 'static,
-        QS: for<'a> QeIdService<'a> + Sync + Send + 'static,
-        TS: for<'a> TcbInfoService<'a, platform::SGX> + Sync + Send + 'static,
-        TDS: for<'a> TcbInfoService<'a, platform::TDX> + Sync + Send + 'static,
-        ES: for<'a> TcbEvaluationDataNumbersService<'a, platform::SGX> + Sync + Send + 'static,
-        TES: for<'a> TcbEvaluationDataNumbersService<'a, platform::TDX> + Sync + Send + 'static,
+        // PSS: for<'a> PckCertsService + Sync + Send + 'static,
+        // PS: for<'a> PckCertService + Sync + Send + 'static,
+        // PC: for<'a> PckCrlService + Sync + Send + 'static,
+        // QS: for<'a> QeIdService + Sync + Send + 'static,
+        // TS: for<'a> TcbInfoService<platform::SGX> + Sync + Send + 'static,
+        // TDS: for<'a> TcbInfoService<platform::TDX> + Sync + Send + 'static,
+        // ES: for<'a> TcbEvaluationDataNumbersService<platform::SGX> + Sync + Send + 'static,
+        // TES: for<'a> TcbEvaluationDataNumbersService<platform::TDX> + Sync + Send + 'static,
         F: for<'a> Fetcher<'a>,
     {
         Client::new(
+            api_version,
             pckcerts_service,
             pckcert_service,
             pckcrl_service,
@@ -341,35 +662,35 @@ impl ClientBuilder {
     }
 }
 
-struct PcsService<T: for<'a> ProvisioningServiceApi<'a> + Sync + ?Sized> {
-    service: Box<T>,
+struct PcsService<T: ProvisioningServiceApi> {
+    service: T,
 }
 
-impl<T: for<'a> ProvisioningServiceApi<'a> + Sync + ?Sized> PcsService<T> {
-    pub fn new(service: Box<T>) -> Self {
+impl<T: ProvisioningServiceApi> PcsService<T> {
+    pub fn new(service: T) -> Self {
         Self { service }
     }
 }
 
-impl<T: for<'a> ProvisioningServiceApi<'a> + Sync + ?Sized> PcsService<T> {
+impl<T: ProvisioningServiceApi> PcsService<T> {
     pub(crate) fn pcs_service(&self) -> &T {
         &self.service
     }
 
     fn call_service<'a, F: Fetcher<'a>>(
-        &'a self,
+        &self,
         fetcher: &'a F,
-        input: &<T as ProvisioningServiceApi<'a>>::Input,
-    ) -> Result<<T as ProvisioningServiceApi<'a>>::Output, Error> {
+        input: &<T as ProvisioningServiceApi>::Input<'_>,
+    ) -> Result<<T as ProvisioningServiceApi>::Output, Error> {
         let (url, headers) =
-            <T as ProvisioningServiceApi<'a>>::build_request(&self.pcs_service(), input)?;
+            <T as ProvisioningServiceApi>::build_request(&self.pcs_service(), input)?;
         let req = fetcher.build_request(&url, headers)?;
         let api_version = input.api_version();
 
         let (status_code, resp) = fetcher.send(req)?;
-        <T as ProvisioningServiceApi<'a>>::validate_response(self.pcs_service(), status_code)?;
+        <T as ProvisioningServiceApi>::validate_response(self.pcs_service(), status_code)?;
         let (response_body, response_headers) = fetcher.parse_response(resp)?;
-        <T as ProvisioningServiceApi<'a>>::parse_response(
+        <T as ProvisioningServiceApi>::parse_response(
             self.pcs_service(),
             response_body,
             response_headers,
@@ -378,14 +699,14 @@ impl<T: for<'a> ProvisioningServiceApi<'a> + Sync + ?Sized> PcsService<T> {
     }
 }
 
-struct CachedService<O: Clone, T: for<'a> ProvisioningServiceApi<'a, Output = O> + Sync + ?Sized> {
+struct CachedService<T: ProvisioningServiceApi> {
     service: BackoffService<T>,
-    cache: Mutex<LruCache<u64, (O, SystemTime)>>,
+    cache: Mutex<LruCache<u64, (<T as ProvisioningServiceApi>::Output, SystemTime)>>,
     cache_shelf_time: Duration,
 }
 
-impl<O: Clone, T: for<'a> ProvisioningServiceApi<'a, Output = O> + Sync + ?Sized>
-    CachedService<O, T>
+impl<T: ProvisioningServiceApi>
+    CachedService<T>
 {
     pub fn new(service: BackoffService<T>, capacity: usize, cache_shelf_time: Duration) -> Self {
         Self {
@@ -396,18 +717,18 @@ impl<O: Clone, T: for<'a> ProvisioningServiceApi<'a, Output = O> + Sync + ?Sized
     }
 }
 
-impl<O: Clone, T: for<'a> ProvisioningServiceApi<'a, Output = O> + Sync + ?Sized>
-    CachedService<O, T>
+impl<T: ProvisioningServiceApi>
+    CachedService<T>
 {
     pub(crate) fn pcs_service(&self) -> &T {
         &self.service.pcs_service()
     }
 
     pub fn call_service<'a, F: Fetcher<'a>>(
-        &'a self,
+        &self,
         fetcher: &'a F,
-        input: &<T as ProvisioningServiceApi<'a>>::Input,
-    ) -> Result<<T as ProvisioningServiceApi<'a>>::Output, Error> {
+        input: &<T as ProvisioningServiceApi>::Input<'_>,
+    ) -> Result<<T as ProvisioningServiceApi>::Output, Error> {
         let key = {
             let mut hasher = DefaultHasher::new();
             input.hash(&mut hasher);
@@ -428,12 +749,12 @@ impl<O: Clone, T: for<'a> ProvisioningServiceApi<'a, Output = O> + Sync + ?Sized
     }
 }
 
-struct BackoffService<T: for<'a> ProvisioningServiceApi<'a> + Sync + ?Sized> {
+struct BackoffService<T: ProvisioningServiceApi> {
     service: PcsService<T>,
     retry_timeout: Option<Duration>,
 }
 
-impl<T: for<'a> ProvisioningServiceApi<'a> + Sync + ?Sized> BackoffService<T> {
+impl<T: ProvisioningServiceApi> BackoffService<T> {
     pub fn new(service: PcsService<T>, retry_timeout: Option<Duration>) -> Self {
         Self {
             service,
@@ -442,7 +763,7 @@ impl<T: for<'a> ProvisioningServiceApi<'a> + Sync + ?Sized> BackoffService<T> {
     }
 }
 
-impl<T: for<'a> ProvisioningServiceApi<'a> + Sync + ?Sized> BackoffService<T> {
+impl<T: ProvisioningServiceApi> BackoffService<T> {
     const RETRY_INITIAL_INTERVAL: Duration = Duration::from_secs(2);
     const RETRY_INTERVAL_MULTIPLIER: f64 = 2.0;
 
@@ -451,10 +772,10 @@ impl<T: for<'a> ProvisioningServiceApi<'a> + Sync + ?Sized> BackoffService<T> {
     }
 
     pub fn call_service<'a, F: Fetcher<'a>>(
-        &'a self,
+        &self,
         fetcher: &'a F,
-        input: &<T as ProvisioningServiceApi<'a>>::Input,
-    ) -> Result<<T as ProvisioningServiceApi<'a>>::Output, Error> {
+        input: &<T as ProvisioningServiceApi>::Input<'_>,
+    ) -> Result<<T as ProvisioningServiceApi>::Output, Error> {
         if let Some(retry_timeout) = self.retry_timeout {
             let op = || match self.service.call_service::<F>(fetcher, input) {
                 Ok(output) => Ok(output),
@@ -485,48 +806,71 @@ impl<T: for<'a> ProvisioningServiceApi<'a> + Sync + ?Sized> BackoffService<T> {
     }
 }
 
-pub struct Client<F: for<'a> Fetcher<'a>> {
-    pckcerts_service: CachedService<PckCerts, dyn for<'a> PckCertsService<'a> + Sync + Send>,
+pub struct Client<F: for<'a> Fetcher<'a>>
+where
+    // PSS: PckCertsService,
+    // PS: PckCertService + Sync + Send + 'static,
+    // PC: PckCrlService + Sync + Send + 'static,
+    // QS: QeIdService + Sync + Send + 'static,
+    // TS: TcbInfoService<platform::SGX> + Sync + Send + 'static,
+    // TDS: TcbInfoService<platform::TDX> + Sync + Send + 'static,
+    // ES: TcbEvaluationDataNumbersService<platform::SGX> + Sync + Send + 'static,
+    // TES: TcbEvaluationDataNumbersService<platform::TDX> + Sync + Send + 'static,
+{
+    api_version: PcsVersion,
+    pckcerts_service: CachedService<PckCertsService>,
     pckcert_service:
-        CachedService<PckCert<Unverified>, dyn for<'a> PckCertService<'a> + Sync + Send>,
-    pckcrl_service: CachedService<PckCrl<Unverified>, dyn for<'a> PckCrlService<'a> + Sync + Send>,
-    qeid_service: CachedService<QeIdentitySigned, dyn for<'a> QeIdService<'a> + Sync + Send>,
-    sgx_tcbinfo_service: CachedService<TcbInfo<platform::SGX>, dyn for<'a> TcbInfoService<'a, platform::SGX> + Sync + Send>,
-    tdx_tcbinfo_service: CachedService<TcbInfo<platform::TDX>, dyn for<'a> TcbInfoService<'a, platform::TDX> + Sync + Send>,
-    sgx_tcb_evaluation_data_numbers_service: CachedService<RawTcbEvaluationDataNumbers<platform::SGX>, dyn for<'a> TcbEvaluationDataNumbersService<'a, platform::SGX> + Sync + Send>,
-    tdx_tcb_evaluation_data_numbers_service: CachedService<RawTcbEvaluationDataNumbers<platform::TDX>, dyn for<'a> TcbEvaluationDataNumbersService<'a, platform::TDX> + Sync + Send>,
+        CachedService<PckCertService>,
+    pckcrl_service: CachedService<PckCrlService>,
+    qeid_service: CachedService<QeIdService>,
+    sgx_tcbinfo_service: CachedService<TcbInfoService<platform::SGX>>,
+    tdx_tcbinfo_service: CachedService<TcbInfoService<platform::TDX>>,
+    sgx_tcb_evaluation_data_numbers_service: CachedService<TcbEvaluationDataNumbersService<platform::SGX>>,
+    tdx_tcb_evaluation_data_numbers_service: CachedService<TcbEvaluationDataNumbersService<platform::TDX>>,
     fetcher: F,
 }
 
-impl<F: for<'a> Fetcher<'a>> Client<F> {
-    fn new<PSS, PS, PC, QS, TS, TDS, ES, TES>(
-        pckcerts_service: PSS,
-        pckcert_service: PS,
-        pckcrl_service: PC,
-        qeid_service: QS,
-        sgx_tcbinfo_service: TS,
-        tdx_tcbinfo_service: TDS,
-        sgx_tcb_evaluation_data_numbers_service: ES,
-        tdx_tcb_evaluation_data_numbers_service: TES,
+impl<F: for<'a> Fetcher<'a>> Client<F>
+where
+    // PSS: PckCertsService,
+    // PS: PckCertService + Sync + Send + 'static,
+    // PC: PckCrlService + Sync + Send + 'static,
+    // QS: QeIdService + Sync + Send + 'static,
+    // TS: TcbInfoService<platform::SGX> + Sync + Send + 'static,
+    // TDS: TcbInfoService<platform::TDX> + Sync + Send + 'static,
+    // ES: TcbEvaluationDataNumbersService<platform::SGX> + Sync + Send + 'static,
+    // TES: TcbEvaluationDataNumbersService<platform::TDX> + Sync + Send + 'static
+{
+    fn new(
+        api_version: PcsVersion,
+        pckcerts_service: PckCertsService,
+        pckcert_service: PckCertService,
+        pckcrl_service: PckCrlService,
+        qeid_service: QeIdService,
+        sgx_tcbinfo_service: TcbInfoService<platform::SGX>,
+        tdx_tcbinfo_service: TcbInfoService<platform::TDX>,
+        sgx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::SGX>,
+        tdx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::TDX>,
         fetcher: F,
         retry_timeout: Option<Duration>,
         cache_capacity: usize,
         cache_shelf_time: Duration,
-    ) -> Client<F>
+    ) -> Self
     where
-        PSS: for<'a> PckCertsService<'a> + Sync + Send + 'static,
-        PS: for<'a> PckCertService<'a> + Sync + Send + 'static,
-        PC: for<'a> PckCrlService<'a> + Sync + Send + 'static,
-        QS: for<'a> QeIdService<'a> + Sync + Send + 'static,
-        TS: for<'a> TcbInfoService<'a, platform::SGX> + Sync + Send + 'static,
-        TDS: for<'a> TcbInfoService<'a, platform::TDX> + Sync + Send + 'static,
-        ES: for<'a> TcbEvaluationDataNumbersService<'a, platform::SGX> + Sync + Send + 'static,
-        TES: for<'a> TcbEvaluationDataNumbersService<'a, platform::TDX> + Sync + Send + 'static,
+        // PSS: PckCertsService,
+        // PS: PckCertService + Sync + Send + 'static,
+        // PC: PckCrlService + Sync + Send + 'static,
+        // QS: QeIdService + Sync + Send + 'static,
+        // TS: TcbInfoService<platform::SGX> + Sync + Send + 'static,
+        // TDS: TcbInfoService<platform::TDX> + Sync + Send + 'static,
+        // ES: TcbEvaluationDataNumbersService<platform::SGX> + Sync + Send + 'static,
+        // TES: TcbEvaluationDataNumbersService<platform::TDX> + Sync + Send + 'static,
     {
         Client {
+            api_version,
             pckcerts_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(Box::new(pckcerts_service)),
+                    PcsService::new(pckcerts_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -534,7 +878,7 @@ impl<F: for<'a> Fetcher<'a>> Client<F> {
             ),
             pckcert_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(Box::new(pckcert_service)),
+                    PcsService::new(pckcert_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -542,7 +886,7 @@ impl<F: for<'a> Fetcher<'a>> Client<F> {
             ),
             pckcrl_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(Box::new(pckcrl_service)),
+                    PcsService::new(pckcrl_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -550,7 +894,7 @@ impl<F: for<'a> Fetcher<'a>> Client<F> {
             ),
             qeid_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(Box::new(qeid_service)),
+                    PcsService::new(qeid_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -558,7 +902,7 @@ impl<F: for<'a> Fetcher<'a>> Client<F> {
             ),
             sgx_tcbinfo_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(Box::new(sgx_tcbinfo_service)),
+                    PcsService::new(sgx_tcbinfo_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -566,7 +910,7 @@ impl<F: for<'a> Fetcher<'a>> Client<F> {
             ),
             tdx_tcbinfo_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(Box::new(tdx_tcbinfo_service)),
+                    PcsService::new(tdx_tcbinfo_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -574,7 +918,7 @@ impl<F: for<'a> Fetcher<'a>> Client<F> {
             ),
             sgx_tcb_evaluation_data_numbers_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(Box::new(sgx_tcb_evaluation_data_numbers_service)),
+                    PcsService::new(sgx_tcb_evaluation_data_numbers_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -582,7 +926,7 @@ impl<F: for<'a> Fetcher<'a>> Client<F> {
             ),
             tdx_tcb_evaluation_data_numbers_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(Box::new(tdx_tcb_evaluation_data_numbers_service)),
+                    PcsService::new(tdx_tcb_evaluation_data_numbers_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -594,10 +938,11 @@ impl<F: for<'a> Fetcher<'a>> Client<F> {
 }
 
 pub trait ProvisioningClient {
-    fn pckcerts(&self, enc_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error>;
+    fn pckcerts(&self, api_key: &Option<String>, enc_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error>;
 
     fn pckcert(
         &self,
+        api_key: &Option<String>,
         encrypted_ppid: Option<&EncPpid>,
         pce_id: &PceId,
         cpu_svn: &CpuSvn,
@@ -627,9 +972,10 @@ pub trait ProvisioningClient {
     ///       microcode value is set to the late microcode value.
     ///
     /// Note that PCK certs for some TCB levels may be missing.
-    fn pckcerts_with_fallback(&self, pck_id: &PckID) -> Result<PckCerts, Error> {
+    fn pckcerts_with_fallback(&self, api_key: &Option<String>, pck_id: &PckID) -> Result<PckCerts, Error> {
         let get_and_collect = |collection: &mut BTreeMap<([u8; 16], u16), PckCert<Unverified>>, cpu_svn: &[u8; 16], pce_svn: u16| -> Result<PckCert<Unverified>, Error> {
             let pck_cert = self.pckcert(
+                api_key,
                 Some(&pck_id.enc_ppid),
                 &pck_id.pce_id,
                 cpu_svn,
@@ -643,7 +989,7 @@ pub trait ProvisioningClient {
             Ok(pck_cert)
         };
 
-        match self.pckcerts(&pck_id.enc_ppid, pck_id.pce_id) {
+        match self.pckcerts(api_key, &pck_id.enc_ppid, pck_id.pce_id) {
             Ok(pck_certs) => return Ok(pck_certs),
             Err(Error::RequestNotSupported) => {} // fallback below
             Err(e) => return Err(e),
@@ -722,60 +1068,66 @@ impl ProvisioningClientFuncSelector for platform::TDX {
 }
 
 
-impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F> {
-    fn pckcerts(&self, encrypted_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error> {
-        let input = self
-            .pckcerts_service
-            .pcs_service()
-            .build_input(encrypted_ppid, pce_id);
+impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F>
+where
+    // PSS: PckCertsService,
+    // PS: PckCertService + Sync + Send + 'static,
+    // PC: PckCrlService + Sync + Send + 'static,
+    // QS: QeIdService + Sync + Send + 'static,
+    // TS: TcbInfoService<platform::SGX> + Sync + Send + 'static,
+    // TDS: TcbInfoService<platform::TDX> + Sync + Send + 'static,
+    // ES: TcbEvaluationDataNumbersService<platform::SGX> + Sync + Send + 'static,
+    // TES: TcbEvaluationDataNumbersService<platform::TDX> + Sync + Send + 'static
+{
+    fn pckcerts(&self, api_key: &Option<String>, encrypted_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error> {
+        let input = PckCertsIn { enc_ppid: encrypted_ppid, pce_id, api_key, api_version: self.api_version };
         self.pckcerts_service.call_service(&self.fetcher, &input)
     }
 
     fn pckcert(
         &self,
+        api_key: &Option<String>,
         encrypted_ppid: Option<&EncPpid>,
         pce_id: &PceId,
         cpu_svn: &CpuSvn,
         pce_isvsvn: PceIsvsvn,
         qe_id: Option<&QeId>,
     ) -> Result<PckCert<Unverified>, Error> {
-        let input = self.pckcert_service.pcs_service().build_input(
-            encrypted_ppid,
-            pce_id,
-            cpu_svn,
-            pce_isvsvn,
-            qe_id,
-        );
+        let input = PckCertIn { encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id, api_version: self.api_version, api_key };
         self.pckcert_service.call_service(&self.fetcher, &input)
     }
 
     fn sgx_tcbinfo(&self, fmspc: &Fmspc, tcb_evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
-        let input = self.sgx_tcbinfo_service.pcs_service().build_input(fmspc, tcb_evaluation_data_number);
+        // let input = self.sgx_tcbinfo_service.pcs_service().build_input(fmspc, tcb_evaluation_data_number);
+        let input = TcbInfoIn { api_version: self.api_version, fmspc, tcb_evaluation_data_number };
         self.sgx_tcbinfo_service.call_service(&self.fetcher, &input)
     }
 
     fn tdx_tcbinfo(&self, fmspc: &Fmspc, tcb_evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
-        let input = self.tdx_tcbinfo_service.pcs_service().build_input(fmspc, tcb_evaluation_data_number);
+        // let input = self.tdx_tcbinfo_service.pcs_service().build_input(fmspc, tcb_evaluation_data_number);
+        let input = TcbInfoIn { api_version: self.api_version, fmspc, tcb_evaluation_data_number };
         self.tdx_tcbinfo_service.call_service(&self.fetcher, &input)
     }
 
     fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl<Unverified>, Error> {
-        let input = self.pckcrl_service.pcs_service().build_input(ca);
+        // let input = self.pckcrl_service.pcs_service().build_input(ca);
+        let input = PckCrlIn { api_version: self.api_version, ca };
         self.pckcrl_service.call_service(&self.fetcher, &input)
     }
 
     fn qe_identity(&self, tcb_evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error> {
-        let input = self.qeid_service.pcs_service().build_input(tcb_evaluation_data_number);
+        let input = QeIdIn { api_version: self.api_version, tcb_evaluation_data_number };
         self.qeid_service.call_service(&self.fetcher, &input)
     }
 
     fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
-        let input = self.sgx_tcb_evaluation_data_numbers_service.pcs_service().build_input();
+        let input = TcbEvaluationDataNumbersIn;
         self.sgx_tcb_evaluation_data_numbers_service.call_service(&self.fetcher, &input)
     }
 
     fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
-        let input = self.tdx_tcb_evaluation_data_numbers_service.pcs_service().build_input();
+        // let input = self.tdx_tcb_evaluation_data_numbers_service.pcs_service().build_input();
+        let input = TcbEvaluationDataNumbersIn;
         self.tdx_tcb_evaluation_data_numbers_service.call_service(&self.fetcher, &input)
 
     }
@@ -861,19 +1213,19 @@ impl<'req> Fetcher<'req> for ReqwestClient {
     }
 }
 
-pub trait ProvisioningServiceApi<'inp> {
-    type Input: 'inp + WithApiVersion + Hash;
+pub trait ProvisioningServiceApi {
+    type Input<'a>: WithApiVersion + Hash;
     type Output: Clone;
 
     fn build_request(
-        &'inp self,
-        input: &Self::Input,
+        &self,
+        input: &Self::Input<'_>,
     ) -> Result<(String, Vec<(String, String)>), Error>;
 
-    fn validate_response(&'inp self, code: StatusCode) -> Result<(), Error>;
+    fn validate_response(&self, code: StatusCode) -> Result<(), Error>;
 
     fn parse_response(
-        &'inp self,
+        &self,
         response_body: String,
         response_headers: Vec<(String, String)>,
         api_version: PcsVersion,
@@ -913,23 +1265,23 @@ mod tests {
     #[derive(Clone, PartialEq, Eq, Debug)]
     struct MockOutput(String);
 
-    impl<'a> ProvisioningServiceApi<'a> for MockService {
-        type Input = MockInput;
+    impl ProvisioningServiceApi for MockService {
+        type Input<'a> = MockInput;
         type Output = MockOutput;
 
         fn build_request(
-            &'a self,
-            _input: &Self::Input,
+            &self,
+            _input: &Self::Input<'_>,
         ) -> Result<(String, Vec<(String, String)>), Error> {
             Ok((_input.0.to_string(), vec![]))
         }
 
-        fn validate_response(&'a self, _code: StatusCode) -> Result<(), Error> {
+        fn validate_response(&self, _code: StatusCode) -> Result<(), Error> {
             Ok(())
         }
 
         fn parse_response(
-            &'a self,
+            &self,
             response_body: String,
             _response_headers: Vec<(std::string::String, std::string::String)>,
             _api_version: PcsVersion,
@@ -967,7 +1319,7 @@ mod tests {
     #[test]
     fn test_call_service_cache_miss() {
         let service = PcsService {
-            service: Box::new(MockService),
+            service: MockService,
         };
         let service = BackoffService::new(service, None);
         let cached_service = CachedService::new(service, 5, Duration::from_secs(120));
@@ -992,7 +1344,7 @@ mod tests {
     #[test]
     fn test_call_service_cache_hit() {
         let service = PcsService {
-            service: Box::new(MockService),
+            service: MockService,
         };
         let service = BackoffService::new(service, None);
         let cached_service = CachedService::new(service, 5, Duration::from_secs(120));
@@ -1015,7 +1367,7 @@ mod tests {
     #[test]
     fn test_cache_capacity_eviction() {
         let service = PcsService {
-            service: Box::new(MockService),
+            service: MockService,
         };
         let service = BackoffService::new(service, None);
         let cached_service = CachedService::new(service, 2, Duration::from_secs(120));

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
@@ -23,17 +23,16 @@ use reqwest::blocking::{Client as ReqwestClient, Response as ReqwestResponse};
 use rustc_serialize::hex::ToHex;
 
 use crate::Error;
-use crate::intel::{INTEL_BASE_URL, PckCertsApi};
 use crate::provisioning_client::common::{ENCLAVE_ID_ISSUER_CHAIN_HEADER, PCK_CERTIFICATE_ISSUER_CHAIN_HEADER, PCK_CRL_ISSUER_CHAIN_HEADER, TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN, TCB_INFO_ISSUER_CHAIN_HEADER_V3, TCB_INFO_ISSUER_CHAIN_HEADER_V4, parse_issuer_header};
 
 // pub mod azure;
 pub(self) mod common;
 pub mod intel;
-// pub mod pccs;
+pub mod pccs;
 
 // pub use self::azure::AzureProvisioningClientBuilder;
 pub use self::intel::IntelProvisioningClientBuilder;
-// pub use self::pccs::PccsProvisioningClientBuilder;
+pub use self::pccs::PccsProvisioningClientBuilder;
 
 // Taken from https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 #[derive(Clone, Debug, Eq, PartialEq, TryFromPrimitive)]
@@ -174,13 +173,13 @@ impl ProvisioningServiceApi for PckCertsService {
     type Input<'a> = PckCertsIn<'a>;
     type Output = PckCerts;
 
-        fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let encrypted_ppid = input.enc_ppid.to_hex();
         let pce_id = input.pce_id.to_le_bytes().to_hex();
         let url = format!(
             "{}/sgx/certification/v{}/pckcerts?encrypted_ppid={}&pceid={}",
-            INTEL_BASE_URL, api_version, encrypted_ppid, pce_id,
+            base_url, api_version, encrypted_ppid, pce_id,
         );
         let headers = if let Some(api_key) = &input.api_key {
             vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
@@ -251,7 +250,7 @@ impl ProvisioningServiceApi for PckCertService {
     type Input<'a> = PckCertIn<'a>;
     type Output = PckCert<Unverified>;
 
-    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let encrypted_ppid = input
             .encrypted_ppid
@@ -260,9 +259,13 @@ impl ProvisioningServiceApi for PckCertService {
         let cpusvn = input.cpu_svn.to_hex();
         let pce_isvsvn = input.pce_isvsvn.to_le_bytes().to_hex();
         let pce_id = input.pce_id.to_le_bytes().to_hex();
+        let qe_id = match input.qe_id {
+            Some(qe_id) => format!("&qeid={}", qe_id.to_hex()),
+            None => String::new(),
+        };
         let url = format!(
-            "{}/sgx/certification/v{}/pckcert?encrypted_ppid={}&cpusvn={}&pcesvn={}&pceid={}",
-            INTEL_BASE_URL, api_version, encrypted_ppid, cpusvn, pce_isvsvn, pce_id,
+            "{}/sgx/certification/v{}/pckcert?encrypted_ppid={}&cpusvn={}&pcesvn={}&pceid={}{}",
+            base_url, api_version, encrypted_ppid, cpusvn, pce_isvsvn, pce_id, qe_id
         );
         let headers = if let Some(api_key) = input.api_key {
             vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
@@ -317,18 +320,29 @@ pub struct PckCrlIn {
     ca: DcapArtifactIssuer,
 }
 
+impl PckCrlIn {
+    fn new(api_version: PcsVersion, ca: DcapArtifactIssuer) -> Self {
+        PckCrlIn { api_version, ca }
+    }
+}
+
 impl WithApiVersion for PckCrlIn {
     fn api_version(&self) -> PcsVersion {
         self.api_version
     }
 }
 
-struct PckCrlService;
-impl ProvisioningServiceApi for PckCrlService {
+pub trait PckCrlService : ProvisioningServiceApi {
+    fn new() -> Self;
+    fn build_input(&self, api_version: PcsVersion, ca: DcapArtifactIssuer) -> <Self as ProvisioningServiceApi>::Input<'_>;
+}
+
+pub struct PCSPckCrlService;
+impl ProvisioningServiceApi for PCSPckCrlService {
     type Input<'a> = PckCrlIn;
     type Output = PckCrl<Unverified>;
 
-    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let ca = match input.ca {
             DcapArtifactIssuer::PCKProcessorCA => "processor",
             DcapArtifactIssuer::PCKPlatformCA => "platform",
@@ -341,7 +355,7 @@ impl ProvisioningServiceApi for PckCrlService {
         };
         let url = format!(
             "{}/sgx/certification/v{}/pckcrl?ca={}&encoding=pem",
-            INTEL_BASE_URL, input.api_version as u8, ca,
+            base_url, input.api_version as u8, ca,
         );
         Ok((url, Vec::new()))
     }
@@ -398,17 +412,17 @@ impl ProvisioningServiceApi for QeIdService {
     type Input<'a> = QeIdIn;
     type Output = QeIdentitySigned;
 
-    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let url = if let Some(tcb_evaluation_data_number) = input.tcb_evaluation_data_number {
             format!(
                 "{}/sgx/certification/v{}/qe/identity?tcbEvaluationDataNumber={}",
-                INTEL_BASE_URL, api_version, tcb_evaluation_data_number
+                base_url, api_version, tcb_evaluation_data_number
             )
         } else {
             format!(
                 "{}/sgx/certification/v{}/qe/identity?update=early",
-                INTEL_BASE_URL, api_version,
+                base_url, api_version,
             )
         };
         Ok((url, Vec::new()))
@@ -472,13 +486,13 @@ impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi for TcbI
     type Input<'a> = TcbInfoIn<'a>;
     type Output = TcbInfo<T>;
 
-    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let fmspc = input.fmspc.as_bytes().to_hex();
         let url = if let Some(evaluation_data_number) = input.tcb_evaluation_data_number {
             format!(
                 "{}/{}/certification/v{}/tcb?fmspc={}&tcbEvaluationDataNumber={}",
-                INTEL_BASE_URL,
+                base_url,
                 T::tag(),
                 api_version,
                 fmspc,
@@ -487,7 +501,7 @@ impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi for TcbI
         } else {
             format!(
                 "{}/{}/certification/v{}/tcb?fmspc={}&update=early",
-                INTEL_BASE_URL,
+                base_url,
                 T::tag(),
                 api_version,
                 fmspc,
@@ -547,17 +561,16 @@ impl WithApiVersion for TcbEvaluationDataNumbersIn {
 }
 
 struct TcbEvaluationDataNumbersService<T: PlatformTypeForTcbInfo> {
-    base_url: String,
     _type: PhantomData<T>
 }
 impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi for TcbEvaluationDataNumbersService<T> {
     type Input<'a> = TcbEvaluationDataNumbersIn;
     type Output = RawTcbEvaluationDataNumbers<T>;
 
-    fn build_request(&self, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let url = format!(
             "{}/{}/certification/v{}/tcbevaluationdatanumbers",
-            self.base_url,
+            base_url,
             T::tag(),
             input.api_version() as u8,
         );
@@ -620,31 +633,23 @@ impl ClientBuilder {
         self
     }
 
-    pub(crate) fn build<F>(
+    pub(crate) fn build<F: for<'a> Fetcher<'a>, PC: PckCrlService>(
         self,
+        base_url: &str,
         api_version: PcsVersion,
         pckcerts_service: PckCertsService,
         pckcert_service: PckCertService,
-        pckcrl_service: PckCrlService,
+        pckcrl_service: PC,
         qeid_service: QeIdService,
         sgx_tcbinfo_service: TcbInfoService<platform::SGX>,
         tdx_tcbinfo_service: TcbInfoService<platform::TDX>,
         sgx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::SGX>,
         tdx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::TDX>,
         fetcher: F,
-    ) -> Client<F>
-    where
-        // PSS: for<'a> PckCertsService + Sync + Send + 'static,
-        // PS: for<'a> PckCertService + Sync + Send + 'static,
-        // PC: for<'a> PckCrlService + Sync + Send + 'static,
-        // QS: for<'a> QeIdService + Sync + Send + 'static,
-        // TS: for<'a> TcbInfoService<platform::SGX> + Sync + Send + 'static,
-        // TDS: for<'a> TcbInfoService<platform::TDX> + Sync + Send + 'static,
-        // ES: for<'a> TcbEvaluationDataNumbersService<platform::SGX> + Sync + Send + 'static,
-        // TES: for<'a> TcbEvaluationDataNumbersService<platform::TDX> + Sync + Send + 'static,
-        F: for<'a> Fetcher<'a>,
+    ) -> Client<F, PC>
     {
         Client::new(
+            base_url,
             api_version,
             pckcerts_service,
             pckcert_service,
@@ -680,10 +685,10 @@ impl<T: ProvisioningServiceApi> PcsService<T> {
     fn call_service<'a, F: Fetcher<'a>>(
         &self,
         fetcher: &'a F,
-        input: &<T as ProvisioningServiceApi>::Input<'_>,
-    ) -> Result<<T as ProvisioningServiceApi>::Output, Error> {
-        let (url, headers) =
-            <T as ProvisioningServiceApi>::build_request(&self.pcs_service(), input)?;
+        base_url: &str,
+        input: &T::Input<'_>,
+    ) -> Result<T::Output, Error> {
+        let (url, headers) = self.service.build_request(base_url, input)?;
         let req = fetcher.build_request(&url, headers)?;
         let api_version = input.api_version();
 
@@ -701,7 +706,7 @@ impl<T: ProvisioningServiceApi> PcsService<T> {
 
 struct CachedService<T: ProvisioningServiceApi> {
     service: BackoffService<T>,
-    cache: Mutex<LruCache<u64, (<T as ProvisioningServiceApi>::Output, SystemTime)>>,
+    cache: Mutex<LruCache<u64, (T::Output, SystemTime)>>,
     cache_shelf_time: Duration,
 }
 
@@ -727,8 +732,9 @@ impl<T: ProvisioningServiceApi>
     pub fn call_service<'a, F: Fetcher<'a>>(
         &self,
         fetcher: &'a F,
-        input: &<T as ProvisioningServiceApi>::Input<'_>,
-    ) -> Result<<T as ProvisioningServiceApi>::Output, Error> {
+        base_url: &str,
+        input: &T::Input<'_>,
+    ) -> Result<T::Output, Error> {
         let key = {
             let mut hasher = DefaultHasher::new();
             input.hash(&mut hasher);
@@ -743,7 +749,7 @@ impl<T: ProvisioningServiceApi>
                 return Ok(value.to_owned());
             }
         }
-        let value = self.service.call_service::<F>(fetcher, input)?;
+        let value = self.service.call_service::<F>(fetcher, base_url, input)?;
         cache.insert(key, (value.clone(), SystemTime::now()));
         Ok(value)
     }
@@ -774,10 +780,11 @@ impl<T: ProvisioningServiceApi> BackoffService<T> {
     pub fn call_service<'a, F: Fetcher<'a>>(
         &self,
         fetcher: &'a F,
-        input: &<T as ProvisioningServiceApi>::Input<'_>,
-    ) -> Result<<T as ProvisioningServiceApi>::Output, Error> {
+        base_url: &str,
+        input: &T::Input<'_>,
+    ) -> Result<T::Output, Error> {
         if let Some(retry_timeout) = self.retry_timeout {
-            let op = || match self.service.call_service::<F>(fetcher, input) {
+            let op = || match self.service.call_service::<F>(fetcher, base_url, input) {
                 Ok(output) => Ok(output),
                 Err(err) => match err {
                     Error::PCSError(status_code, msg) => {
@@ -801,27 +808,19 @@ impl<T: ProvisioningServiceApi> BackoffService<T> {
                 backoff::Error::Transient { err, .. } => err,
             })
         } else {
-            self.service.call_service::<F>(fetcher, input)
+            self.service.call_service::<F>(fetcher, base_url, input)
         }
     }
 }
 
-pub struct Client<F: for<'a> Fetcher<'a>>
-where
-    // PSS: PckCertsService,
-    // PS: PckCertService + Sync + Send + 'static,
-    // PC: PckCrlService + Sync + Send + 'static,
-    // QS: QeIdService + Sync + Send + 'static,
-    // TS: TcbInfoService<platform::SGX> + Sync + Send + 'static,
-    // TDS: TcbInfoService<platform::TDX> + Sync + Send + 'static,
-    // ES: TcbEvaluationDataNumbersService<platform::SGX> + Sync + Send + 'static,
-    // TES: TcbEvaluationDataNumbersService<platform::TDX> + Sync + Send + 'static,
+pub struct Client<F: for<'a> Fetcher<'a>, PC: PckCrlService>
 {
+    base_url: String,
     api_version: PcsVersion,
     pckcerts_service: CachedService<PckCertsService>,
     pckcert_service:
         CachedService<PckCertService>,
-    pckcrl_service: CachedService<PckCrlService>,
+    pckcrl_service: CachedService<PC>,
     qeid_service: CachedService<QeIdService>,
     sgx_tcbinfo_service: CachedService<TcbInfoService<platform::SGX>>,
     tdx_tcbinfo_service: CachedService<TcbInfoService<platform::TDX>>,
@@ -830,22 +829,14 @@ where
     fetcher: F,
 }
 
-impl<F: for<'a> Fetcher<'a>> Client<F>
-where
-    // PSS: PckCertsService,
-    // PS: PckCertService + Sync + Send + 'static,
-    // PC: PckCrlService + Sync + Send + 'static,
-    // QS: QeIdService + Sync + Send + 'static,
-    // TS: TcbInfoService<platform::SGX> + Sync + Send + 'static,
-    // TDS: TcbInfoService<platform::TDX> + Sync + Send + 'static,
-    // ES: TcbEvaluationDataNumbersService<platform::SGX> + Sync + Send + 'static,
-    // TES: TcbEvaluationDataNumbersService<platform::TDX> + Sync + Send + 'static
+impl<F: for<'a> Fetcher<'a>, PC: PckCrlService> Client<F, PC>
 {
     fn new(
+        base_url: &str,
         api_version: PcsVersion,
         pckcerts_service: PckCertsService,
         pckcert_service: PckCertService,
-        pckcrl_service: PckCrlService,
+        pckcrl_service: PC,
         qeid_service: QeIdService,
         sgx_tcbinfo_service: TcbInfoService<platform::SGX>,
         tdx_tcbinfo_service: TcbInfoService<platform::TDX>,
@@ -856,17 +847,9 @@ where
         cache_capacity: usize,
         cache_shelf_time: Duration,
     ) -> Self
-    where
-        // PSS: PckCertsService,
-        // PS: PckCertService + Sync + Send + 'static,
-        // PC: PckCrlService + Sync + Send + 'static,
-        // QS: QeIdService + Sync + Send + 'static,
-        // TS: TcbInfoService<platform::SGX> + Sync + Send + 'static,
-        // TDS: TcbInfoService<platform::TDX> + Sync + Send + 'static,
-        // ES: TcbEvaluationDataNumbersService<platform::SGX> + Sync + Send + 'static,
-        // TES: TcbEvaluationDataNumbersService<platform::TDX> + Sync + Send + 'static,
     {
         Client {
+            base_url: base_url.to_owned(),
             api_version,
             pckcerts_service: CachedService::new(
                 BackoffService::new(
@@ -937,7 +920,7 @@ where
     }
 }
 
-pub trait ProvisioningClient {
+pub trait ProvisioningClient<PC: PckCrlService> {
     fn pckcerts(&self, api_key: &Option<String>, enc_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error>;
 
     fn pckcert(
@@ -954,7 +937,7 @@ pub trait ProvisioningClient {
 
     fn tdx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error>;
 
-    fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl<Unverified>, Error>;
+    fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PC::Output, Error>;
 
     fn qe_identity(&self, evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error>;
 
@@ -1043,45 +1026,36 @@ pub trait ProvisioningClient {
 
 
 pub trait ProvisioningClientFuncSelector: PlatformTypeForTcbInfo {
-    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<Self>, Error>;
-    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<Self>, Error>;
+    fn get_tcb_evaluation_data_numbers<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>) -> Result<RawTcbEvaluationDataNumbers<Self>, Error>;
+    fn get_tcbinfo<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<Self>, Error>;
 }
 
 impl ProvisioningClientFuncSelector for platform::SGX {
-    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
+    fn get_tcb_evaluation_data_numbers<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
         pc.sgx_tcb_evaluation_data_numbers()
     }
 
-    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
+    fn get_tcbinfo<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
         pc.sgx_tcbinfo(fmspc, evaluation_data_number)
     }
 }
 
 impl ProvisioningClientFuncSelector for platform::TDX {
-    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
+    fn get_tcb_evaluation_data_numbers<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
         pc.tdx_tcb_evaluation_data_numbers()
     }
 
-    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
+    fn get_tcbinfo<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
         pc.tdx_tcbinfo(fmspc, evaluation_data_number)
     }
 }
 
 
-impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F>
-where
-    // PSS: PckCertsService,
-    // PS: PckCertService + Sync + Send + 'static,
-    // PC: PckCrlService + Sync + Send + 'static,
-    // QS: QeIdService + Sync + Send + 'static,
-    // TS: TcbInfoService<platform::SGX> + Sync + Send + 'static,
-    // TDS: TcbInfoService<platform::TDX> + Sync + Send + 'static,
-    // ES: TcbEvaluationDataNumbersService<platform::SGX> + Sync + Send + 'static,
-    // TES: TcbEvaluationDataNumbersService<platform::TDX> + Sync + Send + 'static
+impl<F: for<'a> Fetcher<'a>, PC: PckCrlService> ProvisioningClient<PC> for Client<F, PC>
 {
     fn pckcerts(&self, api_key: &Option<String>, encrypted_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error> {
         let input = PckCertsIn { enc_ppid: encrypted_ppid, pce_id, api_key, api_version: self.api_version };
-        self.pckcerts_service.call_service(&self.fetcher, &input)
+        self.pckcerts_service.call_service(&self.fetcher, &self.base_url, &input)
     }
 
     fn pckcert(
@@ -1094,41 +1068,37 @@ where
         qe_id: Option<&QeId>,
     ) -> Result<PckCert<Unverified>, Error> {
         let input = PckCertIn { encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id, api_version: self.api_version, api_key };
-        self.pckcert_service.call_service(&self.fetcher, &input)
+        self.pckcert_service.call_service(&self.fetcher, &self.base_url, &input)
     }
 
     fn sgx_tcbinfo(&self, fmspc: &Fmspc, tcb_evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
-        // let input = self.sgx_tcbinfo_service.pcs_service().build_input(fmspc, tcb_evaluation_data_number);
         let input = TcbInfoIn { api_version: self.api_version, fmspc, tcb_evaluation_data_number };
-        self.sgx_tcbinfo_service.call_service(&self.fetcher, &input)
+        self.sgx_tcbinfo_service.call_service(&self.fetcher, &self.base_url, &input)
     }
 
     fn tdx_tcbinfo(&self, fmspc: &Fmspc, tcb_evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
-        // let input = self.tdx_tcbinfo_service.pcs_service().build_input(fmspc, tcb_evaluation_data_number);
         let input = TcbInfoIn { api_version: self.api_version, fmspc, tcb_evaluation_data_number };
-        self.tdx_tcbinfo_service.call_service(&self.fetcher, &input)
+        self.tdx_tcbinfo_service.call_service(&self.fetcher, &self.base_url, &input)
     }
 
-    fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl<Unverified>, Error> {
-        // let input = self.pckcrl_service.pcs_service().build_input(ca);
-        let input = PckCrlIn { api_version: self.api_version, ca };
-        self.pckcrl_service.call_service(&self.fetcher, &input)
+    fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PC::Output, Error> {
+        let input = self.pckcrl_service.pcs_service().build_input(self.api_version, ca);
+        self.pckcrl_service.call_service(&self.fetcher, &self.base_url, &input)
     }
 
     fn qe_identity(&self, tcb_evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error> {
         let input = QeIdIn { api_version: self.api_version, tcb_evaluation_data_number };
-        self.qeid_service.call_service(&self.fetcher, &input)
+        self.qeid_service.call_service(&self.fetcher, &self.base_url, &input)
     }
 
     fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
         let input = TcbEvaluationDataNumbersIn;
-        self.sgx_tcb_evaluation_data_numbers_service.call_service(&self.fetcher, &input)
+        self.sgx_tcb_evaluation_data_numbers_service.call_service(&self.fetcher, &self.base_url, &input)
     }
 
     fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
-        // let input = self.tdx_tcb_evaluation_data_numbers_service.pcs_service().build_input();
         let input = TcbEvaluationDataNumbersIn;
-        self.tdx_tcb_evaluation_data_numbers_service.call_service(&self.fetcher, &input)
+        self.tdx_tcb_evaluation_data_numbers_service.call_service(&self.fetcher, &self.base_url, &input)
 
     }
 }
@@ -1219,6 +1189,7 @@ pub trait ProvisioningServiceApi {
 
     fn build_request(
         &self,
+        base_url: &str,
         input: &Self::Input<'_>,
     ) -> Result<(String, Vec<(String, String)>), Error>;
 
@@ -1271,6 +1242,7 @@ mod tests {
 
         fn build_request(
             &self,
+            _base_url: &str,
             _input: &Self::Input<'_>,
         ) -> Result<(String, Vec<(String, String)>), Error> {
             Ok((_input.0.to_string(), vec![]))
@@ -1328,10 +1300,10 @@ mod tests {
         let input_b = MockInput(420);
 
         // Initial call to populate the cache for `input_a`
-        cached_service.call_service(&fetcher, &input_a).unwrap();
+        cached_service.call_service(&fetcher, "", &input_a).unwrap();
 
         // input_b should provoke cache miss and add new key to the cache
-        let result = cached_service.call_service(&fetcher, &input_b).unwrap();
+        let result = cached_service.call_service(&fetcher, "", &input_b).unwrap();
 
         let (cached_value, _) = {
             let mut cache = cached_service.cache.lock().unwrap();
@@ -1352,7 +1324,7 @@ mod tests {
         let input = MockInput(42);
 
         // Initial call to populate the cache
-        let _ = cached_service.call_service(&fetcher, &input).unwrap();
+        let _ = cached_service.call_service(&fetcher, "", &input).unwrap();
 
         // Now the service should not be called, and the cached result should be returned
         let (cached_value, _) = {
@@ -1360,7 +1332,7 @@ mod tests {
             cache.get_mut(&calculate_key(&input)).unwrap().to_owned()
         };
 
-        let result = cached_service.call_service(&fetcher, &input).unwrap();
+        let result = cached_service.call_service(&fetcher, "", &input).unwrap();
         assert_eq!(result, cached_value);
     }
 
@@ -1376,7 +1348,7 @@ mod tests {
         // Insert entries into the cache, exceeding its capacity
         for i in 0..3 {
             let input = MockInput(i);
-            let _ = cached_service.call_service(&fetcher, &input).unwrap();
+            let _ = cached_service.call_service(&fetcher, "", &input).unwrap();
         }
 
         // At this point, the cache should have evicted the first inserted entry (MockInput(0))

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
@@ -5,8 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::BTreeMap;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::Read;
 use std::marker::PhantomData;
@@ -567,9 +566,6 @@ impl ClientBuilder {
         &self,
         base_url: &str,
         api_version: PcsVersion,
-        // pckcerts_service: PckCertsService,
-        // pckcert_service: CS,
-        // pckcrl_service: PC,
         qeid_service: QeIdService,
         sgx_tcbinfo_service: TcbInfoService<platform::SGX>,
         tdx_tcbinfo_service: TcbInfoService<platform::TDX>,
@@ -581,9 +577,6 @@ impl ClientBuilder {
         Client::new(
             base_url,
             api_version,
-            // pckcerts_service,
-            // pckcert_service,
-            // pckcrl_service,
             qeid_service,
             sgx_tcbinfo_service,
             tdx_tcbinfo_service,
@@ -747,9 +740,6 @@ pub struct Client<F: for<'a> Fetcher<'a>>
 {
     base_url: String,
     api_version: PcsVersion,
-    // pckcerts_service: CachedService<PckCertsService>,
-    // pckcert_service: CachedService<CS>,
-    // pckcrl_service: CachedService<PC>,
     qeid_service: CachedService<QeIdService>,
     sgx_tcbinfo_service: CachedService<TcbInfoService<platform::SGX>>,
     tdx_tcbinfo_service: CachedService<TcbInfoService<platform::TDX>>,
@@ -763,9 +753,6 @@ impl<F: for<'a> Fetcher<'a>> Client<F>
     fn new(
         base_url: &str,
         api_version: PcsVersion,
-        // pckcerts_service: PckCertsService,
-        // pckcert_service: CS,
-        // pckcrl_service: PC,
         qeid_service: QeIdService,
         sgx_tcbinfo_service: TcbInfoService<platform::SGX>,
         tdx_tcbinfo_service: TcbInfoService<platform::TDX>,
@@ -780,30 +767,6 @@ impl<F: for<'a> Fetcher<'a>> Client<F>
         Client {
             base_url: base_url.to_owned(),
             api_version,
-            // pckcerts_service: CachedService::new(
-            //     BackoffService::new(
-            //         PcsService::new(pckcerts_service),
-            //         retry_timeout.clone(),
-            //     ),
-            //     cache_capacity,
-            //     cache_shelf_time,
-            // ),
-            // pckcert_service: CachedService::new(
-            //     BackoffService::new(
-            //         PcsService::new(pckcert_service),
-            //         retry_timeout.clone(),
-            //     ),
-            //     cache_capacity,
-            //     cache_shelf_time,
-            // ),
-            // pckcrl_service: CachedService::new(
-            //     BackoffService::new(
-            //         PcsService::new(pckcrl_service),
-            //         retry_timeout.clone(),
-            //     ),
-            //     cache_capacity,
-            //     cache_shelf_time,
-            // ),
             qeid_service: CachedService::new(
                 BackoffService::new(
                     PcsService::new(qeid_service),
@@ -851,6 +814,68 @@ impl<F: for<'a> Fetcher<'a>> Client<F>
 
 pub trait ProvisioningClient {
     // fn pckcerts(&self, api_key: &Option<String>, enc_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error>;
+    fn pckcerts(&self, pck_id: &PckID) -> Result<PckCerts, Error>;
+
+    fn pckcert(
+        &self,
+        api_key: &Option<String>,
+        encrypted_ppid: Option<&EncPpid>,
+        pce_id: &PceId,
+        cpu_svn: &CpuSvn,
+        pce_isvsvn: PceIsvsvn,
+        qe_id: Option<&QeId>,
+    ) -> Result<PckCert<Unverified>, Error>;
+
+    fn sgx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error>;
+
+    fn tdx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error>;
+
+    fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl<Unverified>, Error>;
+
+    fn qe_identity(&self, evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error>;
+
+    fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error>;
+
+    fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error>;
+}
+
+
+pub trait ProvisioningClientFuncSelector: PlatformTypeForTcbInfo {
+    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<Self>, Error>;
+    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<Self>, Error>;
+}
+
+impl ProvisioningClientFuncSelector for platform::SGX {
+    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
+        pc.sgx_tcb_evaluation_data_numbers()
+    }
+
+    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
+        pc.sgx_tcbinfo(fmspc, evaluation_data_number)
+    }
+}
+
+impl ProvisioningClientFuncSelector for platform::TDX {
+    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
+        pc.tdx_tcb_evaluation_data_numbers()
+    }
+
+    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
+        pc.tdx_tcbinfo(fmspc, evaluation_data_number)
+    }
+}
+
+
+impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F>
+{
+    fn pckcerts(&self, pck_id: &PckID) -> Result<PckCerts, Error> {
+        todo!()
+    }
+
+    // fn pckcerts(&self, api_key: &Option<String>, encrypted_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error> {
+    //     let input = PckCertsIn { enc_ppid: encrypted_ppid, pce_id, api_key, api_version: self.api_version };
+    //     self.pckcerts_service.call_service(&self.fetcher, &self.base_url, &input)
+    // }
 
     // fn pckcert(
     //     &self,
@@ -860,18 +885,13 @@ pub trait ProvisioningClient {
     //     cpu_svn: &CpuSvn,
     //     pce_isvsvn: PceIsvsvn,
     //     qe_id: Option<&QeId>,
-    // ) -> Result<PckCert<Unverified>, Error>;
+    // ) -> Result<PckCert<Unverified>, Error> {
+    //     let input = self.pckcert_service.pcs_service().build_input(self.api_version, encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id, api_key, None, None);
+    //     self.pckcert_service.call_service(&self.fetcher, &self.base_url, &input)
+    // }
 
-    fn sgx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error>;
-
-    fn tdx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error>;
-
-    // fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl, Error>;
-
-    fn qe_identity(&self, evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error>;
-
-    /// Retrieve PCK certificates using `pckcerts()` and fallback to the
-    /// following method if that's not supported:
+    /// Retrieve PCK certificates when `pckcerts` Rest API is not supported
+    /// using the following method:
     /// 1. Call `pckcert()` with PCK ID to get best available PCK cert.
     /// 2. Try to call `pckcert()` with PCK ID but with CPUSVN all 1's.
     /// 3. Using the FMSPC value from PCK cert in step 1, call `tcbinfo()` to
@@ -884,7 +904,7 @@ pub trait ProvisioningClient {
     ///       microcode value is set to the late microcode value.
     ///
     /// Note that PCK certs for some TCB levels may be missing.
-    // fn pckcerts_with_fallback(&self, api_key: &Option<String>, pck_id: &PckID) -> Result<PckCerts, Error> {
+    // fn pckcerts(&self, pck_id: &PckID) -> Result<PckCerts, Error> {
     //     let get_and_collect = |collection: &mut BTreeMap<([u8; 16], u16), PckCert<Unverified>>, cpu_svn: &[u8; 16], pce_svn: u16| -> Result<PckCert<Unverified>, Error> {
     //         let pck_cert = self.pckcert(
     //             api_key,
@@ -900,13 +920,6 @@ pub trait ProvisioningClient {
     //         collection.insert((ptcb.cpusvn, ptcb.tcb_components.pce_svn()), pck_cert.clone());
     //         Ok(pck_cert)
     //     };
-
-    //     match self.pckcerts(api_key, &pck_id.enc_ppid, pck_id.pce_id) {
-    //         Ok(pck_certs) => return Ok(pck_certs),
-    //         Err(Error::RequestNotSupported) => {} // fallback below
-    //         Err(e) => return Err(e),
-    //     }
-    //     // fallback:
 
     //     // Use BTreeMap to have an ordered PckCerts at the end
     //     let mut pckcerts_map = BTreeMap::new();
@@ -947,58 +960,10 @@ pub trait ProvisioningClient {
     //         .try_into()
     //         .map_err(|e| Error::PCSDecodeError(format!("{}", e).into()))
     // }
-
-    fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error>;
-
-    fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error>;
-}
-
-
-pub trait ProvisioningClientFuncSelector: PlatformTypeForTcbInfo {
-    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<Self>, Error>;
-    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<Self>, Error>;
-}
-
-impl ProvisioningClientFuncSelector for platform::SGX {
-    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
-        pc.sgx_tcb_evaluation_data_numbers()
+    
+    fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl<Unverified>, Error> {
+        todo!()
     }
-
-    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
-        pc.sgx_tcbinfo(fmspc, evaluation_data_number)
-    }
-}
-
-impl ProvisioningClientFuncSelector for platform::TDX {
-    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
-        pc.tdx_tcb_evaluation_data_numbers()
-    }
-
-    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
-        pc.tdx_tcbinfo(fmspc, evaluation_data_number)
-    }
-}
-
-
-impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F>
-{
-    // fn pckcerts(&self, api_key: &Option<String>, encrypted_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error> {
-    //     let input = PckCertsIn { enc_ppid: encrypted_ppid, pce_id, api_key, api_version: self.api_version };
-    //     self.pckcerts_service.call_service(&self.fetcher, &self.base_url, &input)
-    // }
-
-    // fn pckcert(
-    //     &self,
-    //     api_key: &Option<String>,
-    //     encrypted_ppid: Option<&EncPpid>,
-    //     pce_id: &PceId,
-    //     cpu_svn: &CpuSvn,
-    //     pce_isvsvn: PceIsvsvn,
-    //     qe_id: Option<&QeId>,
-    // ) -> Result<PckCert<Unverified>, Error> {
-    //     let input = self.pckcert_service.pcs_service().build_input(self.api_version, encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id, api_key, None, None);
-    //     self.pckcert_service.call_service(&self.fetcher, &self.base_url, &input)
-    // }
 
     fn sgx_tcbinfo(&self, fmspc: &Fmspc, tcb_evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
         let input = TcbInfoIn { api_version: self.api_version, fmspc, tcb_evaluation_data_number };
@@ -1028,7 +993,18 @@ impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F>
     fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
         let input = TcbEvaluationDataNumbersIn;
         self.tdx_tcb_evaluation_data_numbers_service.call_service(&self.fetcher, &self.base_url, &input)
-
+    }
+    
+    fn pckcert(
+        &self,
+        api_key: &Option<String>,
+        encrypted_ppid: Option<&EncPpid>,
+        pce_id: &PceId,
+        cpu_svn: &CpuSvn,
+        pce_isvsvn: PceIsvsvn,
+        qe_id: Option<&QeId>,
+    ) -> Result<PckCert<Unverified>, Error> {
+        todo!()
     }
 }
 

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, SystemTime};
 use lru_cache::LruCache;
 use num_enum::TryFromPrimitive;
 use pcs::{
-    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PckID, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, TcbComponentType, TcbInfo, Unverified, platform
+    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PckID, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, TcbInfo, Unverified, platform
 };
 #[cfg(feature = "reqwest")]
 use reqwest::blocking::{Client as ReqwestClient, Response as ReqwestResponse};
@@ -190,7 +190,7 @@ impl ProvisioningServiceApi for PckCertService {
     type Input<'a> = PckCertIn<'a>;
     type Output = PckCert<Unverified>;
 
-    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let encrypted_ppid = input
             .encrypted_ppid
@@ -215,7 +215,7 @@ impl ProvisioningServiceApi for PckCertService {
         Ok((url, headers))
     }
 
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+    fn validate_response(status_code: StatusCode) -> Result<(), Error> {
         match status_code {
             StatusCode::Ok => Ok(()),
             StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
@@ -244,7 +244,6 @@ impl ProvisioningServiceApi for PckCertService {
     }
 
     fn parse_response(
-        &self,
         response_body: String,
         response_headers: Vec<(String, String)>,
         _api_version: PcsVersion,
@@ -271,7 +270,7 @@ impl ProvisioningServiceApi for PckCrlService {
     type Input<'a> = PckCrlIn;
     type Output = PckCrl<Unverified>;
 
-    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let ca = match input.ca {
             DcapArtifactIssuer::PCKProcessorCA => "processor",
             DcapArtifactIssuer::PCKPlatformCA => "platform",
@@ -289,7 +288,7 @@ impl ProvisioningServiceApi for PckCrlService {
         Ok((url, Vec::new()))
     }
 
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+    fn validate_response(status_code: StatusCode) -> Result<(), Error> {
         match &status_code {
             StatusCode::Ok => Ok(()),
             StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
@@ -313,7 +312,6 @@ impl ProvisioningServiceApi for PckCrlService {
     }
 
     fn parse_response(
-        &self,
         response_body: String,
         response_headers: Vec<(String, String)>,
         _api_version: PcsVersion,
@@ -341,7 +339,7 @@ impl ProvisioningServiceApi for QeIdService {
     type Input<'a> = QeIdIn;
     type Output = QeIdentitySigned;
 
-    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let url = if let Some(tcb_evaluation_data_number) = input.tcb_evaluation_data_number {
             format!(
@@ -357,7 +355,7 @@ impl ProvisioningServiceApi for QeIdService {
         Ok((url, Vec::new()))
     }
 
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+    fn validate_response(status_code: StatusCode) -> Result<(), Error> {
         match &status_code {
             StatusCode::Ok => Ok(()),
             StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
@@ -384,7 +382,6 @@ impl ProvisioningServiceApi for QeIdService {
     }
 
     fn parse_response(
-        &self,
         response_body: String,
         response_headers: Vec<(String, String)>,
         _api_version: PcsVersion,
@@ -415,7 +412,7 @@ impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi for TcbI
     type Input<'a> = TcbInfoIn<'a>;
     type Output = TcbInfo<T>;
 
-    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let api_version = input.api_version as u8;
         let fmspc = input.fmspc.as_bytes().to_hex();
         let url = if let Some(evaluation_data_number) = input.tcb_evaluation_data_number {
@@ -439,7 +436,7 @@ impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi for TcbI
         Ok((url, Vec::new()))
     }
 
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+    fn validate_response(status_code: StatusCode) -> Result<(), Error> {
         match &status_code {
             StatusCode::Ok => Ok(()),
             StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
@@ -465,7 +462,6 @@ impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi for TcbI
     }
 
     fn parse_response(
-        &self,
         response_body: String,
         response_headers: Vec<(String, String)>,
         api_version: PcsVersion,
@@ -496,7 +492,7 @@ impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi for TcbE
     type Input<'a> = TcbEvaluationDataNumbersIn;
     type Output = RawTcbEvaluationDataNumbers<T>;
 
-    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
         let url = format!(
             "{}/{}/certification/v{}/tcbevaluationdatanumbers",
             base_url,
@@ -506,7 +502,7 @@ impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi for TcbE
         Ok((url, Vec::new()))
     }
 
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+    fn validate_response(status_code: StatusCode) -> Result<(), Error> {
         match &status_code {
             StatusCode::Ok => Ok(()),
             StatusCode::InternalServerError => Err(Error::PCSError(
@@ -525,7 +521,6 @@ impl<T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi for TcbE
     }
 
     fn parse_response(
-        &self,
         response_body: String,
         response_headers: Vec<(String, String)>,
         _api_version: PcsVersion,
@@ -566,22 +561,12 @@ impl ClientBuilder {
         &self,
         base_url: &str,
         api_version: PcsVersion,
-        qeid_service: QeIdService,
-        sgx_tcbinfo_service: TcbInfoService<platform::SGX>,
-        tdx_tcbinfo_service: TcbInfoService<platform::TDX>,
-        sgx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::SGX>,
-        tdx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::TDX>,
         fetcher: F,
     ) -> Client<F>
     {
         Client::new(
             base_url,
             api_version,
-            qeid_service,
-            sgx_tcbinfo_service,
-            tdx_tcbinfo_service,
-            sgx_tcb_evaluation_data_numbers_service,
-            tdx_tcb_evaluation_data_numbers_service,
             fetcher,
             self.retry_timeout,
             self.cache_capacity,
@@ -590,36 +575,22 @@ impl ClientBuilder {
     }
 }
 
-struct PcsService<T: ProvisioningServiceApi> {
-    service: T,
-}
+struct PcsService;
+impl PcsService {
 
-impl<T: ProvisioningServiceApi> PcsService<T> {
-    pub fn new(service: T) -> Self {
-        Self { service }
-    }
-}
-
-impl<T: ProvisioningServiceApi> PcsService<T> {
-    pub(crate) fn pcs_service(&self) -> &T {
-        &self.service
-    }
-
-    fn call_service<'a, F: Fetcher<'a>>(
-        &self,
+    fn call_service<'a, F: Fetcher<'a>, T: ProvisioningServiceApi>(
         fetcher: &'a F,
         base_url: &str,
         input: &T::Input<'_>,
     ) -> Result<T::Output, Error> {
-        let (url, headers) = self.service.build_request(base_url, input)?;
+        let (url, headers) = T::build_request(base_url, input)?;
         let req = fetcher.build_request(&url, headers)?;
         let api_version = input.api_version();
 
         let (status_code, resp) = fetcher.send(req)?;
-        <T as ProvisioningServiceApi>::validate_response(self.pcs_service(), status_code)?;
+        T::validate_response(status_code)?;
         let (response_body, response_headers) = fetcher.parse_response(resp)?;
-        <T as ProvisioningServiceApi>::parse_response(
-            self.pcs_service(),
+        T::parse_response(
             response_body,
             response_headers,
             api_version,
@@ -628,7 +599,7 @@ impl<T: ProvisioningServiceApi> PcsService<T> {
 }
 
 struct CachedService<T: ProvisioningServiceApi> {
-    service: BackoffService<T>,
+    service: BackoffService,
     cache: Mutex<LruCache<u64, (T::Output, SystemTime)>>,
     cache_shelf_time: Duration,
 }
@@ -636,7 +607,7 @@ struct CachedService<T: ProvisioningServiceApi> {
 impl<T: ProvisioningServiceApi>
     CachedService<T>
 {
-    pub fn new(service: BackoffService<T>, capacity: usize, cache_shelf_time: Duration) -> Self {
+    pub fn new(service: BackoffService, capacity: usize, cache_shelf_time: Duration) -> Self {
         Self {
             service,
             cache: Mutex::new(LruCache::new(capacity)),
@@ -648,10 +619,6 @@ impl<T: ProvisioningServiceApi>
 impl<T: ProvisioningServiceApi>
     CachedService<T>
 {
-    pub(crate) fn pcs_service(&self) -> &T {
-        &self.service.pcs_service()
-    }
-
     pub fn call_service<'a, F: Fetcher<'a>>(
         &self,
         fetcher: &'a F,
@@ -672,42 +639,36 @@ impl<T: ProvisioningServiceApi>
                 return Ok(value.to_owned());
             }
         }
-        let value = self.service.call_service::<F>(fetcher, base_url, input)?;
+        let value = self.service.call_service::<F, T>(fetcher, base_url, input)?;
         cache.insert(key, (value.clone(), SystemTime::now()));
         Ok(value)
     }
 }
 
-struct BackoffService<T: ProvisioningServiceApi> {
-    service: PcsService<T>,
+struct BackoffService {
     retry_timeout: Option<Duration>,
 }
 
-impl<T: ProvisioningServiceApi> BackoffService<T> {
-    pub fn new(service: PcsService<T>, retry_timeout: Option<Duration>) -> Self {
+impl BackoffService {
+    pub fn new(retry_timeout: Option<Duration>) -> Self {
         Self {
-            service,
             retry_timeout,
         }
     }
 }
 
-impl<T: ProvisioningServiceApi> BackoffService<T> {
+impl BackoffService {
     const RETRY_INITIAL_INTERVAL: Duration = Duration::from_secs(2);
     const RETRY_INTERVAL_MULTIPLIER: f64 = 2.0;
 
-    pub(crate) fn pcs_service(&self) -> &T {
-        &self.service.pcs_service()
-    }
-
-    pub fn call_service<'a, F: Fetcher<'a>>(
+    pub fn call_service<'a, F: Fetcher<'a>, T: ProvisioningServiceApi>(
         &self,
         fetcher: &'a F,
         base_url: &str,
         input: &T::Input<'_>,
     ) -> Result<T::Output, Error> {
         if let Some(retry_timeout) = self.retry_timeout {
-            let op = || match self.service.call_service::<F>(fetcher, base_url, input) {
+            let op = || match PcsService::call_service::<F, T>(fetcher, base_url, input) {
                 Ok(output) => Ok(output),
                 Err(err) => match err {
                     Error::PCSError(status_code, msg) => {
@@ -731,7 +692,7 @@ impl<T: ProvisioningServiceApi> BackoffService<T> {
                 backoff::Error::Transient { err, .. } => err,
             })
         } else {
-            self.service.call_service::<F>(fetcher, base_url, input)
+            PcsService::call_service::<F, T>(fetcher, base_url, input)
         }
     }
 }
@@ -753,11 +714,6 @@ impl<F: for<'a> Fetcher<'a>> Client<F>
     fn new(
         base_url: &str,
         api_version: PcsVersion,
-        qeid_service: QeIdService,
-        sgx_tcbinfo_service: TcbInfoService<platform::SGX>,
-        tdx_tcbinfo_service: TcbInfoService<platform::TDX>,
-        sgx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::SGX>,
-        tdx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::TDX>,
         fetcher: F,
         retry_timeout: Option<Duration>,
         cache_capacity: usize,
@@ -769,7 +725,6 @@ impl<F: for<'a> Fetcher<'a>> Client<F>
             api_version,
             qeid_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(qeid_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -777,7 +732,6 @@ impl<F: for<'a> Fetcher<'a>> Client<F>
             ),
             sgx_tcbinfo_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(sgx_tcbinfo_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -785,7 +739,6 @@ impl<F: for<'a> Fetcher<'a>> Client<F>
             ),
             tdx_tcbinfo_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(tdx_tcbinfo_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -793,7 +746,6 @@ impl<F: for<'a> Fetcher<'a>> Client<F>
             ),
             sgx_tcb_evaluation_data_numbers_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(sgx_tcb_evaluation_data_numbers_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -801,7 +753,6 @@ impl<F: for<'a> Fetcher<'a>> Client<F>
             ),
             tdx_tcb_evaluation_data_numbers_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(tdx_tcb_evaluation_data_numbers_service),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -813,7 +764,6 @@ impl<F: for<'a> Fetcher<'a>> Client<F>
 }
 
 pub trait ProvisioningClient {
-    // fn pckcerts(&self, api_key: &Option<String>, enc_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error>;
     fn pckcerts(&self, pck_id: &PckID) -> Result<PckCerts, Error>;
 
     fn pckcert(
@@ -975,11 +925,6 @@ impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F>
         self.tdx_tcbinfo_service.call_service(&self.fetcher, &self.base_url, &input)
     }
 
-    // fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl, Error> {
-    //     let input = self.pckcrl_service.pcs_service().build_input(self.api_version, ca);
-    //     self.pckcrl_service.call_service(&self.fetcher, &self.base_url, &input)
-    // }
-
     fn qe_identity(&self, tcb_evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error> {
         let input = QeIdIn { api_version: self.api_version, tcb_evaluation_data_number };
         self.qeid_service.call_service(&self.fetcher, &self.base_url, &input)
@@ -1093,15 +1038,13 @@ pub trait ProvisioningServiceApi {
     type Output: Clone;
 
     fn build_request(
-        &self,
         base_url: &str,
         input: &Self::Input<'_>,
     ) -> Result<(String, Vec<(String, String)>), Error>;
 
-    fn validate_response(&self, code: StatusCode) -> Result<(), Error>;
+    fn validate_response(code: StatusCode) -> Result<(), Error>;
 
     fn parse_response(
-        &self,
         response_body: String,
         response_headers: Vec<(String, String)>,
         api_version: PcsVersion,
@@ -1146,19 +1089,17 @@ mod tests {
         type Output = MockOutput;
 
         fn build_request(
-            &self,
             _base_url: &str,
             _input: &Self::Input<'_>,
         ) -> Result<(String, Vec<(String, String)>), Error> {
             Ok((_input.0.to_string(), vec![]))
         }
 
-        fn validate_response(&self, _code: StatusCode) -> Result<(), Error> {
+        fn validate_response(_code: StatusCode) -> Result<(), Error> {
             Ok(())
         }
 
         fn parse_response(
-            &self,
             response_body: String,
             _response_headers: Vec<(std::string::String, std::string::String)>,
             _api_version: PcsVersion,
@@ -1195,11 +1136,8 @@ mod tests {
 
     #[test]
     fn test_call_service_cache_miss() {
-        let service = PcsService {
-            service: MockService,
-        };
-        let service = BackoffService::new(service, None);
-        let cached_service = CachedService::new(service, 5, Duration::from_secs(120));
+        let service = BackoffService::new(None);
+        let cached_service: CachedService<MockService> = CachedService::new(service, 5, Duration::from_secs(120));
         let fetcher = MockFetcher;
         let input_a = MockInput(42);
         let input_b = MockInput(420);
@@ -1220,11 +1158,8 @@ mod tests {
 
     #[test]
     fn test_call_service_cache_hit() {
-        let service = PcsService {
-            service: MockService,
-        };
-        let service = BackoffService::new(service, None);
-        let cached_service = CachedService::new(service, 5, Duration::from_secs(120));
+        let service = BackoffService::new(None);
+        let cached_service: CachedService<MockService> = CachedService::new(service, 5, Duration::from_secs(120));
         let fetcher = MockFetcher;
         let input = MockInput(42);
 
@@ -1243,11 +1178,8 @@ mod tests {
 
     #[test]
     fn test_cache_capacity_eviction() {
-        let service = PcsService {
-            service: MockService,
-        };
-        let service = BackoffService::new(service, None);
-        let cached_service = CachedService::new(service, 2, Duration::from_secs(120));
+        let service = BackoffService::new(None);
+        let cached_service = CachedService::<MockService>::new(service, 2, Duration::from_secs(120));
         let fetcher = MockFetcher;
 
         // Insert entries into the cache, exceeding its capacity

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
@@ -25,12 +25,12 @@ use rustc_serialize::hex::ToHex;
 use crate::Error;
 use crate::provisioning_client::common::{ENCLAVE_ID_ISSUER_CHAIN_HEADER, PCK_CERTIFICATE_ISSUER_CHAIN_HEADER, PCK_CRL_ISSUER_CHAIN_HEADER, TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN, TCB_INFO_ISSUER_CHAIN_HEADER_V3, TCB_INFO_ISSUER_CHAIN_HEADER_V4, parse_issuer_header};
 
-// pub mod azure;
+pub mod azure;
 pub(self) mod common;
 pub mod intel;
 pub mod pccs;
 
-// pub use self::azure::AzureProvisioningClientBuilder;
+pub use self::azure::AzureProvisioningClientBuilder;
 pub use self::intel::IntelProvisioningClientBuilder;
 pub use self::pccs::PccsProvisioningClientBuilder;
 
@@ -168,65 +168,7 @@ impl WithApiVersion for PckCertsIn<'_> {
     }
 }
 
-pub struct PckCertsService;
-impl ProvisioningServiceApi for PckCertsService {
-    type Input<'a> = PckCertsIn<'a>;
-    type Output = PckCerts;
 
-    fn build_request(&self, base_url: &str, input: &Self::Input<'_>) -> Result<(String, Vec<(String, String)>), Error> {
-        let api_version = input.api_version as u8;
-        let encrypted_ppid = input.enc_ppid.to_hex();
-        let pce_id = input.pce_id.to_le_bytes().to_hex();
-        let url = format!(
-            "{}/sgx/certification/v{}/pckcerts?encrypted_ppid={}&pceid={}",
-            base_url, api_version, encrypted_ppid, pce_id,
-        );
-        let headers = if let Some(api_key) = &input.api_key {
-            vec![(SUBSCRIPTION_KEY_HEADER.to_owned(), api_key.to_string())]
-        } else {
-            Vec::new()
-        };
-        Ok((url, headers))
-    }
-
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
-        match status_code {
-            StatusCode::Ok => Ok(()),
-            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
-            StatusCode::Unauthorized => Err(Error::PCSError(
-                status_code,
-                "Failed to authenticate or authorize the request (check your PCS key)",
-            )),
-            StatusCode::NotFound => Err(Error::PCSError(
-                status_code,
-                "Cannot find the requested certificate",
-            )),
-            StatusCode::TooManyRequests => Err(Error::PCSError(status_code, "Too many requests")),
-            StatusCode::InternalServerError => Err(Error::PCSError(
-                status_code,
-                "PCS suffered from an internal server error",
-            )),
-            StatusCode::ServiceUnavailable => Err(Error::PCSError(
-                status_code,
-                "PCS is temporarily unavailable",
-            )),
-            _ => Err(Error::PCSError(
-                status_code,
-                "Unexpected response from PCS server",
-            )),
-        }
-    }
-
-    fn parse_response(
-        &self,
-        response_body: String,
-        response_headers: Vec<(String, String)>,
-        _api_version: PcsVersion,
-    ) -> Result<Self::Output, Error> {
-        let ca_chain = parse_issuer_header(&response_headers, PCK_CERTIFICATE_ISSUER_CHAIN_HEADER)?;
-        PckCerts::parse(&response_body, ca_chain).map_err(|e| Error::OfflineAttestationError(e))
-    }
-}
 
 #[derive(Hash)]
 pub struct PckCertIn<'a> {
@@ -244,7 +186,6 @@ impl WithApiVersion for PckCertIn<'_> {
         self.api_version
     }
 }
-
 struct PckCertService;
 impl ProvisioningServiceApi for PckCertService {
     type Input<'a> = PckCertIn<'a>;
@@ -320,25 +261,14 @@ pub struct PckCrlIn {
     ca: DcapArtifactIssuer,
 }
 
-impl PckCrlIn {
-    fn new(api_version: PcsVersion, ca: DcapArtifactIssuer) -> Self {
-        PckCrlIn { api_version, ca }
-    }
-}
-
 impl WithApiVersion for PckCrlIn {
     fn api_version(&self) -> PcsVersion {
         self.api_version
     }
 }
 
-pub trait PckCrlService : ProvisioningServiceApi {
-    fn new() -> Self;
-    fn build_input(&self, api_version: PcsVersion, ca: DcapArtifactIssuer) -> <Self as ProvisioningServiceApi>::Input<'_>;
-}
-
-pub struct PCSPckCrlService;
-impl ProvisioningServiceApi for PCSPckCrlService {
+pub struct PckCrlService;
+impl ProvisioningServiceApi for PckCrlService {
     type Input<'a> = PckCrlIn;
     type Output = PckCrl<Unverified>;
 
@@ -633,27 +563,27 @@ impl ClientBuilder {
         self
     }
 
-    pub(crate) fn build<F: for<'a> Fetcher<'a>, PC: PckCrlService>(
-        self,
+    pub(crate) fn build<F: for<'a> Fetcher<'a>>(
+        &self,
         base_url: &str,
         api_version: PcsVersion,
-        pckcerts_service: PckCertsService,
-        pckcert_service: PckCertService,
-        pckcrl_service: PC,
+        // pckcerts_service: PckCertsService,
+        // pckcert_service: CS,
+        // pckcrl_service: PC,
         qeid_service: QeIdService,
         sgx_tcbinfo_service: TcbInfoService<platform::SGX>,
         tdx_tcbinfo_service: TcbInfoService<platform::TDX>,
         sgx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::SGX>,
         tdx_tcb_evaluation_data_numbers_service: TcbEvaluationDataNumbersService<platform::TDX>,
         fetcher: F,
-    ) -> Client<F, PC>
+    ) -> Client<F>
     {
         Client::new(
             base_url,
             api_version,
-            pckcerts_service,
-            pckcert_service,
-            pckcrl_service,
+            // pckcerts_service,
+            // pckcert_service,
+            // pckcrl_service,
             qeid_service,
             sgx_tcbinfo_service,
             tdx_tcbinfo_service,
@@ -813,14 +743,13 @@ impl<T: ProvisioningServiceApi> BackoffService<T> {
     }
 }
 
-pub struct Client<F: for<'a> Fetcher<'a>, PC: PckCrlService>
+pub struct Client<F: for<'a> Fetcher<'a>>
 {
     base_url: String,
     api_version: PcsVersion,
-    pckcerts_service: CachedService<PckCertsService>,
-    pckcert_service:
-        CachedService<PckCertService>,
-    pckcrl_service: CachedService<PC>,
+    // pckcerts_service: CachedService<PckCertsService>,
+    // pckcert_service: CachedService<CS>,
+    // pckcrl_service: CachedService<PC>,
     qeid_service: CachedService<QeIdService>,
     sgx_tcbinfo_service: CachedService<TcbInfoService<platform::SGX>>,
     tdx_tcbinfo_service: CachedService<TcbInfoService<platform::TDX>>,
@@ -829,14 +758,14 @@ pub struct Client<F: for<'a> Fetcher<'a>, PC: PckCrlService>
     fetcher: F,
 }
 
-impl<F: for<'a> Fetcher<'a>, PC: PckCrlService> Client<F, PC>
+impl<F: for<'a> Fetcher<'a>> Client<F>
 {
     fn new(
         base_url: &str,
         api_version: PcsVersion,
-        pckcerts_service: PckCertsService,
-        pckcert_service: PckCertService,
-        pckcrl_service: PC,
+        // pckcerts_service: PckCertsService,
+        // pckcert_service: CS,
+        // pckcrl_service: PC,
         qeid_service: QeIdService,
         sgx_tcbinfo_service: TcbInfoService<platform::SGX>,
         tdx_tcbinfo_service: TcbInfoService<platform::TDX>,
@@ -851,30 +780,30 @@ impl<F: for<'a> Fetcher<'a>, PC: PckCrlService> Client<F, PC>
         Client {
             base_url: base_url.to_owned(),
             api_version,
-            pckcerts_service: CachedService::new(
-                BackoffService::new(
-                    PcsService::new(pckcerts_service),
-                    retry_timeout.clone(),
-                ),
-                cache_capacity,
-                cache_shelf_time,
-            ),
-            pckcert_service: CachedService::new(
-                BackoffService::new(
-                    PcsService::new(pckcert_service),
-                    retry_timeout.clone(),
-                ),
-                cache_capacity,
-                cache_shelf_time,
-            ),
-            pckcrl_service: CachedService::new(
-                BackoffService::new(
-                    PcsService::new(pckcrl_service),
-                    retry_timeout.clone(),
-                ),
-                cache_capacity,
-                cache_shelf_time,
-            ),
+            // pckcerts_service: CachedService::new(
+            //     BackoffService::new(
+            //         PcsService::new(pckcerts_service),
+            //         retry_timeout.clone(),
+            //     ),
+            //     cache_capacity,
+            //     cache_shelf_time,
+            // ),
+            // pckcert_service: CachedService::new(
+            //     BackoffService::new(
+            //         PcsService::new(pckcert_service),
+            //         retry_timeout.clone(),
+            //     ),
+            //     cache_capacity,
+            //     cache_shelf_time,
+            // ),
+            // pckcrl_service: CachedService::new(
+            //     BackoffService::new(
+            //         PcsService::new(pckcrl_service),
+            //         retry_timeout.clone(),
+            //     ),
+            //     cache_capacity,
+            //     cache_shelf_time,
+            // ),
             qeid_service: CachedService::new(
                 BackoffService::new(
                     PcsService::new(qeid_service),
@@ -920,24 +849,24 @@ impl<F: for<'a> Fetcher<'a>, PC: PckCrlService> Client<F, PC>
     }
 }
 
-pub trait ProvisioningClient<PC: PckCrlService> {
-    fn pckcerts(&self, api_key: &Option<String>, enc_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error>;
+pub trait ProvisioningClient {
+    // fn pckcerts(&self, api_key: &Option<String>, enc_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error>;
 
-    fn pckcert(
-        &self,
-        api_key: &Option<String>,
-        encrypted_ppid: Option<&EncPpid>,
-        pce_id: &PceId,
-        cpu_svn: &CpuSvn,
-        pce_isvsvn: PceIsvsvn,
-        qe_id: Option<&QeId>,
-    ) -> Result<PckCert<Unverified>, Error>;
+    // fn pckcert(
+    //     &self,
+    //     api_key: &Option<String>,
+    //     encrypted_ppid: Option<&EncPpid>,
+    //     pce_id: &PceId,
+    //     cpu_svn: &CpuSvn,
+    //     pce_isvsvn: PceIsvsvn,
+    //     qe_id: Option<&QeId>,
+    // ) -> Result<PckCert<Unverified>, Error>;
 
     fn sgx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error>;
 
     fn tdx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error>;
 
-    fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PC::Output, Error>;
+    // fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl, Error>;
 
     fn qe_identity(&self, evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error>;
 
@@ -955,69 +884,69 @@ pub trait ProvisioningClient<PC: PckCrlService> {
     ///       microcode value is set to the late microcode value.
     ///
     /// Note that PCK certs for some TCB levels may be missing.
-    fn pckcerts_with_fallback(&self, api_key: &Option<String>, pck_id: &PckID) -> Result<PckCerts, Error> {
-        let get_and_collect = |collection: &mut BTreeMap<([u8; 16], u16), PckCert<Unverified>>, cpu_svn: &[u8; 16], pce_svn: u16| -> Result<PckCert<Unverified>, Error> {
-            let pck_cert = self.pckcert(
-                api_key,
-                Some(&pck_id.enc_ppid),
-                &pck_id.pce_id,
-                cpu_svn,
-                pce_svn,
-                Some(&pck_id.qe_id),
-            )?;
+    // fn pckcerts_with_fallback(&self, api_key: &Option<String>, pck_id: &PckID) -> Result<PckCerts, Error> {
+    //     let get_and_collect = |collection: &mut BTreeMap<([u8; 16], u16), PckCert<Unverified>>, cpu_svn: &[u8; 16], pce_svn: u16| -> Result<PckCert<Unverified>, Error> {
+    //         let pck_cert = self.pckcert(
+    //             api_key,
+    //             Some(&pck_id.enc_ppid),
+    //             &pck_id.pce_id,
+    //             cpu_svn,
+    //             pce_svn,
+    //             Some(&pck_id.qe_id),
+    //         )?;
 
-            // Getting PCK cert using CPUSVN from PCKID
-            let ptcb = pck_cert.platform_tcb()?;
-            collection.insert((ptcb.cpusvn, ptcb.tcb_components.pce_svn()), pck_cert.clone());
-            Ok(pck_cert)
-        };
+    //         // Getting PCK cert using CPUSVN from PCKID
+    //         let ptcb = pck_cert.platform_tcb()?;
+    //         collection.insert((ptcb.cpusvn, ptcb.tcb_components.pce_svn()), pck_cert.clone());
+    //         Ok(pck_cert)
+    //     };
 
-        match self.pckcerts(api_key, &pck_id.enc_ppid, pck_id.pce_id) {
-            Ok(pck_certs) => return Ok(pck_certs),
-            Err(Error::RequestNotSupported) => {} // fallback below
-            Err(e) => return Err(e),
-        }
-        // fallback:
+    //     match self.pckcerts(api_key, &pck_id.enc_ppid, pck_id.pce_id) {
+    //         Ok(pck_certs) => return Ok(pck_certs),
+    //         Err(Error::RequestNotSupported) => {} // fallback below
+    //         Err(e) => return Err(e),
+    //     }
+    //     // fallback:
 
-        // Use BTreeMap to have an ordered PckCerts at the end
-        let mut pckcerts_map = BTreeMap::new();
+    //     // Use BTreeMap to have an ordered PckCerts at the end
+    //     let mut pckcerts_map = BTreeMap::new();
 
-        // 1. Use PCK ID to get best available PCK Cert
-        let pck_cert = get_and_collect(&mut pckcerts_map, &pck_id.cpu_svn, pck_id.pce_isvsvn)?;
+    //     // 1. Use PCK ID to get best available PCK Cert
+    //     let pck_cert = get_and_collect(&mut pckcerts_map, &pck_id.cpu_svn, pck_id.pce_isvsvn)?;
 
-        // 2. Getting PCK cert using CPUSVN all 1's
-        let _ign_err = get_and_collect(&mut pckcerts_map, &[u8::MAX; 16], pck_id.pce_isvsvn);
+    //     // 2. Getting PCK cert using CPUSVN all 1's
+    //     let _ign_err = get_and_collect(&mut pckcerts_map, &[u8::MAX; 16], pck_id.pce_isvsvn);
 
-        let fmspc = pck_cert.sgx_extension()?.fmspc;
-        let tcb_info = self.sgx_tcbinfo(&fmspc, None)?;
-        let tcb_data = tcb_info.data()?;
-        for (cpu_svn, pce_isvsvn) in tcb_data.iter_tcb_components() {
-            // 3. Get PCK based on TCB levels
-            let _ = get_and_collect(&mut pckcerts_map, &cpu_svn, pce_isvsvn)?;
+    //     let fmspc = pck_cert.sgx_extension()?.fmspc;
+    //     let tcb_info = self.sgx_tcbinfo(&fmspc, None)?;
+    //     let tcb_data = tcb_info.data()?;
+    //     for (cpu_svn, pce_isvsvn) in tcb_data.iter_tcb_components() {
+    //         // 3. Get PCK based on TCB levels
+    //         let _ = get_and_collect(&mut pckcerts_map, &cpu_svn, pce_isvsvn)?;
 
-            // 4. If late loaded microcode version is higher than early loaded microcode,
-            //    also try with highest microcode version of both components. We found cases where
-            //    fetching the PCK Cert that exactly matched the TCB level, did not result in a PCK
-            //    Cert for that level
-            let early_ucode_idx = tcb_data.tcb_component_index(TcbComponentType::EarlyMicrocodeUpdate);
-            let late_ucode_idx = tcb_data.tcb_component_index(TcbComponentType::LateMicrocodeUpdate);
-            if let (Some(early_ucode_idx), Some(late_ucode_idx)) = (early_ucode_idx, late_ucode_idx) {
-                let early_ucode = cpu_svn[early_ucode_idx];
-                let late_ucode = cpu_svn[late_ucode_idx];
-                if early_ucode < late_ucode {
-                    let mut cpu_svn = cpu_svn.clone();
-                    cpu_svn[early_ucode_idx] = late_ucode;
-                    let _ign_err = get_and_collect(&mut pckcerts_map, &cpu_svn, pce_isvsvn);
-                }
-            }
-        }
+    //         // 4. If late loaded microcode version is higher than early loaded microcode,
+    //         //    also try with highest microcode version of both components. We found cases where
+    //         //    fetching the PCK Cert that exactly matched the TCB level, did not result in a PCK
+    //         //    Cert for that level
+    //         let early_ucode_idx = tcb_data.tcb_component_index(TcbComponentType::EarlyMicrocodeUpdate);
+    //         let late_ucode_idx = tcb_data.tcb_component_index(TcbComponentType::LateMicrocodeUpdate);
+    //         if let (Some(early_ucode_idx), Some(late_ucode_idx)) = (early_ucode_idx, late_ucode_idx) {
+    //             let early_ucode = cpu_svn[early_ucode_idx];
+    //             let late_ucode = cpu_svn[late_ucode_idx];
+    //             if early_ucode < late_ucode {
+    //                 let mut cpu_svn = cpu_svn.clone();
+    //                 cpu_svn[early_ucode_idx] = late_ucode;
+    //                 let _ign_err = get_and_collect(&mut pckcerts_map, &cpu_svn, pce_isvsvn);
+    //             }
+    //         }
+    //     }
 
-        // BTreeMap by default is Ascending
-        let pck_certs: Vec<_> = pckcerts_map.into_iter().rev().map(|(_, v)| v).collect();
-        pck_certs
-            .try_into()
-            .map_err(|e| Error::PCSDecodeError(format!("{}", e).into()))
-    }
+    //     // BTreeMap by default is Ascending
+    //     let pck_certs: Vec<_> = pckcerts_map.into_iter().rev().map(|(_, v)| v).collect();
+    //     pck_certs
+    //         .try_into()
+    //         .map_err(|e| Error::PCSDecodeError(format!("{}", e).into()))
+    // }
 
     fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error>;
 
@@ -1026,50 +955,50 @@ pub trait ProvisioningClient<PC: PckCrlService> {
 
 
 pub trait ProvisioningClientFuncSelector: PlatformTypeForTcbInfo {
-    fn get_tcb_evaluation_data_numbers<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>) -> Result<RawTcbEvaluationDataNumbers<Self>, Error>;
-    fn get_tcbinfo<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<Self>, Error>;
+    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<Self>, Error>;
+    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<Self>, Error>;
 }
 
 impl ProvisioningClientFuncSelector for platform::SGX {
-    fn get_tcb_evaluation_data_numbers<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
+    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
         pc.sgx_tcb_evaluation_data_numbers()
     }
 
-    fn get_tcbinfo<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
+    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
         pc.sgx_tcbinfo(fmspc, evaluation_data_number)
     }
 }
 
 impl ProvisioningClientFuncSelector for platform::TDX {
-    fn get_tcb_evaluation_data_numbers<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
+    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
         pc.tdx_tcb_evaluation_data_numbers()
     }
 
-    fn get_tcbinfo<PC: PckCrlService>(pc: &dyn ProvisioningClient<PC>, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
+    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
         pc.tdx_tcbinfo(fmspc, evaluation_data_number)
     }
 }
 
 
-impl<F: for<'a> Fetcher<'a>, PC: PckCrlService> ProvisioningClient<PC> for Client<F, PC>
+impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F>
 {
-    fn pckcerts(&self, api_key: &Option<String>, encrypted_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error> {
-        let input = PckCertsIn { enc_ppid: encrypted_ppid, pce_id, api_key, api_version: self.api_version };
-        self.pckcerts_service.call_service(&self.fetcher, &self.base_url, &input)
-    }
+    // fn pckcerts(&self, api_key: &Option<String>, encrypted_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error> {
+    //     let input = PckCertsIn { enc_ppid: encrypted_ppid, pce_id, api_key, api_version: self.api_version };
+    //     self.pckcerts_service.call_service(&self.fetcher, &self.base_url, &input)
+    // }
 
-    fn pckcert(
-        &self,
-        api_key: &Option<String>,
-        encrypted_ppid: Option<&EncPpid>,
-        pce_id: &PceId,
-        cpu_svn: &CpuSvn,
-        pce_isvsvn: PceIsvsvn,
-        qe_id: Option<&QeId>,
-    ) -> Result<PckCert<Unverified>, Error> {
-        let input = PckCertIn { encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id, api_version: self.api_version, api_key };
-        self.pckcert_service.call_service(&self.fetcher, &self.base_url, &input)
-    }
+    // fn pckcert(
+    //     &self,
+    //     api_key: &Option<String>,
+    //     encrypted_ppid: Option<&EncPpid>,
+    //     pce_id: &PceId,
+    //     cpu_svn: &CpuSvn,
+    //     pce_isvsvn: PceIsvsvn,
+    //     qe_id: Option<&QeId>,
+    // ) -> Result<PckCert<Unverified>, Error> {
+    //     let input = self.pckcert_service.pcs_service().build_input(self.api_version, encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id, api_key, None, None);
+    //     self.pckcert_service.call_service(&self.fetcher, &self.base_url, &input)
+    // }
 
     fn sgx_tcbinfo(&self, fmspc: &Fmspc, tcb_evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
         let input = TcbInfoIn { api_version: self.api_version, fmspc, tcb_evaluation_data_number };
@@ -1081,10 +1010,10 @@ impl<F: for<'a> Fetcher<'a>, PC: PckCrlService> ProvisioningClient<PC> for Clien
         self.tdx_tcbinfo_service.call_service(&self.fetcher, &self.base_url, &input)
     }
 
-    fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PC::Output, Error> {
-        let input = self.pckcrl_service.pcs_service().build_input(self.api_version, ca);
-        self.pckcrl_service.call_service(&self.fetcher, &self.base_url, &input)
-    }
+    // fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl, Error> {
+    //     let input = self.pckcrl_service.pcs_service().build_input(self.api_version, ca);
+    //     self.pckcrl_service.call_service(&self.fetcher, &self.base_url, &input)
+    // }
 
     fn qe_identity(&self, tcb_evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error> {
         let input = QeIdIn { api_version: self.api_version, tcb_evaluation_data_number };

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
@@ -11,22 +11,24 @@
 //! <https://download.01.org/intel-sgx/sgx-dcap/1.22/linux/docs/SGX_DCAP_Caching_Service_Design_Guide.pdf>
 
 use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::convert::TryInto;
 use std::marker::PhantomData;
 use std::time::Duration;
 
 use pcs::platform::SGX;
 use pcs::{
-    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCrl, PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, TcbInfo, Unverified, platform
+    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PckID, PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, TcbComponentType, TcbInfo, Unverified, platform
 };
 use rustc_serialize::hex::{FromHex, ToHex};
 
 use super::common::*;
 use super::{
-    Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PckCrlIn, PckCrlService, PcsVersion,
+    Client, ClientBuilder, Fetcher, PckCertIn, PckCrlIn, PcsVersion,
     ProvisioningServiceApi, QeIdIn, QeIdService, StatusCode, TcbInfoIn, TcbInfoService,
 };
-use crate::{Error, PckCertsService};
-use crate::provisioning_client::{PCSPckCrlService, TcbEvaluationDataNumbersService};
+use crate::{Error, ProvisioningClient, WithApiVersion};
+use crate::provisioning_client::{BackoffService, CachedService, PckCertService, PcsService, TcbEvaluationDataNumbersService};
 
 pub struct PccsProvisioningClientBuilder {
     base_url: Cow<'static, str>,
@@ -48,40 +50,176 @@ impl PccsProvisioningClientBuilder {
         self
     }
 
-    pub fn build<F: for<'a> Fetcher<'a>, PC: PckCrlService>(self, fetcher: F) -> Client<F, PC> {
-        let pck_certs = PckCertsService;
-        let pck_cert = PckCertService;
-        let pck_crl = PC::new();
+    pub fn build<F: for<'a> Fetcher<'a>>(&self, fetcher: F) -> PCCSClient<F> {
+        let pckcert_service = PckCertService;
+        let pckcrl_service = PckCrlService::new();
         let qeid = QeIdService;
         let sgx_tcbinfo = TcbInfoService::<platform::SGX> {_type: PhantomData};
         let tdx_tcbinfo = TcbInfoService::<platform::TDX> {_type: PhantomData};
         let sgx_evaluation_data_numbers: TcbEvaluationDataNumbersService<SGX> = TcbEvaluationDataNumbersService::<platform::SGX> { _type: PhantomData };
         let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::TDX> { _type: PhantomData };
 
-
-        self.client_builder
-            .build(&self.base_url, self.api_version, pck_certs, pck_cert, pck_crl, qeid, sgx_tcbinfo, tdx_tcbinfo, sgx_evaluation_data_numbers, tdx_evaluation_data_numbers, fetcher)
+        let client = self.client_builder
+            .build(&self.base_url,
+                self.api_version,
+                // pck_certs,
+                // pck_cert,
+                // pck_crl,
+                qeid,
+                sgx_tcbinfo,
+                tdx_tcbinfo,
+                sgx_evaluation_data_numbers,
+                tdx_evaluation_data_numbers,
+                fetcher);
+        PCCSClient {
+            pckcert_service: CachedService::new(
+                BackoffService::new(
+                    PcsService::new(pckcert_service),
+                    self.client_builder.retry_timeout.clone(),
+                ),
+                self.client_builder.cache_capacity.clone(),
+                self.client_builder.cache_shelf_time.clone(),
+            ),
+            pckcrl_service: CachedService::new(
+                BackoffService::new(
+                    PcsService::new(pckcrl_service),
+                    self.client_builder.retry_timeout.clone(),
+                ),
+                self.client_builder.cache_capacity.clone(),
+                self.client_builder.cache_shelf_time.clone(),
+            ),
+            client
+        }
     }
 }
 
-
-pub struct PCCSPckCrlService {
-    parent: PCSPckCrlService
+struct PCCSClient<F: for<'a> Fetcher<'a>> {
+    pckcert_service: CachedService<PckCertService>,
+    pckcrl_service: CachedService<PckCrlService>,
+    client: Client<F>,
 }
 
-impl PckCrlService for PCCSPckCrlService {
-    fn build_input(&self, api_version: PcsVersion, ca: DcapArtifactIssuer) -> <Self as ProvisioningServiceApi>::Input<'_> {
-        PckCrlIn { api_version, ca }
+impl<F: for<'a> Fetcher<'a>> PCCSClient<F> {
+    fn pckcerts(&self, pck_id: &PckID) -> Result<PckCerts, Error> {
+        // let input = PckCertsIn { api_version: self.client.api_version, pck_id: &pck_id };
+        // self.pckcerts_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
+
+        let get_and_collect = |collection: &mut BTreeMap<([u8; 16], u16), PckCert<Unverified>>, cpu_svn: &[u8; 16], pce_svn: u16| -> Result<PckCert<Unverified>, Error> {
+            let pck_cert = self.pckcert(
+                Some(&pck_id.enc_ppid),
+                &pck_id.pce_id,
+                cpu_svn,
+                pce_svn,
+                &pck_id.qe_id,
+            )?;
+
+            // Getting PCK cert using CPUSVN from PCKID
+            let ptcb = pck_cert.platform_tcb()?;
+            collection.insert((ptcb.cpusvn, ptcb.tcb_components.pce_svn()), pck_cert.clone());
+            Ok(pck_cert)
+        };
+
+        // Use BTreeMap to have an ordered PckCerts at the end
+        let mut pckcerts_map = BTreeMap::new();
+
+        // 1. Use PCK ID to get best available PCK Cert
+        let pck_cert = get_and_collect(&mut pckcerts_map, &pck_id.cpu_svn, pck_id.pce_isvsvn)?;
+
+        // 2. Getting PCK cert using CPUSVN all 1's
+        let _ign_err = get_and_collect(&mut pckcerts_map, &[u8::MAX; 16], pck_id.pce_isvsvn);
+
+        let fmspc = pck_cert.sgx_extension()?.fmspc;
+        let tcb_info = self.sgx_tcbinfo(&fmspc, None)?;
+        let tcb_data = tcb_info.data()?;
+        for (cpu_svn, pce_isvsvn) in tcb_data.iter_tcb_components() {
+            // 3. Get PCK based on TCB levels
+            let _ = get_and_collect(&mut pckcerts_map, &cpu_svn, pce_isvsvn)?;
+
+            // 4. If late loaded microcode version is higher than early loaded microcode,
+            //    also try with highest microcode version of both components. We found cases where
+            //    fetching the PCK Cert that exactly matched the TCB level, did not result in a PCK
+            //    Cert for that level
+            let early_ucode_idx = tcb_data.tcb_component_index(TcbComponentType::EarlyMicrocodeUpdate);
+            let late_ucode_idx = tcb_data.tcb_component_index(TcbComponentType::LateMicrocodeUpdate);
+            if let (Some(early_ucode_idx), Some(late_ucode_idx)) = (early_ucode_idx, late_ucode_idx) {
+                let early_ucode = cpu_svn[early_ucode_idx];
+                let late_ucode = cpu_svn[late_ucode_idx];
+                if early_ucode < late_ucode {
+                    let mut cpu_svn = cpu_svn.clone();
+                    cpu_svn[early_ucode_idx] = late_ucode;
+                    let _ign_err = get_and_collect(&mut pckcerts_map, &cpu_svn, pce_isvsvn);
+                }
+            }
+        }
+
+        // BTreeMap by default is Ascending
+        let pck_certs: Vec<_> = pckcerts_map.into_iter().rev().map(|(_, v)| v).collect();
+        pck_certs
+            .try_into()
+            .map_err(|e| Error::PCSDecodeError(format!("{}", e).into()))
+    }
+
+    fn pckcert(
+        &self,
+        encrypted_ppid: Option<&EncPpid>,
+        pce_id: &PceId,
+        cpu_svn: &CpuSvn,
+        pce_isvsvn: PceIsvsvn,
+        qe_id: &QeId,
+    ) -> Result<PckCert<Unverified>, Error> {
+        let input = PckCertIn { encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id: Some(&qe_id), api_version: self.client.api_version, api_key: &None };
+        self.pckcert_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
     }
     
-    fn new() -> Self {
-        Self { parent: PCSPckCrlService }
+    fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl<Unverified>, Error> {
+        let input = PckCrlIn { api_version: self.client.api_version, ca };
+        self.pckcrl_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
+    }
+
+    fn qe_identity(&self, evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error> {
+        self.client.qe_identity(evaluation_data_number)
+    }
+
+    fn sgx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
+        self.client.sgx_tcbinfo(fmspc, evaluation_data_number)
+    }
+
+    fn tdx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
+        self.client.tdx_tcbinfo(fmspc, evaluation_data_number)
+    }
+
+    fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
+        self.client.sgx_tcb_evaluation_data_numbers()
+    }
+
+    fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
+        self.client.tdx_tcb_evaluation_data_numbers()
     }
 }
 
-impl ProvisioningServiceApi for PCCSPckCrlService {
-    type Input<'a> = <PCSPckCrlService as ProvisioningServiceApi>::Input<'a>;
-    type Output = <PCSPckCrlService as ProvisioningServiceApi>::Output;
+#[derive(Hash)]
+struct PckCertsIn<'a> {
+    api_version: PcsVersion,
+    pck_id: &'a PckID,
+}
+
+impl<'a> WithApiVersion for PckCertsIn<'a> {
+    fn api_version(&self) -> PcsVersion {
+        self.api_version
+    }
+}
+
+struct PckCrlService {
+    parent: crate::provisioning_client::PckCrlService
+}
+impl PckCrlService {
+    fn new() -> Self {
+        Self { parent: crate::provisioning_client::PckCrlService }
+    }
+}
+impl ProvisioningServiceApi for PckCrlService {
+    type Input<'a> = PckCrlIn;
+    type Output = PckCrl<Unverified>;
     
     fn build_request(
         &self,
@@ -118,6 +256,7 @@ impl ProvisioningServiceApi for PCCSPckCrlService {
 #[cfg(all(test, feature = "reqwest"))]
 mod tests {
     use assert_matches::assert_matches;
+    use reqwest::blocking::Client;
     use std::convert::TryFrom;
     use std::hash::{DefaultHasher, Hash, Hasher};
     use std::path::PathBuf;
@@ -125,16 +264,15 @@ mod tests {
     use std::time::Duration;
 
     use pcs::{
-        EnclaveIdentity, Fmspc, PckCrl, PckID, RawTcbEvaluationDataNumbers, TcbEvaluationDataNumbers, WriteOptionsBuilder, platform
+        EnclaveIdentity, Fmspc, PckID, RawTcbEvaluationDataNumbers, TcbEvaluationDataNumbers, WriteOptionsBuilder, platform
     };
 
-    use super::Client;
-    use crate::pccs::PCCSPckCrlService;
+    use crate::pccs::PCCSClient;
     use crate::provisioning_client::{
         test_helpers, DcapArtifactIssuer, Error, PccsProvisioningClientBuilder, PcsVersion,
         ProvisioningClient, StatusCode,
     };
-    use crate::{PckCertIn, PckCrlIn, QeIdIn, ReqwestClient, TcbInfoIn, reqwest_client_insecure_tls};
+    use crate::{Fetcher, PckCertIn, PckCrlIn, QeIdIn, TcbInfoIn, reqwest_client_insecure_tls};
 
     const PCKID_TEST_FILE: &str = "./tests/data/pckid_retrieval.csv";
     const OUTPUT_TEST_DIR: &str = "./tests/data/";
@@ -151,7 +289,7 @@ mod tests {
         url
     }
 
-    fn make_client(api_version: PcsVersion) -> Client<ReqwestClient, PCCSPckCrlService> {
+    fn make_client(api_version: PcsVersion) -> PCCSClient<reqwest::blocking::Client> {
         let url = &*PCCS_URL.get_or_init(pccs_url_from_env);
         PccsProvisioningClientBuilder::new(api_version, url)
             .set_retry_timeout(TIME_RETRY_TIMEOUT)
@@ -169,12 +307,11 @@ mod tests {
             {
                 let pck = client
                     .pckcert(
-                        &None,
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
                         pckid.pce_isvsvn,
-                        Some(&pckid.qe_id),
+                        &pckid.qe_id,
                     )
                     .unwrap();
 
@@ -199,12 +336,11 @@ mod tests {
             {
                 let pck = client
                     .pckcert(
-                        &None,
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
                         pckid.pce_isvsvn,
-                        Some(&pckid.qe_id),
+                        &pckid.qe_id,
                     )
                     .unwrap();
 
@@ -218,7 +354,7 @@ mod tests {
 
                     let (cached_pck, _) = {
                         let mut hasher = DefaultHasher::new();
-                        let input = PckCertIn { encrypted_ppid: Some(&pckid.enc_ppid), pce_id: &pckid.pce_id, cpu_svn: &pckid.cpu_svn, pce_isvsvn: pckid.pce_isvsvn, qe_id: Some(&pckid.qe_id), api_version, api_key: &None };
+                        let input = PckCertIn { encrypted_ppid: Some(&pckid.enc_ppid), pce_id: &pckid.pce_id, cpu_svn: &pckid.cpu_svn, pce_isvsvn: pckid.pce_isvsvn, qe_id: Some(&pckid.qe_id), api_version, api_key: &None};
                         input.hash(&mut hasher);
 
                         cache
@@ -242,12 +378,11 @@ mod tests {
                 // Second service call should return value from cache
                 let pck_from_service = client
                     .pckcert(
-                        &None,
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
                         pckid.pce_isvsvn,
-                        Some(&pckid.qe_id),
+                        &pckid.qe_id,
                     )
                     .unwrap();
 
@@ -274,7 +409,7 @@ mod tests {
                 .unwrap()
                 .iter()
             {
-                let pckcerts = client.pckcerts_with_fallback(&None, &pckid).unwrap();
+                let pckcerts = client.pckcerts(&pckid).unwrap();
                 println!("Found {} PCK certs.", pckcerts.as_pck_certs().len());
 
                 let tcb_info = client.sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None).unwrap();
@@ -286,12 +421,11 @@ mod tests {
 
                 let pck = client
                     .pckcert(
-                        &None,
                     Some(&pckid.enc_ppid),
                     &pckid.pce_id,
                     &pckid.cpu_svn,
                     pckid.pce_isvsvn,
-                    Some(&pckid.qe_id),
+                    &pckid.qe_id,
                     )
                     .unwrap();
 
@@ -312,7 +446,7 @@ mod tests {
                 .unwrap()
                 .iter()
             {
-                let pckcerts = client.pckcerts_with_fallback(&None, &pckid).unwrap();
+                let pckcerts = client.pckcerts(&pckid).unwrap();
 
                 assert!(client
                     .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
@@ -330,7 +464,7 @@ mod tests {
             .iter()
         {
             let pckcerts = client
-                .pckcerts_with_fallback(&None, &pckid)
+                .pckcerts(&pckid)
                 .unwrap();
 
             let fmspc = pckcerts.fmspc().unwrap();
@@ -373,13 +507,13 @@ mod tests {
                 .unwrap()
                 .iter()
             {
-                let pckcerts = client.pckcerts_with_fallback(&None, &pckid).unwrap();
+                let pckcerts = client.pckcerts(&pckid).unwrap();
                 let fmspc = pckcerts.fmspc().unwrap();
                 let tcb_info = client.sgx_tcbinfo(&fmspc, None).unwrap();
 
                 // The cache should be populated after initial service call
                 {
-                    let mut cache = client.sgx_tcbinfo_service.cache.lock().unwrap();
+                    let mut cache = client.client.sgx_tcbinfo_service.cache.lock().unwrap();
 
                     assert!(cache.len() > 0);
 
@@ -476,7 +610,7 @@ mod tests {
 
             // The cache should be populated after initial service call
             {
-                let mut cache = client.qeid_service.cache.lock().unwrap();
+                let mut cache = client.client.qeid_service.cache.lock().unwrap();
 
                 assert!(cache.len() > 0);
 

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
@@ -14,6 +14,7 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::time::Duration;
 
+use pcs::platform::SGX;
 use pcs::{
     CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCrl, PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, TcbInfo, Unverified, platform
 };
@@ -24,8 +25,8 @@ use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PckCrlIn, PckCrlService, PcsVersion,
     ProvisioningServiceApi, QeIdIn, QeIdService, StatusCode, TcbInfoIn, TcbInfoService,
 };
-use super::intel::TcbEvaluationDataNumbersApi;
-use crate::Error;
+use crate::{Error, PckCertsService};
+use crate::provisioning_client::{PCSPckCrlService, TcbEvaluationDataNumbersService};
 
 pub struct PccsProvisioningClientBuilder {
     base_url: Cow<'static, str>,
@@ -47,195 +48,51 @@ impl PccsProvisioningClientBuilder {
         self
     }
 
-    pub fn build<F: for<'a> Fetcher<'a>>(self, fetcher: F) -> Client<F> {
-        let pck_certs = PckCertsApiNotSupported;
-        let pck_cert = PckCertApi::new(self.base_url.clone(), self.api_version);
-        let pck_crl = PckCrlApi::new(self.base_url.clone(), self.api_version);
-        let qeid = QeIdApi::new(self.base_url.clone(), self.api_version.clone());
-        let sgx_tcbinfo = TcbInfoApi::<platform::SGX>::new(self.base_url.clone(), self.api_version);
-        let tdx_tcbinfo = TcbInfoApi::<platform::TDX>::new(self.base_url.clone(), self.api_version);
-        let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(self.base_url.clone());
-        let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(self.base_url.clone());
+    pub fn build<F: for<'a> Fetcher<'a>, PC: PckCrlService>(self, fetcher: F) -> Client<F, PC> {
+        let pck_certs = PckCertsService;
+        let pck_cert = PckCertService;
+        let pck_crl = PC::new();
+        let qeid = QeIdService;
+        let sgx_tcbinfo = TcbInfoService::<platform::SGX> {_type: PhantomData};
+        let tdx_tcbinfo = TcbInfoService::<platform::TDX> {_type: PhantomData};
+        let sgx_evaluation_data_numbers: TcbEvaluationDataNumbersService<SGX> = TcbEvaluationDataNumbersService::<platform::SGX> { _type: PhantomData };
+        let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::TDX> { _type: PhantomData };
+
 
         self.client_builder
-            .build(pck_certs, pck_cert, pck_crl, qeid, sgx_tcbinfo, tdx_tcbinfo, sgx_evaluation_data_numbers, tdx_evaluation_data_numbers, fetcher)
+            .build(&self.base_url, self.api_version, pck_certs, pck_cert, pck_crl, qeid, sgx_tcbinfo, tdx_tcbinfo, sgx_evaluation_data_numbers, tdx_evaluation_data_numbers, fetcher)
     }
 }
 
-pub struct PckCertApi {
-    base_url: Cow<'static, str>,
-    api_version: PcsVersion,
+
+pub struct PCCSPckCrlService {
+    parent: PCSPckCrlService
 }
 
-impl PckCertApi {
-    pub(crate) fn new(base_url: Cow<'static, str>, api_version: PcsVersion) -> PckCertApi {
-        PckCertApi {
-            base_url,
-            api_version,
-        }
+impl PckCrlService for PCCSPckCrlService {
+    fn build_input(&self, api_version: PcsVersion, ca: DcapArtifactIssuer) -> <Self as ProvisioningServiceApi>::Input<'_> {
+        PckCrlIn { api_version, ca }
     }
-}
-
-impl<'inp> PckCertService<'inp> for PckCertApi {
-    fn build_input(
-        &'inp self,
-        encrypted_ppid: Option<&'inp EncPpid>,
-        pce_id: &'inp PceId,
-        cpu_svn: &'inp CpuSvn,
-        pce_isvsvn: PceIsvsvn,
-        qe_id: Option<&'inp QeId>,
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        PckCertIn {
-            encrypted_ppid,
-            pce_id,
-            cpu_svn,
-            pce_isvsvn,
-            qe_id,
-            api_key: &None,
-            api_version: self.api_version,
-        }
+    
+    fn new() -> Self {
+        Self { parent: PCSPckCrlService }
     }
 }
 
-/// Implementation of Get PCK Certificate API (section 3.1 in the [reference]).
-///
-/// [reference]: <https://download.01.org/intel-sgx/sgx-dcap/1.22/linux/docs/SGX_DCAP_Caching_Service_Design_Guide.pdf>
-impl<'inp> ProvisioningServiceApi<'inp> for PckCertApi {
-    type Input = PckCertIn<'inp>;
-    type Output = PckCert<Unverified>;
-
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
-        let api_version = input.api_version as u8;
-        let encrypted_ppid = input
-            .encrypted_ppid
-            .ok_or(Error::NoEncPPID)
-            .map(|e_ppid| e_ppid.to_hex())?;
-
-        let cpu_svn = input.cpu_svn.to_hex();
-        let pce_isvsvn = input.pce_isvsvn.to_le_bytes().to_hex();
-        let pce_id = input.pce_id.to_le_bytes().to_hex();
-        let qe_id = input
-            .qe_id
-            .ok_or(Error::NoQeID)
-            .map(|qe_id| qe_id.to_hex())?;
-
-        let url = format!(
-            "{}/sgx/certification/v{}/pckcert?encrypted_ppid={}&cpusvn={}&pcesvn={}&pceid={}&qeid={}",
-            self.base_url, api_version, encrypted_ppid, cpu_svn, pce_isvsvn, pce_id, qe_id,
-        );
-        let headers = Vec::new();
-        Ok((url, headers))
-    }
-
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
-        match status_code {
-            StatusCode::Ok => Ok(()),
-            StatusCode::BadRequest => {
-                Err(Error::PCSError(status_code, "Invalid request parameters"))
-            }
-            StatusCode::NotFound => Err(Error::PCSError(
-                status_code,
-                "No cache data for this platform",
-            )),
-            StatusCode::NonStandard461 => Err(Error::PCSError(
-                status_code,
-                "The platform was not found in the cache",
-            )),
-            StatusCode::NonStandard462 => Err(Error::PCSError(
-                status_code,
-                "Certificates are not available for certain TCBs",
-            )),
-            StatusCode::InternalServerError => Err(Error::PCSError(
-                status_code,
-                "PCCS suffered from an internal server error",
-            )),
-            StatusCode::BadGateway => Err(Error::PCSError(
-                status_code,
-                "Unable to retrieve the collateral from the Intel SGX PCS",
-            )),
-            _ => Err(Error::PCSError(
-                status_code,
-                "Unexpected response from PCCS server",
-            )),
-        }
-    }
-
-    fn parse_response(
+impl ProvisioningServiceApi for PCCSPckCrlService {
+    type Input<'a> = <PCSPckCrlService as ProvisioningServiceApi>::Input<'a>;
+    type Output = <PCSPckCrlService as ProvisioningServiceApi>::Output;
+    
+    fn build_request(
         &self,
-        response_body: String,
-        response_headers: Vec<(String, String)>,
-        _api_version: PcsVersion,
-    ) -> Result<Self::Output, Error> {
-        let ca_chain = parse_issuer_header(&response_headers, PCK_CERTIFICATE_ISSUER_CHAIN_HEADER)?;
-        Ok(PckCert::new(response_body, ca_chain))
+        base_url: &str,
+        input: &Self::Input<'_>,
+    ) -> Result<(String, Vec<(String, String)>), Error> {
+        self.parent.build_request(base_url, input)
     }
-}
-
-pub struct PckCrlApi {
-    base_url: Cow<'static, str>,
-    api_version: PcsVersion,
-}
-
-impl PckCrlApi {
-    pub fn new(base_url: Cow<'static, str>, api_version: PcsVersion) -> Self {
-        PckCrlApi {
-            base_url,
-            api_version,
-        }
-    }
-}
-
-impl<'inp> PckCrlService<'inp> for PckCrlApi {
-    fn build_input(&'inp self, ca: DcapArtifactIssuer) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        PckCrlIn {
-            api_version: self.api_version,
-            ca,
-        }
-    }
-}
-
-/// Implementation of Get PCK Cert CRL API (section 3.2 of [reference]).
-///
-/// [reference]: <https://download.01.org/intel-sgx/sgx-dcap/1.22/linux/docs/SGX_DCAP_Caching_Service_Design_Guide.pdf>
-impl<'inp> ProvisioningServiceApi<'inp> for PckCrlApi {
-    type Input = PckCrlIn;
-    type Output = PckCrl<Unverified>;
-
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
-        let ca = match input.ca {
-            DcapArtifactIssuer::PCKProcessorCA => "processor",
-            DcapArtifactIssuer::PCKPlatformCA => "platform",
-            DcapArtifactIssuer::SGXRootCA => {
-                return Err(Error::PCSError(StatusCode::BadRequest, "Invalid ca parameter"));
-            },
-        };
-        let url = format!(
-            "{}/sgx/certification/v{}/pckcrl?ca={}",
-            self.base_url, input.api_version as u8, ca
-        );
-        Ok((url, Vec::new()))
-    }
-
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
-        match &status_code {
-            StatusCode::Ok => Ok(()),
-            StatusCode::BadRequest => {
-                Err(Error::PCSError(status_code, "Invalid request parameters"))
-            }
-            StatusCode::NotFound => Err(Error::PCSError(status_code, "PCK CRL cannot be found")),
-            StatusCode::InternalServerError => Err(Error::PCSError(
-                status_code,
-                "PCCS suffered from an internal server error",
-            )),
-            StatusCode::BadGateway => Err(Error::PCSError(
-                status_code,
-                "Unable to retrieve the collateral from the Intel SGX PCS",
-            )),
-            _ => Err(Error::PCSError(
-                status_code,
-                "Unexpected response from PCCS server",
-            )),
-        }
+    
+    fn validate_response(&self, code: StatusCode) -> Result<(), Error> {
+        self.parent.validate_response(code)
     }
 
     fn parse_response(
@@ -257,178 +114,6 @@ impl<'inp> ProvisioningServiceApi<'inp> for PckCrlApi {
     }
 }
 
-pub struct TcbInfoApi<T> {
-    base_url: Cow<'static, str>,
-    api_version: PcsVersion,
-    type_: PhantomData<T>
-}
-
-impl<T: PlatformType> TcbInfoApi<T> {
-    pub fn new(base_url: Cow<'static, str>, api_version: PcsVersion) -> Self {
-        TcbInfoApi {
-            base_url,
-            api_version,
-            type_: PhantomData
-        }
-    }
-}
-
-impl<'inp, T: PlatformTypeForTcbInfo> TcbInfoService<'inp, T> for TcbInfoApi<T> {
-    fn build_input(
-        &'inp self,
-        fmspc: &'inp Fmspc,
-        tcb_evaluation_data_number: Option<u16>,
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        TcbInfoIn {
-            api_version: self.api_version,
-            fmspc,
-            tcb_evaluation_data_number,
-        }
-    }
-}
-
-/// Implementation of Get TCB Info API (section 3.3 of [reference]).
-///
-/// [reference]: <https://download.01.org/intel-sgx/sgx-dcap/1.22/linux/docs/SGX_DCAP_Caching_Service_Design_Guide.pdf>
-impl<'inp, T: PlatformTypeForTcbInfo> ProvisioningServiceApi<'inp> for TcbInfoApi<T> {
-    type Input = TcbInfoIn<'inp>;
-    type Output = TcbInfo<T>;
-
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
-        let api_version = input.api_version as u8;
-        let fmspc = input.fmspc.as_bytes().to_hex();
-        let url = if let Some(evaluation_data_number) = input.tcb_evaluation_data_number {
-            format!(
-                "{}/sgx/certification/v{}/tcb?fmspc={}&tcbEvaluationDataNumber={}",
-                self.base_url, api_version, fmspc, evaluation_data_number)
-        } else {
-            format!(
-                "{}/sgx/certification/v{}/tcb?fmspc={}&update=early",
-                self.base_url, api_version, fmspc,
-            )
-        };
-        Ok((url, Vec::new()))
-    }
-
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
-        match &status_code {
-            StatusCode::Ok => Ok(()),
-            StatusCode::BadRequest => {
-                Err(Error::PCSError(status_code, "Invalid request parameters"))
-            }
-            StatusCode::NotFound => Err(Error::PCSError(
-                status_code,
-                "TCB information for provided FMSPC cannot be found",
-            )),
-            StatusCode::InternalServerError => Err(Error::PCSError(
-                status_code,
-                "PCCS suffered from an internal server error",
-            )),
-            StatusCode::BadGateway => Err(Error::PCSError(
-                status_code,
-                "Unable to retrieve the collateral from the Intel SGX PCS",
-            )),
-            _ => Err(Error::PCSError(
-                status_code,
-                "Unexpected response from PCCS server",
-            )),
-        }
-    }
-
-    fn parse_response(
-        &self,
-        response_body: String,
-        response_headers: Vec<(String, String)>,
-        api_version: PcsVersion,
-    ) -> Result<Self::Output, Error> {
-        let key = match api_version {
-            PcsVersion::V3 => TCB_INFO_ISSUER_CHAIN_HEADER_V3,
-            PcsVersion::V4 => TCB_INFO_ISSUER_CHAIN_HEADER_V4,
-        };
-        let ca_chain = parse_issuer_header(&response_headers, key)?;
-        Ok(TcbInfo::parse(&response_body, ca_chain)?)
-    }
-}
-
-pub struct QeIdApi {
-    base_url: Cow<'static, str>,
-    api_version: PcsVersion,
-}
-
-impl QeIdApi {
-    pub fn new(base_url: Cow<'static, str>, api_version: PcsVersion) -> Self {
-        QeIdApi {
-            base_url,
-            api_version,
-        }
-    }
-}
-
-impl<'inp> QeIdService<'inp> for QeIdApi {
-    fn build_input(&'inp self, tcb_evaluation_data_number: Option<u16>) -> <Self as ProvisioningServiceApi<'inp>>::Input {
-        QeIdIn {
-            api_version: self.api_version,
-            tcb_evaluation_data_number,
-        }
-    }
-}
-
-/// Implementation of Get Intel's QE Identity API (section 3.4 of [reference]).
-///
-/// [reference]: <https://download.01.org/intel-sgx/sgx-dcap/1.22/linux/docs/SGX_DCAP_Caching_Service_Design_Guide.pdf>
-impl<'inp> ProvisioningServiceApi<'inp> for QeIdApi {
-    type Input = QeIdIn;
-    type Output = QeIdentitySigned;
-
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
-        let api_version = input.api_version as u8;
-        let url = if let Some(tcb_evaluation_data_number) = input.tcb_evaluation_data_number {
-            format!(
-                "{}/sgx/certification/v{}/qe/identity?tcbEvaluationDataNumber={}",
-                self.base_url, api_version, tcb_evaluation_data_number
-            )
-        } else {
-            format!(
-                "{}/sgx/certification/v{}/qe/identity?update=early",
-                self.base_url, api_version,
-            )
-        };
-        Ok((url, Vec::new()))
-    }
-
-    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
-        match &status_code {
-            StatusCode::Ok => Ok(()),
-            StatusCode::NotFound => Err(Error::PCSError(
-                status_code,
-                "QE identity information cannot be found",
-            )),
-            StatusCode::InternalServerError => Err(Error::PCSError(
-                status_code,
-                "PCCS suffered from an internal server error",
-            )),
-            StatusCode::BadGateway => Err(Error::PCSError(
-                status_code,
-                "Unable to retrieve the collateral from the Intel SGX PCS",
-            )),
-            _ => Err(Error::PCSError(
-                status_code,
-                "Unexpected response from PCCS server",
-            )),
-        }
-    }
-
-    fn parse_response(
-        &self,
-        response_body: String,
-        response_headers: Vec<(String, String)>,
-        _api_version: PcsVersion,
-    ) -> Result<Self::Output, Error> {
-        let ca_chain = parse_issuer_header(&response_headers, ENCLAVE_ID_ISSUER_CHAIN_HEADER)?;
-        let id = QeIdentitySigned::parse(&response_body, ca_chain)?;
-        Ok(id)
-    }
-}
 
 #[cfg(all(test, feature = "reqwest"))]
 mod tests {
@@ -440,15 +125,16 @@ mod tests {
     use std::time::Duration;
 
     use pcs::{
-        EnclaveIdentity, Fmspc, PckID, RawTcbEvaluationDataNumbers, TcbEvaluationDataNumbers, WriteOptionsBuilder, platform
+        EnclaveIdentity, Fmspc, PckCrl, PckID, RawTcbEvaluationDataNumbers, TcbEvaluationDataNumbers, WriteOptionsBuilder, platform
     };
 
     use super::Client;
+    use crate::pccs::PCCSPckCrlService;
     use crate::provisioning_client::{
         test_helpers, DcapArtifactIssuer, Error, PccsProvisioningClientBuilder, PcsVersion,
         ProvisioningClient, StatusCode,
     };
-    use crate::{reqwest_client_insecure_tls, ReqwestClient};
+    use crate::{PckCertIn, PckCrlIn, QeIdIn, ReqwestClient, TcbInfoIn, reqwest_client_insecure_tls};
 
     const PCKID_TEST_FILE: &str = "./tests/data/pckid_retrieval.csv";
     const OUTPUT_TEST_DIR: &str = "./tests/data/";
@@ -465,7 +151,7 @@ mod tests {
         url
     }
 
-    fn make_client(api_version: PcsVersion) -> Client<ReqwestClient> {
+    fn make_client(api_version: PcsVersion) -> Client<ReqwestClient, PCCSPckCrlService> {
         let url = &*PCCS_URL.get_or_init(pccs_url_from_env);
         PccsProvisioningClientBuilder::new(api_version, url)
             .set_retry_timeout(TIME_RETRY_TIMEOUT)
@@ -483,6 +169,7 @@ mod tests {
             {
                 let pck = client
                     .pckcert(
+                        &None,
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
@@ -512,6 +199,7 @@ mod tests {
             {
                 let pck = client
                     .pckcert(
+                        &None,
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
@@ -530,13 +218,7 @@ mod tests {
 
                     let (cached_pck, _) = {
                         let mut hasher = DefaultHasher::new();
-                        let input = client.pckcert_service.pcs_service().build_input(
-                            Some(&pckid.enc_ppid),
-                            &pckid.pce_id,
-                            &pckid.cpu_svn,
-                            pckid.pce_isvsvn,
-                            Some(&pckid.qe_id),
-                        );
+                        let input = PckCertIn { encrypted_ppid: Some(&pckid.enc_ppid), pce_id: &pckid.pce_id, cpu_svn: &pckid.cpu_svn, pce_isvsvn: pckid.pce_isvsvn, qe_id: Some(&pckid.qe_id), api_version, api_key: &None };
                         input.hash(&mut hasher);
 
                         cache
@@ -560,6 +242,7 @@ mod tests {
                 // Second service call should return value from cache
                 let pck_from_service = client
                     .pckcert(
+                        &None,
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
@@ -591,7 +274,7 @@ mod tests {
                 .unwrap()
                 .iter()
             {
-                let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
+                let pckcerts = client.pckcerts_with_fallback(&None, &pckid).unwrap();
                 println!("Found {} PCK certs.", pckcerts.as_pck_certs().len());
 
                 let tcb_info = client.sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None).unwrap();
@@ -603,6 +286,7 @@ mod tests {
 
                 let pck = client
                     .pckcert(
+                        &None,
                     Some(&pckid.enc_ppid),
                     &pckid.pce_id,
                     &pckid.cpu_svn,
@@ -628,7 +312,7 @@ mod tests {
                 .unwrap()
                 .iter()
             {
-                let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
+                let pckcerts = client.pckcerts_with_fallback(&None, &pckid).unwrap();
 
                 assert!(client
                     .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
@@ -646,7 +330,7 @@ mod tests {
             .iter()
         {
             let pckcerts = client
-                .pckcerts_with_fallback(&pckid)
+                .pckcerts_with_fallback(&None, &pckid)
                 .unwrap();
 
             let fmspc = pckcerts.fmspc().unwrap();
@@ -689,7 +373,7 @@ mod tests {
                 .unwrap()
                 .iter()
             {
-                let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
+                let pckcerts = client.pckcerts_with_fallback(&None, &pckid).unwrap();
                 let fmspc = pckcerts.fmspc().unwrap();
                 let tcb_info = client.sgx_tcbinfo(&fmspc, None).unwrap();
 
@@ -701,10 +385,7 @@ mod tests {
 
                     let (cached_tcb_info, _) = {
                         let mut hasher = DefaultHasher::new();
-                        let input = client
-                            .sgx_tcbinfo_service
-                            .pcs_service()
-                            .build_input(&fmspc, None);
+                        let input = TcbInfoIn{ api_version, fmspc: &fmspc, tcb_evaluation_data_number: None };
                         input.hash(&mut hasher);
 
                         cache
@@ -757,7 +438,7 @@ mod tests {
 
                     let (cached_pckcrl, _) = {
                         let mut hasher = DefaultHasher::new();
-                        let input = client.pckcrl_service.pcs_service().build_input(ca);
+                        let input = PckCrlIn { api_version, ca };
                         input.hash(&mut hasher);
 
                         cache
@@ -801,7 +482,7 @@ mod tests {
 
                 let (cached_qeid, _) = {
                     let mut hasher = DefaultHasher::new();
-                    let input = client.qeid_service.pcs_service().build_input(None);
+                    let input = QeIdIn { api_version, tcb_evaluation_data_number: None };
                     input.hash(&mut hasher);
 
                     cache

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
@@ -18,16 +18,16 @@ use std::time::Duration;
 
 use pcs::platform::SGX;
 use pcs::{
-    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PckID, PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, TcbComponentType, TcbInfo, Unverified, platform
+    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PckID, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, TcbComponentType, TcbInfo, Unverified, platform
 };
-use rustc_serialize::hex::{FromHex, ToHex};
+use rustc_serialize::hex::FromHex;
 
 use super::common::*;
 use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCrlIn, PcsVersion,
-    ProvisioningServiceApi, QeIdIn, QeIdService, StatusCode, TcbInfoIn, TcbInfoService,
+    ProvisioningServiceApi, QeIdService, StatusCode, TcbInfoService,
 };
-use crate::{Error, ProvisioningClient, WithApiVersion};
+use crate::{Error, ProvisioningClient};
 use crate::provisioning_client::{BackoffService, CachedService, PckCertService, PcsService, TcbEvaluationDataNumbersService};
 
 pub struct PccsProvisioningClientBuilder {
@@ -62,9 +62,6 @@ impl PccsProvisioningClientBuilder {
         let client = self.client_builder
             .build(&self.base_url,
                 self.api_version,
-                // pck_certs,
-                // pck_cert,
-                // pck_crl,
                 qeid,
                 sgx_tcbinfo,
                 tdx_tcbinfo,
@@ -93,7 +90,7 @@ impl PccsProvisioningClientBuilder {
     }
 }
 
-struct PCCSClient<F: for<'a> Fetcher<'a>> {
+pub struct PCCSClient<F: for<'a> Fetcher<'a>> {
     pckcert_service: CachedService<PckCertService>,
     pckcrl_service: CachedService<PckCrlService>,
     client: Client<F>,
@@ -101,9 +98,6 @@ struct PCCSClient<F: for<'a> Fetcher<'a>> {
 
 impl<F: for<'a> Fetcher<'a>> PCCSClient<F> {
     fn pckcerts(&self, pck_id: &PckID) -> Result<PckCerts, Error> {
-        // let input = PckCertsIn { api_version: self.client.api_version, pck_id: &pck_id };
-        // self.pckcerts_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
-
         let get_and_collect = |collection: &mut BTreeMap<([u8; 16], u16), PckCert<Unverified>>, cpu_svn: &[u8; 16], pce_svn: u16| -> Result<PckCert<Unverified>, Error> {
             let pck_cert = self.pckcert(
                 Some(&pck_id.enc_ppid),
@@ -170,7 +164,27 @@ impl<F: for<'a> Fetcher<'a>> PCCSClient<F> {
         let input = PckCertIn { encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id: Some(&qe_id), api_version: self.client.api_version, api_key: &None };
         self.pckcert_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
     }
+
     
+}
+
+impl<F: for<'a> Fetcher<'a>> ProvisioningClient for PCCSClient<F> {
+    fn pckcert(
+        &self,
+        api_key: &Option<String>,
+        encrypted_ppid: Option<&EncPpid>,
+        pce_id: &PceId,
+        cpu_svn: &CpuSvn,
+        pce_isvsvn: PceIsvsvn,
+        qe_id: Option<&QeId>,
+    ) -> Result<PckCert<Unverified>, Error> {
+        self.client.pckcert(api_key, encrypted_ppid, pce_id, cpu_svn, pce_isvsvn, qe_id)
+    }
+
+    fn pckcerts(&self, pck_id: &PckID) -> Result<PckCerts, Error> {
+        self.client.pckcerts(pck_id)
+    }
+
     fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl<Unverified>, Error> {
         let input = PckCrlIn { api_version: self.client.api_version, ca };
         self.pckcrl_service.call_service(&self.client.fetcher, &self.client.base_url, &input)
@@ -194,18 +208,6 @@ impl<F: for<'a> Fetcher<'a>> PCCSClient<F> {
 
     fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
         self.client.tdx_tcb_evaluation_data_numbers()
-    }
-}
-
-#[derive(Hash)]
-struct PckCertsIn<'a> {
-    api_version: PcsVersion,
-    pck_id: &'a PckID,
-}
-
-impl<'a> WithApiVersion for PckCertsIn<'a> {
-    fn api_version(&self) -> PcsVersion {
-        self.api_version
     }
 }
 
@@ -256,7 +258,7 @@ impl ProvisioningServiceApi for PckCrlService {
 #[cfg(all(test, feature = "reqwest"))]
 mod tests {
     use assert_matches::assert_matches;
-    use reqwest::blocking::Client;
+    
     use std::convert::TryFrom;
     use std::hash::{DefaultHasher, Hash, Hasher};
     use std::path::PathBuf;
@@ -272,7 +274,7 @@ mod tests {
         test_helpers, DcapArtifactIssuer, Error, PccsProvisioningClientBuilder, PcsVersion,
         ProvisioningClient, StatusCode,
     };
-    use crate::{Fetcher, PckCertIn, PckCrlIn, QeIdIn, TcbInfoIn, reqwest_client_insecure_tls};
+    use crate::{PckCertIn, PckCrlIn, QeIdIn, TcbInfoIn, reqwest_client_insecure_tls};
 
     const PCKID_TEST_FILE: &str = "./tests/data/pckid_retrieval.csv";
     const OUTPUT_TEST_DIR: &str = "./tests/data/";

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
@@ -13,10 +13,8 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 use std::time::Duration;
 
-use pcs::platform::SGX;
 use pcs::{
     CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PckID, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, TcbComponentType, TcbInfo, Unverified, platform
 };
@@ -25,10 +23,10 @@ use rustc_serialize::hex::FromHex;
 use super::common::*;
 use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCrlIn, PcsVersion,
-    ProvisioningServiceApi, QeIdService, StatusCode, TcbInfoService,
+    ProvisioningServiceApi, StatusCode,
 };
 use crate::{Error, ProvisioningClient};
-use crate::provisioning_client::{BackoffService, CachedService, PckCertService, PcsService, TcbEvaluationDataNumbersService};
+use crate::provisioning_client::{BackoffService, CachedService, PckCertService};
 
 pub struct PccsProvisioningClientBuilder {
     base_url: Cow<'static, str>,
@@ -51,27 +49,14 @@ impl PccsProvisioningClientBuilder {
     }
 
     pub fn build<F: for<'a> Fetcher<'a>>(&self, fetcher: F) -> PCCSClient<F> {
-        let pckcert_service = PckCertService;
-        let pckcrl_service = PckCrlService::new();
-        let qeid = QeIdService;
-        let sgx_tcbinfo = TcbInfoService::<platform::SGX> {_type: PhantomData};
-        let tdx_tcbinfo = TcbInfoService::<platform::TDX> {_type: PhantomData};
-        let sgx_evaluation_data_numbers: TcbEvaluationDataNumbersService<SGX> = TcbEvaluationDataNumbersService::<platform::SGX> { _type: PhantomData };
-        let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersService::<platform::TDX> { _type: PhantomData };
 
         let client = self.client_builder
             .build(&self.base_url,
                 self.api_version,
-                qeid,
-                sgx_tcbinfo,
-                tdx_tcbinfo,
-                sgx_evaluation_data_numbers,
-                tdx_evaluation_data_numbers,
                 fetcher);
         PCCSClient {
             pckcert_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(pckcert_service),
                     self.client_builder.retry_timeout.clone(),
                 ),
                 self.client_builder.cache_capacity.clone(),
@@ -79,7 +64,6 @@ impl PccsProvisioningClientBuilder {
             ),
             pckcrl_service: CachedService::new(
                 BackoffService::new(
-                    PcsService::new(pckcrl_service),
                     self.client_builder.retry_timeout.clone(),
                 ),
                 self.client_builder.cache_capacity.clone(),
@@ -211,32 +195,23 @@ impl<F: for<'a> Fetcher<'a>> ProvisioningClient for PCCSClient<F> {
     }
 }
 
-struct PckCrlService {
-    parent: crate::provisioning_client::PckCrlService
-}
-impl PckCrlService {
-    fn new() -> Self {
-        Self { parent: crate::provisioning_client::PckCrlService }
-    }
-}
+struct PckCrlService;
 impl ProvisioningServiceApi for PckCrlService {
     type Input<'a> = PckCrlIn;
     type Output = PckCrl<Unverified>;
     
     fn build_request(
-        &self,
         base_url: &str,
         input: &Self::Input<'_>,
     ) -> Result<(String, Vec<(String, String)>), Error> {
-        self.parent.build_request(base_url, input)
+        crate::provisioning_client::PckCrlService::build_request(base_url, input)
     }
     
-    fn validate_response(&self, code: StatusCode) -> Result<(), Error> {
-        self.parent.validate_response(code)
+    fn validate_response(code: StatusCode) -> Result<(), Error> {
+        crate::provisioning_client::PckCrlService::validate_response(code)
     }
 
     fn parse_response(
-        &self,
         response_body: String,
         response_headers: Vec<(String, String)>,
         _api_version: PcsVersion,


### PR DESCRIPTION
Some experimental code which might make sense to use as the initial step for the refactoring of `dcap-artifact-retrieval` tool. It includes:

- Simplification of generics affecting `Client`, `BackoffService`, `PcsService`.
- API services are now stateless and therefore their functions are now static.
- Attestation specific clients that expose only their supported APIs. Azure behavior remains the same: only `pckcert` is obtained while other APIs still going via Intel PCS.
- Similar Rest APIs are implemented on internal methods which accept a superset of parameters to cover the possible combinations.
- Some lifetime reference annotations have been removed or moved to the functions that actually need them.
- Replacement of `build_input` with explicit initialization of input types.

RTE-785 contains the design spec and links to several tickets with the expected following steps, which also include some of the unfinished work from this experimental branch.