### PR TITLE
Harden github actions and workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -14,6 +14,10 @@ on:
       - "intel-sgx/ppid-retrieval-tool/**"
       - ".github/workflows/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   build:
+    name: Build Docker Image
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Build the Docker image
         run: |
           cd intel-sgx/ppid-retrieval-tool/Docker

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -14,13 +14,19 @@ on:
       - "intel-sgx/ppid-retrieval-tool/**"
       - ".github/workflows/**"
 
+permissions: {}
+
 jobs:
   build:
     name: Build Docker Image
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
       - name: Build the Docker image
         run: |
           cd intel-sgx/ppid-retrieval-tool/Docker

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -15,9 +15,7 @@ on:
       - ".github/workflows/**"
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -26,4 +24,3 @@ jobs:
         run: |
           cd intel-sgx/ppid-retrieval-tool/Docker
           ./build.sh
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Conditionally export PCS_API_KEY and PCCS_URL
         run: |
           if [ -n "${{ secrets.PCS_API_KEY }}" ]; then
-            echo "PCS_API_KEY=${{ secrets.PCS_API_KEY }}" >> $GITHUB_ENV
+            echo "PCS_API_KEY=${{ secrets.PCS_API_KEY }}" >> "$GITHUB_ENV"
           fi
           if [ -n "${{ vars.PCCS_URL }}" ]; then
-            echo "PCCS_URL=${{ vars.PCCS_URL }}" >> $GITHUB_ENV
+            echo "PCCS_URL=${{ vars.PCCS_URL }}" >> "$GITHUB_ENV"
           fi
 
       - name: Install build dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: "0 6 * * *" # Run CI Daily few hours after UTC midnight, so we can track changes from nightly rust & Intel PCS
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Conditionally export PCS_API_KEY and PCCS_URL
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,5 +122,5 @@ jobs:
       - name: Run memory allocator stress test
         run: cd ./examples/mem-alloc-test && cargo run
 
-      - name: snmalloc correntness test
+      - name: snmalloc correctness test
         run: cd ./examples/mem-correctness-test && cargo run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   # This CI will be triggered on any merge_group events
   merge_group:
   schedule:
-    - cron: "0 6 * * *"  # Run CI Daily few hours after UTC midnight, so we can track changes from nightly rust & Intel PCS
+    - cron: "0 6 * * *" # Run CI Daily few hours after UTC midnight, so we can track changes from nightly rust & Intel PCS
 
 env:
   RUST_BACKTRACE: 1
@@ -28,99 +28,99 @@ jobs:
       CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
     steps:
-    - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-    - name: Conditionally export PCS_API_KEY and PCCS_URL
-      run: |
-        if [ -n "${{ secrets.PCS_API_KEY }}" ]; then
-          echo "PCS_API_KEY=${{ secrets.PCS_API_KEY }}" >> $GITHUB_ENV
-        fi
-        if [ -n "${{ vars.PCCS_URL }}" ]; then
-          echo "PCCS_URL=${{ vars.PCCS_URL }}" >> $GITHUB_ENV
-        fi
+      - name: Conditionally export PCS_API_KEY and PCCS_URL
+        run: |
+          if [ -n "${{ secrets.PCS_API_KEY }}" ]; then
+            echo "PCS_API_KEY=${{ secrets.PCS_API_KEY }}" >> $GITHUB_ENV
+          fi
+          if [ -n "${{ vars.PCCS_URL }}" ]; then
+            echo "PCCS_URL=${{ vars.PCCS_URL }}" >> $GITHUB_ENV
+          fi
 
-    - name: Install build dependencies
-      run: sudo ./install_build_deps.sh
+      - name: Install build dependencies
+        run: sudo ./install_build_deps.sh
 
-    - name: Setup Rust toolchain
-      run: |
-        rustup target add x86_64-fortanix-unknown-sgx x86_64-unknown-linux-musl
-        rustup toolchain add nightly
-        rustup target add x86_64-fortanix-unknown-sgx --toolchain nightly
-        rustup update
+      - name: Setup Rust toolchain
+        run: |
+          rustup target add x86_64-fortanix-unknown-sgx x86_64-unknown-linux-musl
+          rustup toolchain add nightly
+          rustup target add x86_64-fortanix-unknown-sgx --toolchain nightly
+          rustup update
 
