### PR TITLE
[RTE-894] Add OID for `TeeReportMac` and `TdxReportMeasurements`

### DIFF
--- a/intel-sgx/sgx_pkix/src/oid.rs
+++ b/intel-sgx/sgx_pkix/src/oid.rs
@@ -30,6 +30,8 @@ lazy_static!{
     pub static ref attestationEmbeddedQe3Quote: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 2, 2, 4].into();
     pub static ref attestationDcapSgx: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 2, 2, 5].into();
     pub static ref attestationDcapTdx: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 2, 2, 16].into();
+    pub static ref attestationTeeReportMac: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 2, 2, 17].into();
+    pub static ref attestationTdxReportMeasurements: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 2, 2, 18].into();
 
     // Fortanix public key algorithm identifiers
     pub static ref ledaCrypt_34_0: ObjectIdentifier = vec![1, 3, 6, 1, 4, 1, 49690, 4, 1].into();


### PR DESCRIPTION
Introducing the new OID in the `sgx_pkix` crates to support TDX report verification in X.509 certificates.