### PR TITLE
Don't force nodes. prefix on all api paths and start using new paths from em-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,22 +1513,22 @@ dependencies = [
 
 [[package]]
 name = "em-client"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987ea4131ab7c1fd254b26131b1198b333a822efd1c498acce803c704c8d5603"
+checksum = "a89c67a846bc4d226b730d258f02444b88aca1af0b994eebdee9f9c5dbeac5b3"
 dependencies = [
- "base64 0.10.1",
- "bitflags 1.2.1",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
  "chrono",
- "futures 0.1.30",
+ "futures 0.3.31",
  "hyper 0.10.16",
  "lazy_static",
- "log 0.3.9",
+ "log 0.4.28",
  "mbedtls",
- "mime 0.2.6",
+ "mime 0.3.17",
  "serde",
  "serde_derive 1.0.204 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_ignored",
+ "serde_ignored 0.1.12",
  "serde_json",
  "url 1.7.2",
  "uuid 0.6.5",
@@ -1549,7 +1549,7 @@ dependencies = [
  "mime 0.2.6",
  "serde",
  "serde_derive 1.0.204 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_ignored",
+ "serde_ignored 0.0.4",
  "serde_json",
  "url 1.7.2",
  "uuid 0.6.5",
@@ -2938,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -3960,7 +3960,7 @@ dependencies = [
  "ipnet",
  "js-sys",
  "log 0.4.28",
- "mime 0.3.16",
+ "mime 0.3.17",
  "native-tls",
  "once_cell",
  "percent-encoding 2.3.2",
@@ -4352,6 +4352,15 @@ name = "serde_ignored"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190e9765dcedb56be63b6e0993a006c7e3b071a016a304736e4a315dc01fb142"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b516445dac1e3535b6d658a7b528d771153dfb272ed4180ca4617a20550365ff"
 dependencies = [
  "serde",
 ]

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "sgx" ]
 
 [dependencies]
 b64-ct = "0.1.3"
-em-client = { version = "4.0.0", default-features = false, features = ["client"] }
+em-client = { version = "4.0.2", default-features = false, features = ["client"] }
 em-node-agent-client = "1.0.0"
 hyper = { version = "0.10", default-features = false }
 mbedtls = { version = ">=0.12.0, <0.14.0", default-features = false, features = ["rdrand", "std", "ssl"] }

--- a/em-app/src/utils.rs
+++ b/em-app/src/utils.rs
@@ -62,15 +62,15 @@ pub fn get_runtime_configuration(
     
     config.push_cert(cert, key).map_err(|e| format!("TLS configuration failed: {:?}", e))?;
 
-    let base_path = if server.starts_with("ccm.") && server.ends_with("fortanix.com") {
-        format!("nodes.{}", server)
+   let tls_client = if (server.starts_with("ccm.") || server.starts_with("em.")) && server.ends_with("fortanix.com") {
+        MbedSSLClient::new_with_sni(Arc::new(config), true, Some(format!("nodes.{}", server)))
     } else {
-        server.to_owned()
+        MbedSSLClient::new(Arc::new(config), true)
     };
 
-    let ssl = MbedSSLClient::new_with_sni(Arc::new(config), true, Some(base_path.clone()));
-    let connector = HttpsConnector::new(ssl);
-    let mut client = Client::try_new_with_connector(&format!("https://{}:{}", base_path, port), None, connector).map_err(|e| format!("EM SaaS request failed: {:?}", e))?;
+    let connector = HttpsConnector::new(tls_client);
+    let mut client = Client::try_new_with_connector(&format!("https://{}:{}", server, port), None, connector)
+        .map_err(|e| format!("CCM client construction failed: {:?}", e))?;
     client.set_use_new_paths(true);
     let response = client.get_runtime_application_config(expected_hash).map_err(|e| format!("Failed requesting workflow config response: {:?}", e))?;
 

--- a/em-app/src/utils.rs
+++ b/em-app/src/utils.rs
@@ -61,10 +61,17 @@ pub fn get_runtime_configuration(
     }
     
     config.push_cert(cert, key).map_err(|e| format!("TLS configuration failed: {:?}", e))?;
-    
-    let ssl = MbedSSLClient::new_with_sni(Arc::new(config), true, Some(format!("nodes.{}", server)));
+
+    let base_path = if server.starts_with("ccm.") && server.ends_with("fortanix.com") {
+        format!("nodes.{}", server)
+    } else {
+        server.to_owned()
+    };
+
+    let ssl = MbedSSLClient::new_with_sni(Arc::new(config), true, Some(base_path.clone()));
     let connector = HttpsConnector::new(ssl);
-    let client = Client::try_new_with_connector(&format!("https://{}:{}/v1/runtime/app_configs", server, port), None, connector).map_err(|e| format!("EM SaaS request failed: {:?}", e))?;
+    let mut client = Client::try_new_with_connector(&format!("https://{}:{}", base_path, port), None, connector).map_err(|e| format!("EM SaaS request failed: {:?}", e))?;
+    client.set_use_new_paths(true);
     let response = client.get_runtime_application_config(expected_hash).map_err(|e| format!("Failed requesting workflow config response: {:?}", e))?;
 
     Ok(response)


### PR DESCRIPTION
This PR also enables the use of the new api paths from the em-client