### PR TITLE
[RTE-894] Correcting SGX-ISA types and functions related to TDX support

### DIFF
--- a/intel-sgx/aesm-client/Cargo.toml
+++ b/intel-sgx/aesm-client/Cargo.toml
@@ -27,7 +27,7 @@ test-sgx = []
 [dependencies]
 # Project dependencies
 sgxs = { version = "0.8.0", path = "../sgxs", optional = true }
-sgx-isa = { version = "0.4.0", path = "../sgx-isa"}
+sgx-isa = { version = "0.4.1", path = "../sgx-isa"}
 
 # External dependencies
 byteorder = "1.0"          # Unlicense/MIT
@@ -53,6 +53,6 @@ libloading = "0.5.2"
 protobuf-codegen = "3" # MIT
 
 [dev-dependencies]
-sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
+sgx-isa = { version = "0.4.1", path = "../sgx-isa" }
 "report-test" = { version = "0.5.0", path = "../report-test" }
 "sgxs-loaders" = { version = "0.5.0", path = "../sgxs-loaders" }

--- a/intel-sgx/sgx-isa/src/arch.rs
+++ b/intel-sgx/sgx-isa/src/arch.rs
@@ -15,6 +15,10 @@ pub struct Align16<T>(pub T);
 #[repr(align(128))]
 pub struct Align128<T>(pub T);
 
+/// Wrapper struct to force 256-byte alignment.
+#[repr(align(256))]
+pub struct Align256<T>(pub T);
+
 /// Wrapper struct to force 512-byte alignment.
 #[repr(align(512))]
 pub struct Align512<T>(pub T);
@@ -68,5 +72,28 @@ pub fn ereport(
         );
 
         report.assume_init()
+    }
+}
+
+/// Call the `EVERIFYREPORT2` instruction to verify a REPORT MAC struct.
+/// The concrete type is [`crate::ReportMac`].
+pub fn everifyreport2(tdx_report_mac: &Align256<[u8; 256]>) -> Result<(), u32> {
+    unsafe {
+        let error: u32;
+        asm!(
+            "xchg %rbx, {0}",
+            "enclu",
+            "mov {0}, %rbx",
+            "jz 1f",
+            "xor %eax, %eax",
+            "1:",
+            inout(reg) tdx_report_mac => _,
+            inlateout("eax") Enclu::EVerifyReport2 as u32 => error,
+            options(att_syntax, nostack),
+        );
+        match error {
+            0 => Ok(()),
+            err => Err(err),
+        }
     }
 }

--- a/intel-sgx/sgx-isa/src/arch.rs
+++ b/intel-sgx/sgx-isa/src/arch.rs
@@ -5,79 +5,96 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 use super::Enclu;
 use core::arch::asm;
-use core::mem::MaybeUninit;
 
-/// Wrapper struct to force 16-byte alignment.
-#[repr(align(16))]
-pub struct Align16<T>(pub T);
+/// Group all functions and types that is already upstreamed in the sgxstd
+#[cfg(all(target_env = "sgx", not(feature = "sgxstd")))]
+mod upstream {
+    use super::*;
+    use core::mem::MaybeUninit;
 
-/// Wrapper struct to force 128-byte alignment.
-#[repr(align(128))]
-pub struct Align128<T>(pub T);
+    /// Wrapper struct to force 16-byte alignment.
+    #[repr(align(16))]
+    pub struct Align16<T>(pub T);
+
+    /// Wrapper struct to force 128-byte alignment.
+    #[repr(align(128))]
+    pub struct Align128<T>(pub T);
+
+    /// Wrapper struct to force 512-byte alignment.
+    #[repr(align(512))]
+    pub struct Align512<T>(pub T);
+
+    /// Call the `EGETKEY` instruction to obtain a 128-bit secret key.
+    pub fn egetkey(request: &Align512<[u8; 512]>) -> Result<Align16<[u8; 16]>, u32> {
+        unsafe {
+            let mut out = MaybeUninit::uninit();
+            let error;
+
+            asm!(
+                // rbx is reserved by LLVM
+                "xchg %rbx, {0}",
+                "enclu",
+                "mov {0}, %rbx",
+                inout(reg) request => _,
+                inlateout("eax") Enclu::EGetkey as u32 => error,
+                in("rcx") out.as_mut_ptr(),
+                options(att_syntax, nostack),
+            );
+
+            match error {
+                0 => Ok(out.assume_init()),
+                err => Err(err),
+            }
+        }
+    }
+
+    /// Call the `EREPORT` instruction.
+    ///
+    /// This creates a cryptographic report describing the contents of the current
+    /// enclave. The report may be verified by the enclave described in
+    /// `targetinfo`.
+    pub fn ereport(
+        targetinfo: &Align512<[u8; 512]>,
+        reportdata: &Align128<[u8; 64]>,
+    ) -> Align512<[u8; 432]> {
+        unsafe {
+            let mut report = MaybeUninit::uninit();
+
+            asm!(
+                // rbx is reserved by LLVM
+                "xchg %rbx, {0}",
+                "enclu",
+                "mov {0}, %rbx",
+                inout(reg) targetinfo => _,
+                in("eax") Enclu::EReport as u32,
+                in("rcx") reportdata,
+                in("rdx") report.as_mut_ptr(),
+                options(att_syntax, preserves_flags, nostack),
+            );
+
+            report.assume_init()
+        }
+    }
+}
+
+// Export the function in the `upstream` group if not using `sgxstd`
+#[cfg(all(target_env = "sgx", not(feature = "sgxstd")))]
+pub use self::upstream::*;
+
+// Export function in the `fortanix_sgx::arch` namespace if using `sgxstd`
+#[cfg(all(target_env = "sgx", feature = "sgxstd"))]
+pub use std::os::fortanix_sgx::arch::*;
+
+// Functions and types below is not yet upstreamed and will be added to the
+// upstream in the future.
 
 /// Wrapper struct to force 256-byte alignment.
 #[repr(align(256))]
 pub struct Align256<T>(pub T);
 