-    - name: Cargo test --all --exclude sgxs-loaders
-      run: cargo test --verbose --locked --all --exclude sgxs-loaders --exclude async-usercalls && [ "$(echo $(nm -D target/debug/sgx-detect|grep __vdso_sgx_enter_enclave))" = "w __vdso_sgx_enter_enclave" ]
+      - name: Cargo test --all --exclude sgxs-loaders
+        run: cargo test --verbose --locked --all --exclude sgxs-loaders --exclude async-usercalls && [ "$(echo $(nm -D target/debug/sgx-detect|grep __vdso_sgx_enter_enclave))" = "w __vdso_sgx_enter_enclave" ]
 
-    - name: Nightly test -p async-usercalls --target x86_64-fortanix-unknown-sgx --no-run
-      run: cargo +nightly test --verbose --locked -p async-usercalls --target x86_64-fortanix-unknown-sgx --no-run
+      - name: Nightly test -p async-usercalls --target x86_64-fortanix-unknown-sgx --no-run
+        run: cargo +nightly test --verbose --locked -p async-usercalls --target x86_64-fortanix-unknown-sgx --no-run
 
-    - name: Nightly test -p dcap-artifact-retrieval --target x86_64-fortanix-unknown-sgx --no-default-features --no-run
-      run: cargo +nightly test --verbose --locked -p dcap-artifact-retrieval --target x86_64-fortanix-unknown-sgx --no-default-features --no-run
+      - name: Nightly test -p dcap-artifact-retrieval --target x86_64-fortanix-unknown-sgx --no-default-features --no-run
+        run: cargo +nightly test --verbose --locked -p dcap-artifact-retrieval --target x86_64-fortanix-unknown-sgx --no-default-features --no-run
 
-    - name: Cargo test -p dcap-artifact-retrieval --features rustls-tls
-      run: cargo test --verbose --locked -p dcap-artifact-retrieval --features rustls-tls
+      - name: Cargo test -p dcap-artifact-retrieval --features rustls-tls
+        run: cargo test --verbose --locked -p dcap-artifact-retrieval --features rustls-tls
 
-    - name: Cargo test -p dcap-ql --features link
-      run: cargo test --verbose --locked -p dcap-ql --features link
+      - name: Cargo test -p dcap-ql --features link
+        run: cargo test --verbose --locked -p dcap-ql --features link
 
-    - name: Cargo test -p dcap-ql --features verify
-      run: cargo test --verbose --locked -p dcap-ql --features verify
+      - name: Cargo test -p dcap-ql --features verify
+        run: cargo test --verbose --locked -p dcap-ql --features verify
 
-    - name: Cargo test -p ias --features mbedtls
-      run: cargo test --verbose --locked -p ias --features mbedtls
+      - name: Cargo test -p ias --features mbedtls
+        run: cargo test --verbose --locked -p ias --features mbedtls
 
-    - name: Cargo test -p ias --features client,mbedtls
-      run: cargo test --verbose --locked -p ias --features client,mbedtls
+      - name: Cargo test -p ias --features client,mbedtls
+        run: cargo test --verbose --locked -p ias --features client,mbedtls
 
-    # uses backtrace, which still requires nightly on SGX
-    - name: Nightly build -p aesm-client --target=x86_64-fortanix-unknown-sgx
-      run: cargo +nightly build --verbose --locked -p aesm-client --target=x86_64-fortanix-unknown-sgx
+      # uses backtrace, which still requires nightly on SGX
+      - name: Nightly build -p aesm-client --target=x86_64-fortanix-unknown-sgx
+        run: cargo +nightly build --verbose --locked -p aesm-client --target=x86_64-fortanix-unknown-sgx
 
