### PR TITLE
Add missing required fields for pushing `tdx-ql`

### DIFF
--- a/intel-sgx/tdx-ql/Cargo.toml
+++ b/intel-sgx/tdx-ql/Cargo.toml
@@ -3,6 +3,18 @@ name = "tdx-ql"
 version = "0.1.0"
 edition = "2021"
 readme = "README.md"
+authors = ["Fortanix, Inc."]
+license = "MPL-2.0"
+description = """
+Idiomatic Rust bindings for TDX report generation for TDX guest machine.
+
+TDX: Trust Domain Extension
+DCAP: DataCenter Attestation Primitives
+"""
+repository = "https://github.com/fortanix/rust-sgx"
+homepage = "https://edp.fortanix.com/"
+keywords = ["sgx", "tdx", "dcap", "quote"]
+categories = ["api-bindings"]
 
 [dependencies]
 sgx-isa = { version = "0.5.0", path = "../../intel-sgx/sgx-isa" }


### PR DESCRIPTION
These missing fields may prevent pushing to crates.io.