-/// Wrapper struct to force 512-byte alignment.
-#[repr(align(512))]
-pub struct Align512<T>(pub T);
-
-/// Call the `EGETKEY` instruction to obtain a 128-bit secret key.
-pub fn egetkey(request: &Align512<[u8; 512]>) -> Result<Align16<[u8; 16]>, u32> {
-    unsafe {
-        let mut out = MaybeUninit::uninit();
-        let error;
-
-        asm!(
-            // rbx is reserved by LLVM
-            "xchg %rbx, {0}",
-            "enclu",
-            "mov {0}, %rbx",
-            inout(reg) request => _,
-            inlateout("eax") Enclu::EGetkey as u32 => error,
-            in("rcx") out.as_mut_ptr(),
-            options(att_syntax, nostack),
-        );
-
-        match error {
-            0 => Ok(out.assume_init()),
-            err => Err(err),
-        }
-    }
-}
-
-/// Call the `EREPORT` instruction.
-///
-/// This creates a cryptographic report describing the contents of the current
-/// enclave. The report may be verified by the enclave described in
-/// `targetinfo`.
-pub fn ereport(
-    targetinfo: &Align512<[u8; 512]>,
-    reportdata: &Align128<[u8; 64]>,
-) -> Align512<[u8; 432]> {
-    unsafe {
-        let mut report = MaybeUninit::uninit();
-
-        asm!(
-            // rbx is reserved by LLVM
-            "xchg %rbx, {0}",
-            "enclu",
-            "mov {0}, %rbx",
-            inout(reg) targetinfo => _,
-            in("eax") Enclu::EReport as u32,
-            in("rcx") reportdata,
-            in("rdx") report.as_mut_ptr(),
-            options(att_syntax, preserves_flags, nostack),
-        );
-
-        report.assume_init()
-    }
-}
-
 /// Call the `EVERIFYREPORT2` instruction to verify a REPORT MAC struct.
 /// The concrete type is [`crate::ReportMac`].