-    # uses sgxstd feature
-    - name: Nightly build -p aesm-client --target=x86_64-fortanix-unknown-sgx --features sgx-isa/sgxstd
-      run: cargo +nightly build --verbose --locked -p aesm-client --target=x86_64-fortanix-unknown-sgx --features sgx-isa/sgxstd
+      # uses sgxstd feature
+      - name: Nightly build -p aesm-client --target=x86_64-fortanix-unknown-sgx --features sgx-isa/sgxstd
+        run: cargo +nightly build --verbose --locked -p aesm-client --target=x86_64-fortanix-unknown-sgx --features sgx-isa/sgxstd
 
-    - name: Nightly test -p sgx-isa --features sgxstd --target x86_64-fortanix-unknown-sgx --no-run
-      run: cargo +nightly test --verbose --locked -p sgx-isa --features sgxstd --target x86_64-fortanix-unknown-sgx --no-run
+      - name: Nightly test -p sgx-isa --features sgxstd --target x86_64-fortanix-unknown-sgx --no-run
+        run: cargo +nightly test --verbose --locked -p sgx-isa --features sgxstd --target x86_64-fortanix-unknown-sgx --no-run
 
-    - name: Nightly test -p pcs --target x86_64-fortanix-unknown-sgx
-      run: cargo +nightly test --verbose --locked -p pcs --target x86_64-fortanix-unknown-sgx --no-run
+      - name: Nightly test -p pcs --target x86_64-fortanix-unknown-sgx
+        run: cargo +nightly test --verbose --locked -p pcs --target x86_64-fortanix-unknown-sgx --no-run
 
-    - name: Nightly test -p pcs --features verify
-      run: cargo +nightly test --verbose --locked -p pcs --features verify
+      - name: Nightly test -p pcs --features verify
+        run: cargo +nightly test --verbose --locked -p pcs --features verify
 
-    # Unfortunately running `faketime '2021-09-10 11:00:00 GMT' cargo test -p nitro-attestation-verify` causes a segmentation
-    #  fault while compiling. We only execute `faketime` during the tests
-    #- run: cargo test --locked -p nitro-attestation-verify --no-run && faketime '2021-09-08 11:00:00 GMT' cargo test --locked -p nitro-attestation-verify --lib
+      # Unfortunately running `faketime '2021-09-10 11:00:00 GMT' cargo test -p nitro-attestation-verify` causes a segmentation
+      #  fault while compiling. We only execute `faketime` during the tests
+      #- run: cargo test --locked -p nitro-attestation-verify --no-run && faketime '2021-09-08 11:00:00 GMT' cargo test --locked -p nitro-attestation-verify --lib
 
-    - name: Cargo test nitro-attestation-verify with faketime
-      run: cargo test --locked -p nitro-attestation-verify --no-run && faketime '2021-09-10 11:00:00 GMT' cargo test --locked -p nitro-attestation-verify --lib
+      - name: Cargo test nitro-attestation-verify with faketime
+        run: cargo test --locked -p nitro-attestation-verify --no-run && faketime '2021-09-10 11:00:00 GMT' cargo test --locked -p nitro-attestation-verify --lib
 
-    - name: Build fortanix-sgx-tools for x86_64-unknown-linux-musl
-      # NOTE: Skipping linking with the glibc version of OpenSSL to produce a musl based binary. It is unlikely that this would produce a working binary anyway.
-      run: |
-        mkdir -p /tmp/muslinclude
-        ln -sf /usr/include/x86_64-linux-gnu/openssl /tmp/muslinclude/openssl
-        PKG_CONFIG_ALLOW_CROSS=1 CFLAGS=-I/tmp/muslinclude CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=true cargo build --locked -p fortanix-sgx-tools --target x86_64-unknown-linux-musl
+      - name: Build fortanix-sgx-tools for x86_64-unknown-linux-musl
+        # NOTE: Skipping linking with the glibc version of OpenSSL to produce a musl based binary. It is unlikely that this would produce a working binary anyway.
+        run: |
+          mkdir -p /tmp/muslinclude
+          ln -sf /usr/include/x86_64-linux-gnu/openssl /tmp/muslinclude/openssl
+          PKG_CONFIG_ALLOW_CROSS=1 CFLAGS=-I/tmp/muslinclude CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=true cargo build --locked -p fortanix-sgx-tools --target x86_64-unknown-linux-musl
 
