### PR TITLE
sgxs-tools: Support AEX-Notify feature

### DIFF
--- a/intel-sgx/sgx-isa/src/lib.rs
+++ b/intel-sgx/sgx-isa/src/lib.rs
@@ -392,13 +392,14 @@ bitflags! {
     #[repr(C)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct AttributesFlags: u64 {
-        const INIT          = 0b0000_0001;
-        const DEBUG         = 0b0000_0010;
-        const MODE64BIT     = 0b0000_0100;
-        const PROVISIONKEY  = 0b0001_0000;
-        const EINITTOKENKEY = 0b0010_0000;
-        const CET           = 0b0100_0000;
-        const KSS           = 0b1000_0000;
+        const INIT          = 0b000_0000_0001;
+        const DEBUG         = 0b000_0000_0010;
+        const MODE64BIT     = 0b000_0000_0100;
+        const PROVISIONKEY  = 0b000_0001_0000;
+        const EINITTOKENKEY = 0b000_0010_0000;
+        const CET           = 0b000_0100_0000;
+        const KSS           = 0b000_1000_0000;
+        const AEXNOTIFY     = 0b100_1000_0000;
     }
 }
 
@@ -451,7 +452,8 @@ impl Tcs {
 bitflags! {
     #[repr(C)]
     pub struct TcsFlags: u64 {
-        const DBGOPTIN = 0b0000_0001;
+        const DBGOPTIN  = 0b0000_0001;
+        const AEXNOTIFY = 0b0000_0010;
     }
 }
 

--- a/intel-sgx/sgxs-tools/src/bin/sgxs-info.rs
+++ b/intel-sgx/sgxs-tools/src/bin/sgxs-info.rs
@@ -13,7 +13,7 @@ use std::fs::File;
 use std::path::Path;
 
 use clap::{App, Arg};
-use sgx_isa::{PageType, SecinfoFlags, Tcs};
+use sgx_isa::{PageType, SecinfoFlags, Tcs, TcsFlags};
 
 use crate::sgxs_crate::sgxs::{self, SgxsRead};
 use crate::sgxs_crate::util::size_fit_natural;
@@ -210,8 +210,8 @@ impl<'a, R: sgxs::SgxsRead + 'a> Pages<'a, R> {
         Ok(self.reader.read_page()?.map(|(eadd, chunks, data)| {
             let tcs_info = if eadd.secinfo.flags.page_type() == PageType::Tcs as u8 {
                 let tcs = Tcs::try_copy_from(&data).unwrap();
-                Some(format!(" [oentry=0x{:x}, ossa=0x{:x}, nssa={}]",
-                             tcs.oentry, tcs.ossa, tcs.nssa))
+                Some(format!(" [oentry=0x{:x}, ossa=0x{:x}, nssa={}, aexnotify={}]",
+                             tcs.oentry, tcs.ossa, tcs.nssa, tcs.flags.contains(TcsFlags::AEXNOTIFY)))
             } else {
                 None
             };


### PR DESCRIPTION
Changes:

- sgxs-sign: support signing enclaves with the AEX-Notify feature enabled
- sgxs-info: print whether a given TCS has AEX-Notify enabled

AEX-Notify is currently not supported by EDP, but this commit allows other runtimes building on sgxs-tools (e.g., [bare-sgx](https://github.com/jovanbulck/bare-sgx/tree/sgxs)) to support AEX-Notify.