### PR TITLE
Update SGX crate versions to publish new `sgx-isa` and `sgx-pkix` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aesm-client"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "byteorder 1.5.0",
@@ -34,7 +34,7 @@ dependencies = [
  "protobuf",
  "protobuf-codegen",
  "report-test",
- "sgx-isa 0.4.1",
+ "sgx-isa",
  "sgxs",
  "sgxs-loaders",
  "thiserror 1.0.59",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-ql"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "byteorder 1.5.0",
@@ -1303,7 +1303,7 @@ dependencies = [
  "report-test",
  "serde",
  "serde_json",
- "sgx-isa 0.4.1",
+ "sgx-isa",
  "sgxs",
  "sgxs-loaders",
  "yasna 0.3.2",
@@ -1311,22 +1311,22 @@ dependencies = [
 
 [[package]]
 name = "dcap-ql-sys"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "num-derive",
  "num-traits",
- "sgx-isa 0.4.1",
+ "sgx-isa",
 ]
 
 [[package]]
 name = "dcap-retrieve-pckid"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aesm-client",
  "anyhow",
  "dcap-ql",
  "report-test",
- "sgx-isa 0.4.1",
+ "sgx-isa",
  "sgxs-loaders",
 ]
 
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "em-app"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "b64-ct",
@@ -1502,8 +1502,8 @@ dependencies = [
  "serde_bytes",
  "serde_derive 1.0.204 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json",
- "sgx-isa 0.4.1",
- "sgx_pkix 0.2.2",
+ "sgx-isa",
+ "sgx_pkix",
  "url 1.7.2",
  "uuid 0.6.5",
  "uuid 0.8.2",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runner-sgx"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -1599,7 +1599,7 @@ dependencies = [
  "nix 0.13.1",
  "openssl",
  "rustc_version",
- "sgx-isa 0.4.1",
+ "sgx-isa",
  "sgxs",
  "thiserror 1.0.59",
  "tokio",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "fortanix-sgx-tools"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "aesm-client",
  "anyhow",
@@ -1773,7 +1773,7 @@ dependencies = [
  "os_str_bytes 7.1.1",
  "serde",
  "serde_derive 1.0.204 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx-isa 0.4.1",
+ "sgx-isa",
  "sgxs",
  "sgxs-loaders",
  "thiserror 1.0.59",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "ias"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aesm-client",
  "base64 0.13.0",
@@ -2444,8 +2444,8 @@ dependencies = [
  "serde-bytes-repr",
  "serde_bytes",
  "serde_json",
- "sgx-isa 0.4.1",
- "sgx_pkix 0.2.2",
+ "sgx-isa",
+ "sgx_pkix",
  "sgxs",
  "sgxs-loaders",
  "tokio",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "pcs"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "b64-ct",
@@ -3481,8 +3481,8 @@ dependencies = [
  "rustc-serialize",
  "serde",
  "serde_json",
- "sgx-isa 0.4.1",
- "sgx_pkix 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx-isa",
+ "sgx_pkix",
  "tempdir",
  "test-case",
  "yasna 0.3.2",
@@ -3928,12 +3928,12 @@ dependencies = [
 
 [[package]]
 name = "report-test"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "enclave-runner 0.8.0",
  "enclave-runner-sgx",
- "sgx-isa 0.4.1",
+ "sgx-isa",
  "sgxs",
 ]
 
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "sgx-isa"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bitflags 1.2.1",
  "mbedtls",
@@ -4475,41 +4475,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "sgx-isa"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0746ac51caf664e67fdb6643b27f0e29d4b9e1cea0b374644ab28bfa2b83fc9"
-dependencies = [
- "bitflags 1.2.1",
-]
-
-[[package]]
 name = "sgx_pkix"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "byteorder 1.5.0",
  "lazy_static",
  "pkix",
  "quick-error",
- "sgx-isa 0.4.1",
-]
-
-[[package]]
-name = "sgx_pkix"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd99155dbd1b4c45ad6a742cb0415387b68f22ab7e8f4cabba4e49d606e5ded"
-dependencies = [
- "byteorder 1.5.0",
- "lazy_static",
- "pkix",
- "quick-error",
- "sgx-isa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx-isa",
 ]
 
 [[package]]
 name = "sgxs"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "byteorder 1.5.0",
@@ -4517,7 +4495,7 @@ dependencies = [
  "foreign-types",
  "openssl",
  "openssl-sys",
- "sgx-isa 0.4.1",
+ "sgx-isa",
  "sha2 0.10.9",
  "thiserror 1.0.59",
  "time 0.3.41",
@@ -4525,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs-loaders"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aesm-client",
  "anyhow",
@@ -4533,7 +4511,7 @@ dependencies = [
  "libloading 0.5.2",
  "nix 0.15.0",
  "report-test",
- "sgx-isa 0.4.1",
+ "sgx-isa",
  "sgxs",
  "thiserror 1.0.59",
  "winapi",
@@ -4541,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs-tools"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "aesm-client",
  "anyhow",
@@ -4568,7 +4546,7 @@ dependencies = [
  "serde",
  "serde_derive 1.0.204 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml",
- "sgx-isa 0.4.1",
+ "sgx-isa",
  "sgxs",
  "sgxs-loaders",
  "syn 0.15.44",
@@ -4778,7 +4756,7 @@ version = "0.1.0"
 dependencies = [
  "clap 4.4.18",
  "nix 0.30.1",
- "sgx-isa 0.4.1",
+ "sgx-isa",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ please ensure the **tag name** used for the new release following format:
 `{crate name}` is used, but `{version number}` is still required for keeping
 a good tag name.
 
+### Updating the version dependency across multiple crates
+
+We use relaxed dependency version requirements across the crates in this repository. As a result, we should avoid increasing the minimum required version of a dependency unless it is truly necessary, especially for minor updates (e.g., 0.4.0 -> 0.5.0). If one crate requires a newer major or minor version, other crates that depend on it but are not affected by the changes should continue to support the older version instead of unnecessarily raising their own dependency requirements. We can do this by using proper version range (e.g., `sgx-isa = >=0.4.0, <0.6.0`).
+
 # Contributing
 
 We gratefully accept contributions from the community.

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "em-app"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["fortanix.com"]
 license = "MPL-2.0"
 edition = "2018"
@@ -30,8 +30,8 @@ uuid_sdkms = { package = "uuid", version = "0.8", features = ["v4", "serde"] }
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
-sgx_pkix = { version = "0.2.0", path = "../intel-sgx/sgx_pkix" }
-sgx-isa = { version = "0.4", path = "../intel-sgx/sgx-isa", default-features = false }
+sgx_pkix = { version = ">=0.2.0, <0.4.0", path = "../intel-sgx/sgx_pkix" }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../intel-sgx/sgx-isa", default-features = false }
 
 [target.x86_64-unknown-linux-musl.dependencies]
 aws-nitro-enclaves-nsm-api = "0.2.0"

--- a/intel-sgx/aesm-client/Cargo.toml
+++ b/intel-sgx/aesm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesm-client"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -27,7 +27,7 @@ test-sgx = []
 [dependencies]
 # Project dependencies
 sgxs = { version = "0.8.0", path = "../sgxs", optional = true }
-sgx-isa = { version = "0.4.1", path = "../sgx-isa"}
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa"}
 
 # External dependencies
 byteorder = "1.0"          # Unlicense/MIT
@@ -53,6 +53,6 @@ libloading = "0.5.2"
 protobuf-codegen = "3" # MIT
 
 [dev-dependencies]
-sgx-isa = { version = "0.4.1", path = "../sgx-isa" }
+sgx-isa = { version = "0.5.0", path = "../sgx-isa" }
 "report-test" = { version = "0.5.0", path = "../report-test" }
 "sgxs-loaders" = { version = "0.5.0", path = "../sgxs-loaders" }

--- a/intel-sgx/aesm-client/Cargo.toml
+++ b/intel-sgx/aesm-client/Cargo.toml
@@ -27,7 +27,7 @@ test-sgx = []
 [dependencies]
 # Project dependencies
 sgxs = { version = "0.8.0", path = "../sgxs", optional = true }
-sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa"}
+sgx-isa = { version = ">=0.4.1, <0.6.0", path = "../sgx-isa"}
 
 # External dependencies
 byteorder = "1.0"          # Unlicense/MIT
@@ -53,6 +53,6 @@ libloading = "0.5.2"
 protobuf-codegen = "3" # MIT
 
 [dev-dependencies]
-sgx-isa = { version = "0.5.0", path = "../sgx-isa" }
+sgx-isa = { version = ">=0.4.1, <0.6.0", path = "../sgx-isa" }
 "report-test" = { version = "0.5.0", path = "../report-test" }
 "sgxs-loaders" = { version = "0.5.0", path = "../sgxs-loaders" }

--- a/intel-sgx/dcap-ql-sys/Cargo.toml
+++ b/intel-sgx/dcap-ql-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-ql-sys"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Fortanix, Inc."]
 links = "sgx_dcap_ql"
 build = "build.rs"
@@ -24,7 +24,7 @@ link = []
 
 [dependencies]
 # Project dependencies
-"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 
 # External dependencies
 num-derive = "0.4" # MIT/Apache-2.0

--- a/intel-sgx/dcap-ql/Cargo.toml
+++ b/intel-sgx/dcap-ql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-ql"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -36,9 +36,9 @@ verify = ["mbedtls", "num", "yasna"]
 
 [dependencies]
 # Project dependencies
-"dcap-ql-sys" = { version = "0.2.0", path = "../dcap-ql-sys", optional = true }
-"sgxs-loaders" = { version = "0.5.0", path = "../sgxs-loaders", optional = true }
-"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
+dcap-ql-sys = { version = "0.2.0", path = "../dcap-ql-sys", optional = true }
+sgxs-loaders = { version = "0.5.0", path = "../sgxs-loaders", optional = true }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 
 # External dependencies
 byteorder = "1.1.0" # Unlicense/MIT

--- a/intel-sgx/dcap-retrieve-pckid/Cargo.toml
+++ b/intel-sgx/dcap-retrieve-pckid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-retrieve-pckid"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -17,7 +17,7 @@ categories = ["command-line-utilities"]
 aesm-client = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
 dcap-ql = { version = "0.4.0", path = "../dcap-ql", default-features = false }
 report-test = { version = "0.5.1", path = "../report-test" }
-sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
+sgx-isa = { version = "0.5.0", path = "../sgx-isa" }
 sgxs-loaders = { version = "0.5.0", path = "../sgxs-loaders" }
 
 # External dependencies

--- a/intel-sgx/dcap-retrieve-pckid/Cargo.toml
+++ b/intel-sgx/dcap-retrieve-pckid/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["command-line-utilities"]
 aesm-client = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
 dcap-ql = { version = "0.4.0", path = "../dcap-ql", default-features = false }
 report-test = { version = "0.5.1", path = "../report-test" }
-sgx-isa = { version = "0.5.0", path = "../sgx-isa" }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 sgxs-loaders = { version = "0.5.0", path = "../sgxs-loaders" }
 
 # External dependencies

--- a/intel-sgx/enclave-runner-sgx/Cargo.toml
+++ b/intel-sgx/enclave-runner-sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runner-sgx"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -22,7 +22,7 @@ exclude = ["fake-vdso/.gitignore", "fake-vdso/Makefile", "fake-vdso/main.S"]
 # Project dependencies
 sgxs = { version = "0.8.1", path = "../sgxs" }
 fortanix-sgx-abi = { version = "0.7.0", path = "../fortanix-sgx-abi" }
-sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 insecure-time = { version = "0.2", path = "../insecure-time", features = ["estimate_crystal_clock_freq"] }
 ipc-queue = { version = "0.5.0", path = "../../ipc-queue" }
 enclave-runner = { version = "0.8.0", path = "../../enclave-runner" }

--- a/intel-sgx/fortanix-sgx-tools/Cargo.toml
+++ b/intel-sgx/fortanix-sgx-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortanix-sgx-tools"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -25,7 +25,7 @@ sgxs-loaders = { version = "0.5.0", path = "../sgxs-loaders" }
 enclave-runner-sgx = { version = "0.1.0", path = "../enclave-runner-sgx" }
 enclave-runner = { version = "0.8.0", path = "../../enclave-runner" }
 sgxs = { version = "0.8.0", path = "../sgxs" }
-sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 
 # External dependencies
 xmas-elf = "0.10.0"        # Apache-2.0/MIT

--- a/intel-sgx/ias/Cargo.toml
+++ b/intel-sgx/ias/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ias"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -23,8 +23,8 @@ url = "2.2"
 mbedtls = { version = ">=0.12.0, <0.14.0", features = ["std"], default-features = false, optional = true }
 pkix = ">=0.1.0, <0.3.0"
 
-sgx-isa = { version = "0.4", path = "../sgx-isa" }
-sgx_pkix = { version = "0.2", path = "../sgx_pkix" }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
+sgx_pkix = { version = ">=0.2.0, <0.4.0", path = "../sgx_pkix" }
 
 [target.'cfg(not(target_env="sgx"))'.dependencies]
 reqwest = { version = "0.12", features = ["json"], optional = true }

--- a/intel-sgx/pcs/Cargo.toml
+++ b/intel-sgx/pcs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcs"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -21,12 +21,12 @@ categories = ["os", "hardware-support"]
 [dependencies]
 chrono = { version = "0.4.42", features = ["now"] }
 dcap-ql = { version = "0.4.0", path = "../dcap-ql", default-features = false }
-sgx-isa = { version = "0.4.1", path = "../sgx-isa", default-features = true }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa", default-features = true }
 pkix = "0.2.0"
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 rustc-serialize = "0.3"
 serde = { version = "1.0.7", features = ["derive"] }
-sgx_pkix = "0.2"
+sgx_pkix = { version = ">=0.2.0, <0.4.0", path = "../sgx_pkix" }
 serde_json = { version = "1.0", features = ["raw_value"] }
 percent-encoding = "2.3.2"
 base16 = "0.2"

--- a/intel-sgx/pcs/Cargo.toml
+++ b/intel-sgx/pcs/Cargo.toml
@@ -21,7 +21,7 @@ categories = ["os", "hardware-support"]
 [dependencies]
 chrono = { version = "0.4.42", features = ["now"] }
 dcap-ql = { version = "0.4.0", path = "../dcap-ql", default-features = false }
-sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa", default-features = true }
+sgx-isa = { version = ">=0.4.1, <0.6.0", path = "../sgx-isa", default-features = true }
 pkix = "0.2.0"
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 rustc-serialize = "0.3"

--- a/intel-sgx/report-test/Cargo.toml
+++ b/intel-sgx/report-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "report-test"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -19,7 +19,7 @@ categories = ["development-tools"]
 "enclave-runner-sgx" = { version = "0.1.0", path = "../enclave-runner-sgx" }
 "enclave-runner" = { version = "0.8.0", path = "../../enclave-runner" }
 "sgxs" = { version = "0.8.0", path = "../sgxs" }
-"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
+"sgx-isa" = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 
 # External dependencies
 anyhow = "1.0"   # MIT/Apache-2.0

--- a/intel-sgx/sgx-isa/Cargo.toml
+++ b/intel-sgx/sgx-isa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgx-isa"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/sgx_pkix/Cargo.toml
+++ b/intel-sgx/sgx_pkix/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Unfortunately crates.io prevents us from changing the name to `sgx-pkix`
 name = "sgx_pkix"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"
@@ -13,6 +13,6 @@ categories = ["cryptography"]
 [dependencies]
 byteorder = "1.0"
 pkix = ">=0.1.1, <0.3.0"
-sgx-isa = { version = "0.4", path = "../sgx-isa" }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 quick-error = "1.1.0"
 lazy_static = "1"

--- a/intel-sgx/sgxs-loaders/Cargo.toml
+++ b/intel-sgx/sgxs-loaders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-loaders"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -25,8 +25,8 @@ no_sgx_enclave_common = []
 
 [dependencies]
 # Project dependencies
-"sgxs" = { version = "0.8.0", path = "../sgxs" }
-"sgx-isa" = { version = "0.4.0", path = "../sgx-isa" }
+sgxs = { version = "0.8.0", path = "../sgxs" }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 
 # External dependencies
 bitflags = "1"           # MIT/Apache-2.0

--- a/intel-sgx/sgxs-tools/Cargo.toml
+++ b/intel-sgx/sgxs-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-tools"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -28,7 +28,7 @@ path = "src/sgx_detect/main.rs"
 sgxs = { version = "0.8.0", path = "../sgxs", features = ["crypto-openssl"] }
 sgxs-loaders = { version = "0.5.0", path = "../sgxs-loaders" }
 aesm-client = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
-sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 report-test = { version = "0.5.0", path = "../report-test" }
 enclave-runner-sgx = { version = "0.1.0", path = "../enclave-runner-sgx" }
 enclave-runner = { version = "0.8.0", path = "../../enclave-runner" }

--- a/intel-sgx/sgxs/Cargo.toml
+++ b/intel-sgx/sgxs/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["parsing", "encoding"]
 
 [dependencies]
 # Project dependencies
-sgx-isa = { version = "0.5.0", path = "../sgx-isa" }
+sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 
 # External dependencies
 byteorder = "1.0"                                     # Unlicense/MIT

--- a/intel-sgx/sgxs/Cargo.toml
+++ b/intel-sgx/sgxs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -14,7 +14,7 @@ categories = ["parsing", "encoding"]
 
 [dependencies]
 # Project dependencies
-sgx-isa = { version = "0.4.0", path = "../sgx-isa" }
+sgx-isa = { version = "0.5.0", path = "../sgx-isa" }
 
 # External dependencies
 byteorder = "1.0"                                     # Unlicense/MIT

--- a/intel-sgx/tdx-ql/Cargo.toml
+++ b/intel-sgx/tdx-ql/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["sgx", "tdx", "dcap", "quote"]
 categories = ["api-bindings"]
 
 [dependencies]
-sgx-isa = { path = "../../intel-sgx/sgx-isa" }
+sgx-isa = { version = "0.5.0", path = "../../intel-sgx/sgx-isa" }
 nix = { version = "0.30", features = ["ioctl"] }
 
 [dev-dependencies]

--- a/intel-sgx/tdx-ql/README.md
+++ b/intel-sgx/tdx-ql/README.md
@@ -1,4 +1,16 @@
-# tdx-isa
+# tdx-ql
 
-Rust wrapper crate for TDX attestation functions. It using `ioctl` to
-communicate with device `/dev/tdx_guest`.
+Rust wrapper crate for Intel TDX guest attestation IOCTLs. It talks to the
+Linux TDX guest driver via `/dev/tdx-guest` to request TDREPORT data and
+related attestation inputs that are later used to generate a quote.
+
+## References
+
+- Intel Trust Domain Extensions (TDX) documentation:
+  <https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/documentation.html>
+- Linux TDX guest driver ABI (`/dev/tdx-guest`) documentation:
+  <https://docs.kernel.org/virt/coco/tdx-guest.html>
+- Linux TDX guest driver source (`drivers/virt/coco/tdx-guest/`):
+  <https://github.com/torvalds/linux/blob/master/drivers/virt/coco/tdx-guest/>
+- Linux TDX architecture and attestation background:
+  <https://www.kernel.org/doc/html/latest/arch/x86/tdx.html>


### PR DESCRIPTION
- Breaking changes in `sgx-isa` as it introduces new Intel TDX ISA in the crate.
- Breaking changes in `sgx_pkix` for renaming one of the OID to be more specific.
- Updating all dependency requirement to be more relaxed instead of using default requirements.
- Bumping crates that has dependency updates
    - em-app 0.5.1 -> 0.5.2
    - aesm-client 0.6.1 -> 0.6.2
    - dcap-ql-sys 0.2.1 -> 0.2.2
    - dcap-ql 0.4.1 -> 0.4.2
    - dcap-retrieve-pckid 0.3.2 -> 0.3.3
    - pcs 0.8.1 -> 0.8.2
    - report-test 0.5.1 -> 0.5.2
    - sgx-isa 0.4.1 -> 0.5.0
    - sgx_pkix 0.2.2 -> 0.3.0
    - sgxs-loaders 0.5.0 -> 0.5.1
    - enclave-runner-sgx 0.1.0 -> 0.1.1
    - fortanix-sgx-tools 0.6.2 -> 0.6.3
    - sgxs 0.8.1 -> 0.8.2