-    - name: Build em-app, get-certificate for x86_64-unknown-linux-musl
-      run: cargo build --verbose --locked -p em-app -p get-certificate --target=x86_64-unknown-linux-musl
+      - name: Build em-app, get-certificate for x86_64-unknown-linux-musl
+        run: cargo build --verbose --locked -p em-app -p get-certificate --target=x86_64-unknown-linux-musl
 
-    - name: Build em-app, get-certificate for x86_64-fortanix-unknown-sgx
-      run: cargo build --verbose --locked -p em-app -p get-certificate --target=x86_64-fortanix-unknown-sgx
+      - name: Build em-app, get-certificate for x86_64-fortanix-unknown-sgx
+        run: cargo build --verbose --locked -p em-app -p get-certificate --target=x86_64-fortanix-unknown-sgx
 
-    - name: insecure-time test
-      run: cargo +nightly test -p insecure-time --features estimate_crystal_clock_freq
+      - name: insecure-time test
+        run: cargo +nightly test -p insecure-time --features estimate_crystal_clock_freq
 
-    - name: insecure-time build for SGX platform
-      run: cargo +nightly build -p insecure-time --features estimate_crystal_clock_freq --target x86_64-fortanix-unknown-sgx
+      - name: insecure-time build for SGX platform
+        run: cargo +nightly build -p insecure-time --features estimate_crystal_clock_freq --target x86_64-fortanix-unknown-sgx
 
-    - name: Generate API docs
-      run: ./doc/generate-api-docs.sh
+      - name: Generate API docs
+        run: ./doc/generate-api-docs.sh
 
-    - name: Run memory allocator stress test
-      run: cd ./examples/mem-alloc-test && cargo run
+      - name: Run memory allocator stress test
+        run: cd ./examples/mem-alloc-test && cargo run
 
-    - name: snmalloc correntness test
-      run: cd ./examples/mem-correctness-test && cargo run
+      - name: snmalloc correntness test
+        run: cd ./examples/mem-correctness-test && cargo run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
   schedule:
     - cron: "0 6 * * *" # Run CI Daily few hours after UTC midnight, so we can track changes from nightly rust & Intel PCS
 
+permissions: {}
+
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
@@ -28,7 +30,10 @@ jobs:
       CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Conditionally export PCS_API_KEY and PCCS_URL
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,12 @@ jobs:
           # Extract the crate name from the GITHUB_REF_NAME environment variable
           # GITHUB_REF_NAME contains the Tag name (e.g. rs-lic_v0.2.4) associated with the event
           export CRATE_NAME=$(python3 -c "print('$GITHUB_REF_NAME'.rsplit('_v', 1)[0])")
-          echo "CRATE_NAME=$CRATE_NAME" >> $GITHUB_ENV
+          echo "CRATE_NAME=$CRATE_NAME" >> "$GITHUB_ENV"
 
       - name: Set per-crate config (toolchain/target)
         run: |
           source ./crate-publish-config.sh "$CRATE_NAME"
-          echo "CARGO_BUILD_TARGET=$CARGO_BUILD_TARGET" >> $GITHUB_ENV
+          echo "CARGO_BUILD_TARGET=$CARGO_BUILD_TARGET" >> "$GITHUB_ENV"
 
       - name: Update Rust toolchain
         run: rustup update
@@ -113,10 +113,10 @@ jobs:
           # Extract the crate name from the GITHUB_REF_NAME environment variable
           # GITHUB_REF_NAME contains the Tag name (e.g. rs-lic_v0.2.4) associated with the event
           export CRATE_NAME=$(python3 -c "print('$GITHUB_REF_NAME'.rsplit('_v', 1)[0])")