-pub fn everifyreport2(tdx_report_mac: &Align256<[u8; 256]>) -> Result<(), u32> {
+pub fn everifyreport2(report_mac: &Align256<[u8; 256]>) -> Result<(), u32> {
     unsafe {
         let error: u32;
         asm!(
@@ -87,7 +104,7 @@ pub fn everifyreport2(tdx_report_mac: &Align256<[u8; 256]>) -> Result<(), u32> {
             "jz 1f",
             "xor %eax, %eax",
             "1:",
-            inout(reg) tdx_report_mac => _,
+            inout(reg) report_mac => _,
             inlateout("eax") Enclu::EVerifyReport2 as u32 => error,
             options(att_syntax, nostack),
         );

--- a/intel-sgx/sgx-isa/src/large_array_impl.rs
+++ b/intel-sgx/sgx-isa/src/large_array_impl.rs
@@ -289,16 +289,16 @@ impl ::core::fmt::Debug for Keyrequest {
     }
 }
 
-impl ::core::fmt::Debug for ReportMac {
+impl ::core::fmt::Debug for ReportMacStruct {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("ReportMac")
             .field("report_type", &self.report_type)
-            .field("reserved1", &self.reserved1)
-            .field("cpu_svn", &self.cpu_svn)
+            .field("reserved1", &self._reserved1)
+            .field("cpusvn", &self.cpusvn)
             .field("tee_tcb_info_hash", &self.tee_tcb_info_hash)
             .field("tee_info_hash", &self.tee_info_hash)
             .field("report_data", &self.report_data)
-            .field("reserved2", &self.reserved2)
+            .field("reserved2", &self._reserved2)
             .field("mac", &self.mac)
             .finish()
     }

--- a/intel-sgx/sgx-isa/src/large_array_impl.rs
+++ b/intel-sgx/sgx-isa/src/large_array_impl.rs
@@ -288,3 +288,18 @@ impl ::core::fmt::Debug for Keyrequest {
         }
     }
 }
+
+impl ::core::fmt::Debug for ReportMac {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("ReportMac")
+            .field("report_type", &self.report_type)
+            .field("reserved1", &self.reserved1)
+            .field("cpu_svn", &self.cpu_svn)
+            .field("tee_tcb_info_hash", &self.tee_tcb_info_hash)
+            .field("tee_info_hash", &self.tee_info_hash)
+            .field("report_data", &self.report_data)
+            .field("reserved2", &self.reserved2)
+            .field("mac", &self.mac)
+            .finish()
+    }
+}

--- a/intel-sgx/sgx-isa/src/lib.rs
+++ b/intel-sgx/sgx-isa/src/lib.rs
@@ -31,7 +31,7 @@ use serde::{Serialize, Deserialize};
 #[cfg(target_env = "sgx")]
 mod arch;
 
-use core::{convert::TryFrom, num::TryFromIntError, slice};
+use core::{slice, convert::TryFrom};
 
 #[cfg(feature = "serde")]
 mod array_64 {
@@ -114,6 +114,7 @@ macro_rules! impl_default_clone_eq {
 
 pub mod tdx;
 
+#[macro_export]
 macro_rules! enum_def {
     (
         #[derive($($derive:meta),*)]
@@ -128,8 +129,8 @@ macro_rules! enum_def {
             $($key = $val,)*
         }
 
-        impl TryFrom<$repr> for $name {
-            type Error = TryFromIntError;
+        impl core::convert::TryFrom<$repr> for $name {
+            type Error = core::num::TryFromIntError;
             fn try_from(v: $repr) -> Result<Self, Self::Error> {
                 match v {
                     $($val => Ok($name::$key),)*
@@ -835,6 +836,19 @@ struct_def! {
 
 impl ReportType {
     pub const UNPADDED_SIZE: usize = 4;
+}
+
+// All variants of ReportVersion that is valid for TDX report
+enum_def! {
+#[derive(Clone,Copy,Debug,PartialEq,Eq)]
+#[repr(u8)]
+pub enum ReportTypeType {
+    Sgx = 0x00,
+    // 0x01 - 0x7F - Reserved for processor-based TEE report
+    // 0x80 - Reserved for SEAM-based TEE report
+    Tdx = 0x81,
+    // 0x82 - 0xFF - Reserved for SEAM-based TEE report
+}
 }
 
 /// SHA384 hash size in bytes

--- a/intel-sgx/sgx-isa/src/lib.rs
+++ b/intel-sgx/sgx-isa/src/lib.rs
@@ -30,10 +30,22 @@ use serde::{Serialize, Deserialize};
 
 #[cfg(all(target_env = "sgx", feature = "sgxstd"))]
 use std::os::fortanix_sgx::arch;
+
 #[cfg(all(target_env = "sgx", not(feature = "sgxstd")))]
 mod arch;
-use core::{convert::TryFrom, num::TryFromIntError, slice};
 
+// Compatibility layer before the `EVERIFYREPORT2` is upstreamed
+#[cfg(all(target_env = "sgx", feature = "sgxstd"))]
+#[path ="arch.rs"]
+mod non_std_arch;
+
+#[cfg(all(target_env = "sgx", feature = "sgxstd"))]
+use non_std_arch::{Align256, everifyreport2};
+
+#[cfg(all(target_env = "sgx", not(feature = "sgxstd")))]
+use arch::{Align256, everifyreport2};
+
+use core::{convert::TryFrom, num::TryFromIntError, slice};
 
 #[cfg(feature = "serde")]
 mod array_64 {
@@ -305,6 +317,7 @@ pub enum ErrorCode {
     PageAttributesMismatch =  19,
     PageNotModifiable      =  20,
     PageNotDebuggable      =  21,
+    InvalidReportMacStruct =  28,
     InvalidCpusvn          =  32,
     InvalidIsvsvn          =  64,
     UnmaskedEvent          = 128,
@@ -702,7 +715,7 @@ impl Report {
     /// implementation of the verifying function.
     ///
     /// Care should be taken that `check_mac` prevents timing attacks,
-    /// in particular that the comparison happens in constant time. 
+    /// in particular that the comparison happens in constant time.
     #[cfg(target_env = "sgx")]
     pub fn verify<F, R>(&self, check_mac: F) -> R
     where
@@ -805,6 +818,100 @@ bitflags! {
 impl Default for Keypolicy {
     fn default() -> Self {
         Self::empty()
+    }
+}
+
+struct_def! {
+    /// Rust definition of `REPORTTYPE` from `REPORTMACSTRUCT`.
+    ///
+    /// Ref: Intel® Trust Domain CPU Architectural Extensions, table 2-4.
+    /// Version: 343754-002US, MAY 2021
+    /// Link: <https://cdrdv2.intel.com/v1/dl/getContent/733582>
+    #[repr(C, align(4))]
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
+    pub struct TeeReportType {
+        /// Trusted Execution Environment(TEE) type:
+        ///   0x00:      SGX Legacy REPORT TYPE
+        ///   0x7F-0x01: Reserved
+        ///   0x80:      Reserved
+        ///   0x81:      TEE Report type 2
+        ///   0xFF-0x82: Reserved
+        pub report_type: u8,
+        /// TYPE-specific subtype, Stage1: value is 0
+        pub subtype: u8,
+        /// TYPE-specific version, Stage1: value is 0
+        pub version: u8,
+        pub reserved: u8,
+    }
+}
+
+impl TeeReportType {
+    pub const UNPADDED_SIZE: usize = 4;
+}
+
+/// SHA384 hash size in bytes
+pub const HASH_384_SIZE: usize = 48;
+/// SHA384 hash
+pub type Sha384Hash = [u8; HASH_384_SIZE];
+
+pub const CPU_SVN_SIZE: usize = 16;
+pub const REPORT_MAC_STRUCT_SIZE: usize = 256;
+pub const REPORT_MAC_STRUCT_RESERVED1_BYTES: usize = 12;
+pub const REPORT_MAC_STRUCT_RESERVED2_BYTES: usize = 32;
+pub const REPORT_DATA_SIZE: usize = 64;
+
+/// Message SHA 256 HASH Code - 32 bytes
+pub const TEE_MAC_SIZE: usize = 32;
+
+
+struct_def! {
+/// Rust definition of `REPORTMACSTRUCT`, used by TDX `TDREPORT_STRUCT`
+/// and the future 256BITSGX
+///
+/// Ref: Intel® Trust Domain CPU Architectural Extensions, table 2-5.
+/// Version: 343754-002US, MAY 2021
+/// Link TDX: <https://cdrdv2.intel.com/v1/dl/getContent/733582>
+/// Link 256BITSGX: <https://cdrdv2-public.intel.com/851355/319433-057-architecture-instruction-set-extensions-programming-reference.pdf>
+#[repr(C, align(256))]
+#[cfg_attr(
+    feature = "large_array_derive",
+    derive(Clone, Debug, Eq, PartialEq)
+)]
+pub struct ReportMac {
+    /// (  0) TEE Report type
+    pub report_type: TeeReportType,
+    /// (  4) Reserved, must be zero
+    pub reserved1: [u8; REPORT_MAC_STRUCT_RESERVED1_BYTES],
+    /// ( 16) Security Version of the CPU
+    pub cpu_svn: [u8; CPU_SVN_SIZE],
+    /// ( 32) SHA384 of TEE_TCB_INFO for TEEs
+    pub tee_tcb_info_hash: Sha384Hash,
+    /// ( 80) SHA384 of TEE_INFO
+    pub tee_info_hash: Sha384Hash,
+    /// (128) Data provided by the user
+    pub report_data: [u8; REPORT_DATA_SIZE],
+    /// (192) Reserved, must be zero
+    pub reserved2: [u8; REPORT_MAC_STRUCT_RESERVED2_BYTES],
+    /// (224) The Message Authentication Code over this structure
+    pub mac: [u8; TEE_MAC_SIZE],
+}
+}
+
+impl ReportMac {
+    pub const UNPADDED_SIZE: usize = 256;
+
+    #[cfg(target_env = "sgx")]
+    pub fn verify(&self) -> Result<(), ErrorCode> {
+        everifyreport2(self.as_ref())
+            // Same as `egetkey` reasoning: unwrap is okay here
+            .map_err(|e| ErrorCode::try_from(e).unwrap())
+    }
+}
+
+#[cfg(target_env = "sgx")]
+impl AsRef<Align256<[u8; ReportMac::UNPADDED_SIZE]>> for ReportMac {
+    fn as_ref(&self) -> &Align256<[u8; Self::UNPADDED_SIZE]> {
+        unsafe { &*(self as *const _ as *const _) }
     }
 }
 

--- a/intel-sgx/sgx-isa/src/lib.rs
+++ b/intel-sgx/sgx-isa/src/lib.rs
@@ -28,22 +28,8 @@ extern crate serde;
 #[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize};
 
-#[cfg(all(target_env = "sgx", feature = "sgxstd"))]
-use std::os::fortanix_sgx::arch;
-
-#[cfg(all(target_env = "sgx", not(feature = "sgxstd")))]
+#[cfg(target_env = "sgx")]
 mod arch;
-
-// Compatibility layer before the `EVERIFYREPORT2` is upstreamed
-#[cfg(all(target_env = "sgx", feature = "sgxstd"))]
-#[path ="arch.rs"]
-mod non_std_arch;
-
-#[cfg(all(target_env = "sgx", feature = "sgxstd"))]
-use non_std_arch::{Align256, everifyreport2};
-
-#[cfg(all(target_env = "sgx", not(feature = "sgxstd")))]
-use arch::{Align256, everifyreport2};
 
 use core::{convert::TryFrom, num::TryFromIntError, slice};
 
@@ -235,7 +221,9 @@ macro_rules! struct_def {
     (@align bytes 128 name $name:ident) => {
         struct_def!(@align type Align128 name $name);
     };
-
+    (@align bytes 256 name $name:ident) => {
+        struct_def!(@align type Align256 name $name);
+    };
     (@align bytes 512 name $name:ident) => {
         struct_def!(@align type Align512 name $name);
     };
@@ -829,7 +817,7 @@ struct_def! {
     /// Link: <https://cdrdv2.intel.com/v1/dl/getContent/733582>
     #[repr(C, align(4))]
     #[derive(Clone, Debug, Default, Eq, PartialEq)]
-    pub struct TeeReportType {
+    pub struct ReportType {
         /// Trusted Execution Environment(TEE) type:
         ///   0x00:      SGX Legacy REPORT TYPE
         ///   0x7F-0x01: Reserved
@@ -845,7 +833,7 @@ struct_def! {
     }
 }
 
-impl TeeReportType {
+impl ReportType {
     pub const UNPADDED_SIZE: usize = 4;
 }
 
@@ -875,15 +863,15 @@ struct_def! {
 #[repr(C, align(256))]
 #[cfg_attr(
     feature = "large_array_derive",
-    derive(Clone, Debug, Eq, PartialEq)
+    derive(Clone, Debug, Default, Eq, PartialEq)
 )]
-pub struct ReportMac {
+pub struct ReportMacStruct {
     /// (  0) TEE Report type
-    pub report_type: TeeReportType,
+    pub report_type: ReportType,
     /// (  4) Reserved, must be zero
-    pub reserved1: [u8; REPORT_MAC_STRUCT_RESERVED1_BYTES],
+    pub _reserved1: [u8; REPORT_MAC_STRUCT_RESERVED1_BYTES],
     /// ( 16) Security Version of the CPU
-    pub cpu_svn: [u8; CPU_SVN_SIZE],
+    pub cpusvn: [u8; CPU_SVN_SIZE],
     /// ( 32) SHA384 of TEE_TCB_INFO for TEEs
     pub tee_tcb_info_hash: Sha384Hash,
     /// ( 80) SHA384 of TEE_INFO
@@ -891,27 +879,20 @@ pub struct ReportMac {
     /// (128) Data provided by the user
     pub report_data: [u8; REPORT_DATA_SIZE],
     /// (192) Reserved, must be zero
-    pub reserved2: [u8; REPORT_MAC_STRUCT_RESERVED2_BYTES],
+    pub _reserved2: [u8; REPORT_MAC_STRUCT_RESERVED2_BYTES],
     /// (224) The Message Authentication Code over this structure
     pub mac: [u8; TEE_MAC_SIZE],
 }
 }
 
-impl ReportMac {
+impl ReportMacStruct {
     pub const UNPADDED_SIZE: usize = 256;
 
     #[cfg(target_env = "sgx")]
     pub fn verify(&self) -> Result<(), ErrorCode> {
-        everifyreport2(self.as_ref())
+        arch::everifyreport2(self.as_ref())
             // Same as `egetkey` reasoning: unwrap is okay here
             .map_err(|e| ErrorCode::try_from(e).unwrap())
-    }
-}
-
-#[cfg(target_env = "sgx")]
-impl AsRef<Align256<[u8; ReportMac::UNPADDED_SIZE]>> for ReportMac {
-    fn as_ref(&self) -> &Align256<[u8; Self::UNPADDED_SIZE]> {
-        unsafe { &*(self as *const _ as *const _) }
     }
 }
 

--- a/intel-sgx/sgx-isa/src/tdx.rs
+++ b/intel-sgx/sgx-isa/src/tdx.rs
@@ -12,7 +12,7 @@ use crate::arch;
 #[cfg(all(target_env = "sgx", feature = "sgxstd"))]
 use std::os::fortanix_sgx::arch;
 
-use crate::{slice, struct_def, ReportMacStruct, Sha384Hash};
+use crate::{enum_def, slice, struct_def, ReportMacStruct, Sha384Hash};
 
 #[cfg(target_env = "sgx")]
 use crate::ErrorCode;
@@ -23,10 +23,17 @@ pub const SGX_LEGACY_REPORT_TYPE: usize = 0x0;
 pub const TEE_REPORT2_TYPE: usize = 0x8;
 /// SUBTYPE for Report Type2 is 0
 pub const TEE_REPORT2_SUBTYPE: usize = 0x0;
-/// VERSION for Report Type2 is 0
-pub const TEE_REPORT2_VERSION: usize = 0x0;
-/// VERSION for Report Type2 which mr_servicetd is used
-pub const TEE_REPORT2_VERSION_SERVICETD: usize = 0x1;
+
+// All variants of REPORTTYPE.VERSION that is valid for TDX report
+enum_def! {
+#[derive(Clone,Copy,Debug,PartialEq,Eq)]
+#[repr(u8)]
+pub enum TdxReportTypeVersion {
+    NoBound       = 0x00,
+    ServTdUsed    = 0x01,
+    ConfigSvnUsed = 0x02,
+}
+}
 
 // Ensure new type name is backward compatibe
 pub type TdxReportMac = super::ReportMacStruct;

--- a/intel-sgx/sgx-isa/src/tdx.rs
+++ b/intel-sgx/sgx-isa/src/tdx.rs
@@ -70,6 +70,9 @@ pub const TDX_REPORT_MAC_STRUCT_SIZE: usize = 256;
 pub const TDX_REPORT_MAC_STRUCT_RESERVED1_BYTES: usize = 12;
 pub const TDX_REPORT_MAC_STRUCT_RESERVED2_BYTES: usize = 32;
 
+// Ensure new type name is backward compatibe
+pub type TdxReportMac = ReportMac;
+
 struct_def! {
     /// Rust definition of `REPORTMACSTRUCT` from `TDREPORT_STRUCT`.
     ///
@@ -81,7 +84,7 @@ struct_def! {
         feature = "large_array_derive",
         derive(Clone, Debug, Eq, PartialEq)
     )]
-    pub struct TdxReportMac {
+    pub struct ReportMac {
         /// (  0) TEE Report type
         pub report_type: TeeReportType,
         /// (  4) Reserved, must be zero
@@ -101,12 +104,12 @@ struct_def! {
     }
 }
 
-impl TdxReportMac {
+impl ReportMac {
     pub const UNPADDED_SIZE: usize = 256;
 }
 
 #[cfg(target_env = "sgx")]
-impl AsRef<tdx_arch::Align256<[u8; TdxReportMac::UNPADDED_SIZE]>> for TdxReportMac {
+impl AsRef<tdx_arch::Align256<[u8; ReportMac::UNPADDED_SIZE]>> for ReportMac {
     fn as_ref(&self) -> &tdx_arch::Align256<[u8; Self::UNPADDED_SIZE]> {
         unsafe { &*(self as *const _ as *const _) }
     }
@@ -253,7 +256,7 @@ struct_def! {
     )]
     pub struct TdxReportV1 {
         /// (  0) Report mac struct for SGX report type 2
-        pub report_mac: TdxReportMac,
+        pub report_mac: ReportMac,
         /// (256) Struct contains details about extra TCB elements not found in CPUSVN
         pub tee_tcb_info: TeeTcbInfo,
         /// (495) Reserved, must be zero
@@ -324,7 +327,7 @@ impl Display for TdxError {
             TdxError::Interrupted => f.write_str("Usercall is interrupted"),
             TdxError::InvalidCpuSvn => f.write_str("Failed to verify TD report: invalid Cpu Svn"),
             TdxError::InvalidParameter => f.write_str("The parameter is incorrect"),
-            TdxError::InvalidReportMacStruct => f.write_str("Failed to verify TD report: invalid TdxReportMac"),
+            TdxError::InvalidReportMacStruct => f.write_str("Failed to verify TD report: invalid ReportMac"),
             TdxError::InvalidRtmrIndex => f.write_str("Only supported RTMR index is 2 and 3"),
             TdxError::NotSupported => f.write_str("Request feature is not supported"),
             TdxError::OutOfMemory => f.write_str("Not enough memory is available to complete this operation"),
@@ -344,9 +347,9 @@ mod debug_impl {
     use super::*;
     use core::fmt::{Debug, Formatter, Result};
 
-    impl Debug for TdxReportMac {
+    impl Debug for ReportMac {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-            f.debug_struct("TdxReportMac")
+            f.debug_struct("ReportMac")
                 .field("report_type", &self.report_type)
                 .field("reserved1", &self.reserved1)
                 .field("cpu_svn", &self.cpu_svn)
@@ -419,7 +422,7 @@ mod tdx_arch {
     pub struct Align256<T>(pub T);
 
     /// Call the `EVERIFYREPORT2` instruction to verify a 256-bit TDX REPORT MAC struct.
-    /// The concrete type is [`crate::tdx::TdxReportMac`].
+    /// The concrete type is [`crate::tdx::ReportMac`].
     pub fn everifyreport2(tdx_report_mac: &Align256<[u8; 256]>) -> Result<(), u32> {
         unsafe {
             let error: u32;

--- a/intel-sgx/sgx-isa/src/tdx.rs
+++ b/intel-sgx/sgx-isa/src/tdx.rs
@@ -12,17 +12,7 @@ use crate::arch;
 #[cfg(all(target_env = "sgx", feature = "sgxstd"))]
 use std::os::fortanix_sgx::arch;
 
-use core::fmt::Display;
-
-use crate::{slice, struct_def};
-
-/// SHA384 hash size in bytes
-pub const TEE_HASH_384_SIZE: usize = 48;
-/// Message SHA 256 HASH Code - 32 bytes
-pub const TEE_MAC_SIZE: usize = 32;
-
-pub const TDX_REPORT_DATA_SIZE: usize = 64;
-pub const TEE_CPU_SVN_SIZE: usize = 16;
+use crate::{slice, struct_def, ErrorCode, ReportMac, Sha384Hash};
 
 /// SGX Legacy Report Type
 pub const SGX_LEGACY_REPORT_TYPE: usize = 0x0;
@@ -35,85 +25,8 @@ pub const TEE_REPORT2_VERSION: usize = 0x0;
 /// VERSION for Report Type2 which mr_servicetd is used
 pub const TEE_REPORT2_VERSION_SERVICETD: usize = 0x1;
 
-/// SHA384 hash
-pub type Sha384Hash = [u8; TEE_HASH_384_SIZE];
-
-struct_def! {
-    /// Rust definition of `REPORTTYPE` from `REPORTMACSTRUCT`.
-    ///
-    /// Ref: Intel® Trust Domain CPU Architectural Extensions, table 2-4.
-    /// Version: 343754-002US, MAY 2021
-    /// Link: <https://cdrdv2.intel.com/v1/dl/getContent/733582>
-    #[repr(C, align(4))]
-    #[derive(Clone, Debug, Default, Eq, PartialEq)]
-    pub struct TeeReportType {
-        /// Trusted Execution Environment(TEE) type:
-        ///   0x00:      SGX Legacy REPORT TYPE
-        ///   0x7F-0x01: Reserved
-        ///   0x80:      Reserved
-        ///   0x81:      TEE Report type 2
-        ///   0xFF-0x82: Reserved
-        pub report_type: u8,
-        /// TYPE-specific subtype, Stage1: value is 0
-        pub subtype: u8,
-        /// TYPE-specific version, Stage1: value is 0
-        pub version: u8,
-        pub reserved: u8,
-    }
-}
-
-impl TeeReportType {
-    pub const UNPADDED_SIZE: usize = 4;
-}
-
-pub const TDX_REPORT_MAC_STRUCT_SIZE: usize = 256;
-pub const TDX_REPORT_MAC_STRUCT_RESERVED1_BYTES: usize = 12;
-pub const TDX_REPORT_MAC_STRUCT_RESERVED2_BYTES: usize = 32;
-
 // Ensure new type name is backward compatibe
-pub type TdxReportMac = ReportMac;
-
-struct_def! {
-    /// Rust definition of `REPORTMACSTRUCT` from `TDREPORT_STRUCT`.
-    ///
-    /// Ref: Intel® Trust Domain CPU Architectural Extensions, table 2-5.
-    /// Version: 343754-002US, MAY 2021
-    /// Link: <https://cdrdv2.intel.com/v1/dl/getContent/733582>
-    #[repr(C, align(256))]
-    #[cfg_attr(
-        feature = "large_array_derive",
-        derive(Clone, Debug, Eq, PartialEq)
-    )]
-    pub struct ReportMac {
-        /// (  0) TEE Report type
-        pub report_type: TeeReportType,
-        /// (  4) Reserved, must be zero
-        pub reserved1: [u8; TDX_REPORT_MAC_STRUCT_RESERVED1_BYTES],
-        /// ( 16) Security Version of the CPU
-        pub cpu_svn: [u8; TEE_CPU_SVN_SIZE],
-        /// ( 32) SHA384 of TEE_TCB_INFO for TEEs
-        pub tee_tcb_info_hash: Sha384Hash,
-        /// ( 80) SHA384 of TEE_INFO
-        pub tee_info_hash: Sha384Hash,
-        /// (128) Data provided by the user
-        pub report_data: [u8; TDX_REPORT_DATA_SIZE],
-        /// (192) Reserved, must be zero
-        pub reserved2: [u8; TDX_REPORT_MAC_STRUCT_RESERVED2_BYTES],
-        /// (224) The Message Authentication Code over this structure
-        pub mac: [u8; TEE_MAC_SIZE],
-    }
-}
-
-impl ReportMac {
-    pub const UNPADDED_SIZE: usize = 256;
-}
-
-#[cfg(target_env = "sgx")]
-impl AsRef<tdx_arch::Align256<[u8; ReportMac::UNPADDED_SIZE]>> for ReportMac {
-    fn as_ref(&self) -> &tdx_arch::Align256<[u8; Self::UNPADDED_SIZE]> {
-        unsafe { &*(self as *const _ as *const _) }
-    }
-}
+pub type TdxReportMac = super::ReportMac;
 
 /// Size of a TDX report in bytes.
 pub const TDX_REPORT_SIZE: usize = 1024;
@@ -239,7 +152,6 @@ impl TdInfoV1 {
 }
 
 // TODO(RTE-805): Add support for TDINFO_STRUCT with size 768 bytes
-
 struct_def! {
     /// Rust definition of `TDREPORT_STRUCT` from the output of the `TDG.MR.REPORT` function.
     /// Total size of this variant is __1024__ bytes with `report_mac.report_type.version` equals __0 or 1__.
@@ -270,75 +182,8 @@ impl TdxReportV1 {
     pub const UNPADDED_SIZE: usize = 1024;
 
     #[cfg(target_env = "sgx")]
-    pub fn verify(&self) -> Result<(), TdxError> {
-        tdx_arch::everifyreport2(self.report_mac.as_ref())
-            .map_err(TdxError::from_everifyreport2_return_code)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum TdxError {
-    Success,
-    BadAddress,
-    Busy,
-    DeviceFailure,
-    ExtendFailure,
-    Interrupted,
-    InvalidCpuSvn,
-    InvalidParameter,
-    InvalidReportMacStruct,
-    InvalidRtmrIndex,
-    NotSupported,
-    OutOfMemory,
-    QuoteFailure,
-    ReportFailure,
-    TdcallFailure,
-    UnsupportedAttKeyId,
-    VsockFailure,
-    WrongDevice,
-    Unexpected(u32),
-}
-
-impl TdxError {
-    #[cfg(target_env = "sgx")]
-    fn from_everifyreport2_return_code(code: u32) -> TdxError {
-        match code {
-            0 => TdxError::Success,
-            // This leaf operation is not supported on this CPU
-            0b00001 => TdxError::NotSupported,
-            0b01110 => TdxError::InvalidReportMacStruct,
-            0b10000 => TdxError::InvalidCpuSvn,
-            other => TdxError::Unexpected(other),
-        }
-    }
-}
-
-#[cfg(all(feature = "sgxstd", target_env = "sgx"))]
-impl std::error::Error for TdxError {}
-
-impl Display for TdxError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            TdxError::Success => f.write_str("Success"),
-            TdxError::BadAddress => f.write_str("Bad address"),
-            TdxError::Busy => f.write_str("The device driver return busy"),
-            TdxError::DeviceFailure => f.write_str("Failed to acess tdx attest device"),
-            TdxError::ExtendFailure => f.write_str("Failed to extend rtmr"),
-            TdxError::Interrupted => f.write_str("Usercall is interrupted"),
-            TdxError::InvalidCpuSvn => f.write_str("Failed to verify TD report: invalid Cpu Svn"),
-            TdxError::InvalidParameter => f.write_str("The parameter is incorrect"),
-            TdxError::InvalidReportMacStruct => f.write_str("Failed to verify TD report: invalid ReportMac"),
-            TdxError::InvalidRtmrIndex => f.write_str("Only supported RTMR index is 2 and 3"),
-            TdxError::NotSupported => f.write_str("Request feature is not supported"),
-            TdxError::OutOfMemory => f.write_str("Not enough memory is available to complete this operation"),
-            TdxError::QuoteFailure => f.write_str("Failed to get the TD Quote"),
-            TdxError::ReportFailure => f.write_str("Failed to get the TD Report"),
-            TdxError::TdcallFailure => f.write_str("TD call failed"),
-            TdxError::UnsupportedAttKeyId => f.write_str("The platform Quoting infrastructure does not support any of the keys described in att_key_id_list"),
-            TdxError::VsockFailure => f.write_str("vsock related failure"),
-            TdxError::WrongDevice => f.write_str("Unsupported device"),
-            TdxError::Unexpected(num) => f.write_fmt(format_args!("Unexpected errno: {}", num)),
-        }
+    pub fn verify(&self) -> Result<(), ErrorCode> {
+        self.report_mac.verify()
     }
 }
 
@@ -346,21 +191,6 @@ impl Display for TdxError {
 mod debug_impl {
     use super::*;
     use core::fmt::{Debug, Formatter, Result};
-
-    impl Debug for ReportMac {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-            f.debug_struct("ReportMac")
-                .field("report_type", &self.report_type)
-                .field("reserved1", &self.reserved1)
-                .field("cpu_svn", &self.cpu_svn)
-                .field("tee_tcb_info_hash", &self.tee_tcb_info_hash)
-                .field("tee_info_hash", &self.tee_info_hash)
-                .field("report_data", &self.report_data)
-                .field("reserved2", &self.reserved2)
-                .field("mac", &self.mac)
-                .finish()
-        }
-    }
 
     impl Debug for TdxReportV1 {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {
@@ -407,40 +237,6 @@ mod debug_impl {
                 .field("rtmr", &self.rtmr)
                 .field("servtd_hash", &self.servtd_hash)
                 .finish()
-        }
-    }
-}
-
-/// Since this is not upstreamed to rust yet.
-#[cfg(target_env = "sgx")]
-mod tdx_arch {
-    use crate::Enclu;
-    use core::arch::asm;
-
-    /// Wrapper struct to force 256-byte alignment.
-    #[repr(align(256))]
-    pub struct Align256<T>(pub T);
-
-    /// Call the `EVERIFYREPORT2` instruction to verify a 256-bit TDX REPORT MAC struct.
-    /// The concrete type is [`crate::tdx::ReportMac`].
-    pub fn everifyreport2(tdx_report_mac: &Align256<[u8; 256]>) -> Result<(), u32> {
-        unsafe {
-            let error: u32;
-            asm!(
-                "xchg %rbx, {0}",
-                "enclu",
-                "mov {0}, %rbx",
-                "jz 1f",
-                "xor %eax, %eax",
-                "1:",
-                inout(reg) tdx_report_mac => _,
-                inlateout("eax") Enclu::EVerifyReport2 as u32 => error,
-                options(att_syntax, nostack),
-            );
-            match error {
-                0 => Ok(()),
-                err => Err(err),
-            }
         }
     }
 }

--- a/intel-sgx/sgx-isa/src/tdx.rs
+++ b/intel-sgx/sgx-isa/src/tdx.rs
@@ -12,7 +12,10 @@ use crate::arch;
 #[cfg(all(target_env = "sgx", feature = "sgxstd"))]
 use std::os::fortanix_sgx::arch;
 
-use crate::{slice, struct_def, ErrorCode, ReportMac, Sha384Hash};
+use crate::{slice, struct_def, ReportMacStruct, Sha384Hash};
+
+#[cfg(target_env = "sgx")]
+use crate::ErrorCode;
 
 /// SGX Legacy Report Type
 pub const SGX_LEGACY_REPORT_TYPE: usize = 0x0;
@@ -26,7 +29,7 @@ pub const TEE_REPORT2_VERSION: usize = 0x0;
 pub const TEE_REPORT2_VERSION_SERVICETD: usize = 0x1;
 
 // Ensure new type name is backward compatibe
-pub type TdxReportMac = super::ReportMac;
+pub type TdxReportMac = super::ReportMacStruct;
 
 /// Size of a TDX report in bytes.
 pub const TDX_REPORT_SIZE: usize = 1024;
@@ -168,7 +171,7 @@ struct_def! {
     )]
     pub struct TdxReportV1 {
         /// (  0) Report mac struct for SGX report type 2
-        pub report_mac: ReportMac,
+        pub report_mac: ReportMacStruct,
         /// (256) Struct contains details about extra TCB elements not found in CPUSVN
         pub tee_tcb_info: TeeTcbInfo,
         /// (495) Reserved, must be zero

--- a/intel-sgx/sgx-isa/src/tdx.rs
+++ b/intel-sgx/sgx-isa/src/tdx.rs
@@ -17,16 +17,9 @@ use crate::{enum_def, slice, struct_def, ReportMacStruct, Sha384Hash};
 #[cfg(target_env = "sgx")]
 use crate::ErrorCode;
 
-/// SGX Legacy Report Type
-pub const SGX_LEGACY_REPORT_TYPE: usize = 0x0;
-/// TEE Report Type2
-pub const TEE_REPORT2_TYPE: usize = 0x8;
-/// SUBTYPE for Report Type2 is 0
-pub const TEE_REPORT2_SUBTYPE: usize = 0x0;
-
 // All variants of REPORTTYPE.VERSION that is valid for TDX report
 enum_def! {
-#[derive(Clone,Copy,Debug,PartialEq,Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum TdxReportTypeVersion {
     NoBound       = 0x00,
@@ -34,9 +27,6 @@ pub enum TdxReportTypeVersion {
     ConfigSvnUsed = 0x02,
 }
 }
-
-// Ensure new type name is backward compatibe
-pub type TdxReportMac = super::ReportMacStruct;
 
 /// Size of a TDX report in bytes.
 pub const TDX_REPORT_SIZE: usize = 1024;
@@ -190,11 +180,6 @@ struct_def! {
 
 impl TdxReportV1 {
     pub const UNPADDED_SIZE: usize = 1024;
-
-    #[cfg(target_env = "sgx")]
-    pub fn verify(&self) -> Result<(), ErrorCode> {
-        self.report_mac.verify()
-    }
 }
 
 #[cfg(not(feature = "large_array_derive"))]

--- a/intel-sgx/tdx-ql/examples/tdx_ql_cli.rs
+++ b/intel-sgx/tdx-ql/examples/tdx_ql_cli.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use tdx_ql::{
-    TDX_REPORT_DATA_SIZE, TDX_REPORT_SIZE, TDX_RTMR_EXTEND_DATA_SIZE, extend_tdx_rtmr,
+    REPORT_DATA_SIZE, TDX_REPORT_SIZE, TDX_RTMR_EXTEND_DATA_SIZE, extend_tdx_rtmr,
     get_tdx_report,
 };
 
@@ -41,8 +41,8 @@ fn main() {
             verbose,
         } => {
             let report_data = match report_data {
-                Some(hex) => parse_hex_exact::<TDX_REPORT_DATA_SIZE>(&hex),
-                None => Ok([0u8; TDX_REPORT_DATA_SIZE]),
+                Some(hex) => parse_hex_exact::<REPORT_DATA_SIZE>(&hex),
+                None => Ok([0u8; REPORT_DATA_SIZE]),
             }
             .unwrap_or_else(|err| exit_with_error(&err));
 

--- a/intel-sgx/tdx-ql/src/lib.rs
+++ b/intel-sgx/tdx-ql/src/lib.rs
@@ -8,10 +8,59 @@
 #![doc = include_str!("../README.md")]
 
 use nix::errno::Errno;
-use sgx_isa::tdx::TdxError;
-pub use sgx_isa::tdx::{TdxReportV1, TDX_REPORT_DATA_SIZE, TDX_REPORT_SIZE};
+pub use sgx_isa::REPORT_DATA_SIZE;
+pub use sgx_isa::tdx::{TdxReportV1, TDX_REPORT_SIZE};
 
 pub mod tdx_ioctl;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TdxError {
+    Success,
+    BadAddress,
+    Busy,
+    DeviceFailure,
+    ExtendFailure,
+    Interrupted,
+    InvalidCpuSvn,
+    InvalidParameter,
+    InvalidReportMacStruct,
+    InvalidRtmrIndex,
+    NotSupported,
+    OutOfMemory,
+    QuoteFailure,
+    ReportFailure,
+    TdcallFailure,
+    UnsupportedAttKeyId,
+    VsockFailure,
+    WrongDevice,
+    Unexpected(u32),
+}
+
+impl core::fmt::Display for TdxError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TdxError::Success => f.write_str("Success"),
+            TdxError::BadAddress => f.write_str("Bad address"),
+            TdxError::Busy => f.write_str("The device driver return busy"),
+            TdxError::DeviceFailure => f.write_str("Failed to acess tdx attest device"),
+            TdxError::ExtendFailure => f.write_str("Failed to extend rtmr"),
+            TdxError::Interrupted => f.write_str("Usercall is interrupted"),
+            TdxError::InvalidCpuSvn => f.write_str("Failed to verify TD report: invalid Cpu Svn"),
+            TdxError::InvalidParameter => f.write_str("The parameter is incorrect"),
+            TdxError::InvalidReportMacStruct => f.write_str("Failed to verify TD report: invalid ReportMac"),
+            TdxError::InvalidRtmrIndex => f.write_str("Only supported RTMR index is 2 and 3"),
+            TdxError::NotSupported => f.write_str("Request feature is not supported"),
+            TdxError::OutOfMemory => f.write_str("Not enough memory is available to complete this operation"),
+            TdxError::QuoteFailure => f.write_str("Failed to get the TD Quote"),
+            TdxError::ReportFailure => f.write_str("Failed to get the TD Report"),
+            TdxError::TdcallFailure => f.write_str("TD call failed"),
+            TdxError::UnsupportedAttKeyId => f.write_str("The platform Quoting infrastructure does not support any of the keys described in att_key_id_list"),
+            TdxError::VsockFailure => f.write_str("vsock related failure"),
+            TdxError::WrongDevice => f.write_str("Unsupported device"),
+            TdxError::Unexpected(num) => f.write_fmt(format_args!("Unexpected errno: {}", num)),
+        }
+    }
+}
 
 // TODO: Add TdxReportV2 support
 /// Request a TDX Report of the calling TD.
@@ -26,7 +75,7 @@ pub mod tdx_ioctl;
 ///
 /// # Errors
 /// Propagates the underlying TDX attestation error code.
-pub fn get_tdx_report(report_data: [u8; TDX_REPORT_DATA_SIZE]) -> Result<TdxReportV1, TdxError> {
+pub fn get_tdx_report(report_data: [u8; REPORT_DATA_SIZE]) -> Result<TdxReportV1, TdxError> {
     tdx_ioctl::get_report(report_data)
 }
 
@@ -84,7 +133,7 @@ mod tests {
 
     #[test]
     fn test_tdx_att_get_report_invalid_device() {
-        let result = get_tdx_report([0; TDX_REPORT_DATA_SIZE]);
+        let result = get_tdx_report([0; REPORT_DATA_SIZE]);
         match result {
             Ok(_) => panic!("expecting error"),
             Err(err) => assert_eq!(err, TdxError::DeviceFailure),

--- a/intel-sgx/tdx-ql/src/tdx_ioctl.rs
+++ b/intel-sgx/tdx-ql/src/tdx_ioctl.rs
@@ -8,7 +8,7 @@
 //! ioctl-based TDX attestation backend.
 
 use crate::{
-    errno_to_tdx_err, TdxError, TdxReportV1, TDX_REPORT_DATA_SIZE, TDX_REPORT_SIZE,
+    errno_to_tdx_err, TdxError, TdxReportV1, REPORT_DATA_SIZE, TDX_REPORT_SIZE,
     TDX_RTMR_EXTEND_DATA_SIZE,
 };
 
@@ -16,7 +16,7 @@ const TDX_ATTEST_DEV_PATH: &str = "/dev/tdx_guest";
 
 #[repr(C)]
 struct TdxReportReq {
-    report_data: [u8; TDX_REPORT_DATA_SIZE],
+    report_data: [u8; REPORT_DATA_SIZE],
     td_report: [u8; TDX_REPORT_SIZE],
 }
 
@@ -26,7 +26,7 @@ nix::ioctl_readwrite!(tdx_cmd_get_report, b'T', 1, TdxReportReq);
 /// This function only able to provide a report with version number 0.
 ///
 /// Note: Linux kernel currently only support version 0, see <https://docs.kernel.org/virt/coco/tdx-guest.html>
-pub fn get_report(report_data: [u8; TDX_REPORT_DATA_SIZE]) -> Result<TdxReportV1, TdxError> {
+pub fn get_report(report_data: [u8; REPORT_DATA_SIZE]) -> Result<TdxReportV1, TdxError> {
     use std::os::fd::AsRawFd;
     let mut req = TdxReportReq {
         report_data,


### PR DESCRIPTION
Since REPORTMACSTRUCT is used by both SGX and TDX.
The naming should not strict to TDX.

This PR:
1. Renames the type to `ReportMacStruct` and move to the main crate level instead of under `tdx`  module namespace.
2. Keeps backward compatibility by adding a type alias using old name.
3. `verify` function now is part of `ReportMac` instead of  `TdxReportV1`, although maintaining compatibility that the `verify`  function still exists in `TdxReportV1`
4. Move the internal `tdx_arch` module to be part of entire `arch`  module in the crate.
5. Refactor the `arch` module to allow non-upstreamed new instruction sets to be used without breaking the entire module namespace in the main `lib.rs` file.
7. Move all `TdxError` crates out as it is more relevant to `tdx-ql`  crate. The error from SGX-ISA should be only the `ErrorCode` types.  `TdxError` is not part of the ISA.
8. Add proper enum to `ReportType` possible known constants, instead of a singular constants.