-          echo "CRATE_NAME=$CRATE_NAME" >> $GITHUB_ENV
+          echo "CRATE_NAME=$CRATE_NAME" >> "$GITHUB_ENV"
 
       - name: Build artifacts for GitHub Release
-        run: ./build-release-artifacts.py --target x86_64-unknown-linux-gnu --package $CRATE_NAME
+        run: ./build-release-artifacts.py --target x86_64-unknown-linux-gnu --package "$CRATE_NAME"
 
       - name: Publish GitHub Release using GitHub CLI
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install build dependencies
         run: sudo ./install_build_deps.sh
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install build dependencies
         run: ./install_build_deps.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,34 +6,34 @@ name: Create GitHub release and publish crate to crates.io
 on:
   push:
     tags:
-      - 'em-app_v[0-9]+.[0-9]+.[0-9]+'
-      - 'aesm-client_v[0-9]+.[0-9]+.[0-9]+'
-      - 'async-usercalls_v[0-9]+.[0-9]+.[0-9]+'
-      - 'confidential-vm-blobs_v[0-9]+.[0-9]+.[0-9]+'
-      - 'dcap-artifact-retrieval_v[0-9]+.[0-9]+.[0-9]+'
-      - 'dcap-provider_v[0-9]+.[0-9]+.[0-9]+'
-      - 'dcap-ql-sys_v[0-9]+.[0-9]+.[0-9]+'
-      - 'dcap-ql_v[0-9]+.[0-9]+.[0-9]+'
-      - 'dcap-retrieve-pckid_v[0-9]+.[0-9]+.[0-9]+'
-      - 'enclave-runner_v[0-9]+.[0-9]+.[0-9]+'
-      - 'enclave-runner-sgx_v[0-9]+.[0-9]+.[0-9]+'
-      - 'fortanix-sgx-abi_v[0-9]+.[0-9]+.[0-9]+'
-      - 'fortanix-sgx-tools_v[0-9]+.[0-9]+.[0-9]+'
-      - 'fortanix-vme-eif_v[0-9]+.[0-9]+.[0-9]+'
-      - 'fortanix-vme-initramfs_v[0-9]+.[0-9]+.[0-9]+'
-      - 'fortanix-vme-runner_v[0-9]+.[0-9]+.[0-9]+'
-      - 'ias_v[0-9]+.[0-9]+.[0-9]+'
-      - 'insecure-time_v[0-9]+.[0-9]+.[0-9]+'
-      - 'pcs_v[0-9]+.[0-9]+.[0-9]+'
-      - 'report-test_v[0-9]+.[0-9]+.[0-9]+'
-      - 'sgx_pkix_v[0-9]+.[0-9]+.[0-9]+'
-      - 'sgx-isa_v[0-9]+.[0-9]+.[0-9]+'
-      - 'sgxs-loaders_v[0-9]+.[0-9]+.[0-9]+'
-      - 'sgxs-tools_v[0-9]+.[0-9]+.[0-9]+'
-      - 'sgxs_v[0-9]+.[0-9]+.[0-9]+'
-      - 'ipc-queue_v[0-9]+.[0-9]+.[0-9]+'
-      - 'rs-libc_v[0-9]+.[0-9]+.[0-9]+'
-      - 'tdx-ql_v[0-9]+.[0-9]+.[0-9]+'
+      - "em-app_v[0-9]+.[0-9]+.[0-9]+"
+      - "aesm-client_v[0-9]+.[0-9]+.[0-9]+"
+      - "async-usercalls_v[0-9]+.[0-9]+.[0-9]+"
+      - "confidential-vm-blobs_v[0-9]+.[0-9]+.[0-9]+"
+      - "dcap-artifact-retrieval_v[0-9]+.[0-9]+.[0-9]+"
+      - "dcap-provider_v[0-9]+.[0-9]+.[0-9]+"
+      - "dcap-ql-sys_v[0-9]+.[0-9]+.[0-9]+"
+      - "dcap-ql_v[0-9]+.[0-9]+.[0-9]+"
+      - "dcap-retrieve-pckid_v[0-9]+.[0-9]+.[0-9]+"
+      - "enclave-runner_v[0-9]+.[0-9]+.[0-9]+"
+      - "enclave-runner-sgx_v[0-9]+.[0-9]+.[0-9]+"
+      - "fortanix-sgx-abi_v[0-9]+.[0-9]+.[0-9]+"
+      - "fortanix-sgx-tools_v[0-9]+.[0-9]+.[0-9]+"
+      - "fortanix-vme-eif_v[0-9]+.[0-9]+.[0-9]+"
+      - "fortanix-vme-initramfs_v[0-9]+.[0-9]+.[0-9]+"
+      - "fortanix-vme-runner_v[0-9]+.[0-9]+.[0-9]+"
+      - "ias_v[0-9]+.[0-9]+.[0-9]+"
+      - "insecure-time_v[0-9]+.[0-9]+.[0-9]+"
+      - "pcs_v[0-9]+.[0-9]+.[0-9]+"
+      - "report-test_v[0-9]+.[0-9]+.[0-9]+"
+      - "sgx_pkix_v[0-9]+.[0-9]+.[0-9]+"
+      - "sgx-isa_v[0-9]+.[0-9]+.[0-9]+"
+      - "sgxs-loaders_v[0-9]+.[0-9]+.[0-9]+"
+      - "sgxs-tools_v[0-9]+.[0-9]+.[0-9]+"
+      - "sgxs_v[0-9]+.[0-9]+.[0-9]+"
+      - "ipc-queue_v[0-9]+.[0-9]+.[0-9]+"
+      - "rs-libc_v[0-9]+.[0-9]+.[0-9]+"
+      - "tdx-ql_v[0-9]+.[0-9]+.[0-9]+"
 
 env:
   RUST_BACKTRACE: 1
@@ -57,7 +57,6 @@ jobs:
 
       - name: Install build dependencies
         run: sudo ./install_build_deps.sh
-
 
       - name: Get name of crate to be published
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,10 @@ on:
       - "rs-libc_v[0-9]+.[0-9]+.[0-9]+"
       - "tdx-ql_v[0-9]+.[0-9]+.[0-9]+"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ on:
       - "rs-libc_v[0-9]+.[0-9]+.[0-9]+"
       - "tdx-ql_v[0-9]+.[0-9]+.[0-9]+"
 
+permissions: {}
+
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
@@ -54,6 +56,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install build dependencies
         run: sudo ./install_build_deps.sh
@@ -85,10 +89,14 @@ jobs:
     needs: publish
     environment: "Publish to crates.io"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # Needed to publish Github releases
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install build dependencies
         run: ./install_build_deps.sh


### PR DESCRIPTION
This PR aims to harden Github actions and workflows against malicious actors. 
It is an initial pass only, there are several items left for future PRs.

Most of the changes come from findings by either [zizmor](https://docs.zizmor.sh/) or [actionlint](https://github.com/rhysd/actionlint) 

I have formatted the workflow files for consistency (yamlls), and fixed a typo in one of the job names as well as added a missing job name for the Docker image build.

The substantial changes in this PR (with links to the corresponding audit rules from the tools) are:

- [Introduced a cooldown period for dependabot, to somewhat mitigate the risk of supply-chain compromise](https://docs.zizmor.sh/audits/#dependabot-cooldown)
- [Pinning of unpinned `use` steps](https://docs.zizmor.sh/audits/#unpinned-uses)
- [Initial attempt at minimizing excessive permissions ](https://docs.zizmor.sh/audits/#excessive-permissions)
- [Add concurrency limits to each workflow](https://docs.zizmor.sh/audits/#concurrency-limits)
- [Double quote usage of env-vars to mitigate globbing and word splitting](https://www.shellcheck.net/wiki/SC2086)


Note that this changes the default permissions in workflows to the empty set. I have tried to guess the necessary permissions for each job where applicable, but it is very possible I have missed something. 
We might want to use https://github.com/GitHubSecurityLab/actions-permissions/tree/main to verify the minimal permissions for each job before this PR gets merged.