### PR TITLE
Improve insecure-time frequency estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,6 +2628,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
+ "spin",
 ]
 
 [[package]]
@@ -4640,6 +4641,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runner-sgx"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "insecure-time"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap 4.4.18",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,6 +1064,15 @@ name = "confidential-vm-blobs"
 version = "0.1.0"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1182,33 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio 1.2.0",
+ "parking_lot",
+ "rustix 1.1.3",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1352,6 +1388,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2 1.0.95",
+ "quote 1.0.41",
+ "rustc_version",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1480,15 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.41",
  "syn 2.0.115",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2625,6 +2692,7 @@ name = "insecure-time"
 version = "0.3.0"
 dependencies = [
  "clap 4.4.18",
+ "crossterm",
  "rand 0.8.5",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
@@ -2733,9 +2801,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2790,6 +2858,12 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -2977,6 +3051,18 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "log 0.4.28",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4597,12 +4683,23 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.10"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.2.0",
+ "signal-hook",
 ]
 
 [[package]]
@@ -4971,7 +5068,7 @@ dependencies = [
  "backtrace",
  "bytes 1.7.1",
  "libc",
- "mio",
+ "mio 0.8.11",
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
@@ -5208,6 +5305,12 @@ checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -5584,6 +5687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/intel-sgx/enclave-runner-sgx/Cargo.toml
+++ b/intel-sgx/enclave-runner-sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runner-sgx"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -23,7 +23,7 @@ exclude = ["fake-vdso/.gitignore", "fake-vdso/Makefile", "fake-vdso/main.S"]
 sgxs = { version = "0.8.1", path = "../sgxs" }
 fortanix-sgx-abi = { version = "0.7.0", path = "../fortanix-sgx-abi" }
 sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
-insecure-time = { version = "0.2", path = "../insecure-time", features = ["estimate_crystal_clock_freq"] }
+insecure-time = { version = "0.3", path = "../insecure-time", features = ["estimate_crystal_clock_freq"] }
 ipc-queue = { version = "0.5.0", path = "../../ipc-queue" }
 enclave-runner = { version = "0.8.0", path = "../../enclave-runner" }
 

--- a/intel-sgx/insecure-time/Cargo.toml
+++ b/intel-sgx/insecure-time/Cargo.toml
@@ -23,6 +23,7 @@ spin = { version = "0.10", default-features = false, features = ["rwlock", "mute
 [dev-dependencies]
 rand = "0.8"
 clap = { version = "4.4", features = ["derive"] }
+crossterm = "0.29"
 
 [features]
 default = ["std"]

--- a/intel-sgx/insecure-time/Cargo.toml
+++ b/intel-sgx/insecure-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insecure-time"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2021"

--- a/intel-sgx/insecure-time/Cargo.toml
+++ b/intel-sgx/insecure-time/Cargo.toml
@@ -18,6 +18,7 @@ name = "insecure-time"
 [dependencies]
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
+spin = { version = "0.10", default-features = false, features = ["rwlock", "mutex", "spin_mutex"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/intel-sgx/insecure-time/examples/insecure-time.rs
+++ b/intel-sgx/insecure-time/examples/insecure-time.rs
@@ -45,7 +45,7 @@ fn estimate_frequency() {
         let t1 = (SystemTime::now(), Ticks::now());
         let test_duration = diff_system_time(t0.0, t1.0);
 
-        println!("{:?}: Estimated frequency = {:?}, reported frequency = {:?}", test_duration, Freq::estimate(t1.1.abs_diff(&t0.1), test_duration), &reported_freq);
+        println!("{:?}: Estimated frequency = {:?}, reported frequency = {:?}", test_duration, Freq::estimate(t1.1.abs_diff(t0.1), test_duration), &reported_freq);
         std::thread::sleep(Duration::from_secs(10));
     }
 }

--- a/intel-sgx/insecure-time/examples/insecure-time.rs
+++ b/intel-sgx/insecure-time/examples/insecure-time.rs
@@ -1,6 +1,10 @@
-use {
-    insecure_time::{FixedFreqTscBuilder, Ticks, Tsc, TscBuilder, Freq},
-    std::time::{Duration, SystemTime},
+use insecure_time::{FixedFreqTscBuilder, Freq, NativeTime, Ticks, Tsc, TscBuilder};
+use rand::{distributions::Uniform, prelude::Distribution, thread_rng};
+use std::{
+    ops::Add,
+    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+    time::{Duration, Instant, SystemTime},
+    u64,
 };
 use clap::Parser;
 
@@ -13,6 +17,20 @@ fn diff_system_time(t0: SystemTime, t1: SystemTime) -> Duration {
 enum Cli {
     TestFixedFreqDrift,
     EstimateFreq,
+    LearningFreqTsc {
+        /// frequency sync period (`max_sync_interval`) in milliseconds
+        #[arg(long, default_value_t = 5000)]
+        sync_ms: u64,
+        /// simulate slow calls to system time by wating randomly up to this much in microseconds
+        #[arg(long, default_value_t = 0)]
+        system_time_slowness_micros: u64,
+        /// Max acceptable drift passed to LearningFreqTscBuilder
+        #[arg(long, default_value_t = 1000)]
+        max_acceptable_drift_micros: u64,
+        /// `frequency_learning_period` passed to LearningFreqTscBuilder
+        #[arg(long, default_value_t = 5000)]
+        freq_learn_ms: u64,
+    },
 }
 
 fn test_fixed_frequency_drift() {
@@ -50,11 +68,107 @@ fn estimate_frequency() {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+struct SystemTimeSource(Duration);
+
+impl Add<Duration> for SystemTimeSource {
+    type Output = Self;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
+
+static SYSTEM_TIME_NOW_CALLS: AtomicUsize = AtomicUsize::new(0);
+static SYSTEM_TIME_SLOWNESS_MICROS: AtomicU64 = AtomicU64::new(0);
+impl NativeTime for SystemTimeSource {
+    fn minimum() -> Self {
+        todo!()
+    }
+
+    fn abs_diff(&self, other: &Self) -> Duration {
+        self.0.abs_diff(other.0)
+    }
+
+    fn now() -> Self {
+        SYSTEM_TIME_NOW_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let slowness_micros = SYSTEM_TIME_SLOWNESS_MICROS.load(Ordering::Relaxed);
+        let res = Self(
+            SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap(),
+        );
+        if slowness_micros > 0 {
+            let delay = Duration::from_micros(Uniform::new_inclusive(0, slowness_micros).sample(&mut thread_rng()));
+            let now = Instant::now();
+            while now.elapsed() < delay {}
+        }
+        res
+    }
+}
+
+fn learning_freq_tsc(sync_interval_millis: u64, max_acceptable_drift_micros: u64, frequency_learning_period_millis: u64) {
+    let tsc = insecure_time::LearningFreqTscBuilder::<SystemTimeSource>::new()
+        .set_frequency_learning_period(Duration::from_millis(frequency_learning_period_millis))
+        .set_max_acceptable_drift(Duration::from_micros(max_acceptable_drift_micros))
+        .set_max_sync_interval(Duration::from_millis(sync_interval_millis))
+        .set_monotonic_time()
+        .build();
+
+    let mut max_drift_nanos = 0i128;
+    let (mut min_freq_estimate, mut max_freq_estimate) = (None, None);
+    let mut last_freq_estimate = None;
+    let mut last_print = Duration::ZERO;
+    let mut sum_drift_sq = 0i128;
+    for i in 0usize.. {
+        let system_time_now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap();
+        let tsc_now = tsc.now();
+
+        let drift = tsc_now.0.as_nanos() as i128 - system_time_now.as_nanos() as i128;
+
+        sum_drift_sq += drift * drift;
+        if max_drift_nanos.abs() < drift.abs() {
+            max_drift_nanos = drift;
+        }
+
+        if system_time_now - last_print >= Duration::from_millis(1000) {
+            let dirft_rms = ((sum_drift_sq / (i as i128 + 1)) as f64).sqrt();
+            println!("iter {i} - tsc drift: max: {:.2}μs, rms: {:.2}μs, current: {:.2}μs",
+                max_drift_nanos as f64 / 1000.0,
+                dirft_rms as f64 / 1000.0,
+                drift as f64 / 1000.0
+            );
+            let freq_estimate = tsc.frequency_estimate().map(|f| f.as_u64());
+            min_freq_estimate = freq_estimate.map(|f| f.min(min_freq_estimate.unwrap_or(u64::MAX)));
+            max_freq_estimate = freq_estimate.map(|f| f.max(max_freq_estimate.unwrap_or(0)));
+
+            let freq_change_permill = (freq_estimate.unwrap_or(0) as f64 - last_freq_estimate.unwrap_or(0) as f64) / last_freq_estimate.unwrap_or(0) as f64 * 1000_000.0;
+            last_freq_estimate = freq_estimate;
+
+            println!("freq estimate: {:?} (change: {:.3} PPM), min: {:?}, max: {:?}, spread: {}Hz",
+                freq_estimate, freq_change_permill,
+                min_freq_estimate, max_freq_estimate, max_freq_estimate.unwrap_or(0).saturating_sub(min_freq_estimate.unwrap_or(u64::MAX))
+            );
+            println!("System time reads: {}, tsc resyncs: {}", SYSTEM_TIME_NOW_CALLS.load(Ordering::Relaxed), tsc.resyncs());
+            println!("---");
+            last_print = system_time_now;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+
 fn main() {
     let cli = Cli::parse();
 
     match cli {
         Cli::TestFixedFreqDrift => test_fixed_frequency_drift(),
         Cli::EstimateFreq => estimate_frequency(),
+        Cli::LearningFreqTsc { sync_ms, system_time_slowness_micros, max_acceptable_drift_micros, freq_learn_ms } => {
+            SYSTEM_TIME_SLOWNESS_MICROS.store(system_time_slowness_micros, Ordering::Relaxed);
+            learning_freq_tsc(sync_ms, max_acceptable_drift_micros, freq_learn_ms)
+        },
     }
 }

--- a/intel-sgx/insecure-time/examples/insecure-time.rs
+++ b/intel-sgx/insecure-time/examples/insecure-time.rs
@@ -1,3 +1,4 @@
+use crossterm::event::KeyCode;
 use insecure_time::{FixedFreqTscBuilder, Freq, NativeTime, Ticks, Tsc, TscBuilder};
 use rand::{distributions::Uniform, prelude::Distribution, thread_rng};
 use std::{
@@ -93,13 +94,17 @@ impl NativeTime for SystemTimeSource {
     fn now() -> Self {
         SYSTEM_TIME_NOW_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let slowness_micros = SYSTEM_TIME_SLOWNESS_MICROS.load(Ordering::Relaxed);
+        let delay = if slowness_micros > 0 {
+            Duration::from_micros(Uniform::new_inclusive(0, slowness_micros).sample(&mut thread_rng()))
+        } else {
+            Duration::ZERO
+        };
         let res = Self(
             SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap(),
         );
         if slowness_micros > 0 {
-            let delay = Duration::from_micros(Uniform::new_inclusive(0, slowness_micros).sample(&mut thread_rng()));
             let now = Instant::now();
             while now.elapsed() < delay {}
         }
@@ -108,6 +113,7 @@ impl NativeTime for SystemTimeSource {
 }
 
 fn learning_freq_tsc(sync_interval_millis: u64, max_acceptable_drift_micros: u64, frequency_learning_period_millis: u64) {
+    println!("nominal TSC frequency: {:?}", insecure_time::Freq::get());
     let tsc = insecure_time::LearningFreqTscBuilder::<SystemTimeSource>::new()
         .set_frequency_learning_period(Duration::from_millis(frequency_learning_period_millis))
         .set_max_acceptable_drift(Duration::from_micros(max_acceptable_drift_micros))
@@ -120,6 +126,7 @@ fn learning_freq_tsc(sync_interval_millis: u64, max_acceptable_drift_micros: u64
     let mut last_freq_estimate = None;
     let mut last_print = Duration::ZERO;
     let mut sum_drift_sq = 0i128;
+    let mut count_drift = 0;
     for i in 0usize.. {
         let system_time_now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -129,12 +136,13 @@ fn learning_freq_tsc(sync_interval_millis: u64, max_acceptable_drift_micros: u64
         let drift = tsc_now.0.as_nanos() as i128 - system_time_now.as_nanos() as i128;
 
         sum_drift_sq += drift * drift;
+        count_drift += 1;
         if max_drift_nanos.abs() < drift.abs() {
             max_drift_nanos = drift;
         }
 
         if system_time_now - last_print >= Duration::from_millis(1000) {
-            let dirft_rms = ((sum_drift_sq / (i as i128 + 1)) as f64).sqrt();
+            let dirft_rms = ((sum_drift_sq / count_drift) as f64).sqrt();
             println!("iter {i} - tsc drift: max: {:.2}μs, rms: {:.2}μs, current: {:.2}μs",
                 max_drift_nanos as f64 / 1000.0,
                 dirft_rms as f64 / 1000.0,
@@ -153,9 +161,22 @@ fn learning_freq_tsc(sync_interval_millis: u64, max_acceptable_drift_micros: u64
             );
             println!("System time reads: {}, tsc resyncs: {}", SYSTEM_TIME_NOW_CALLS.load(Ordering::Relaxed), tsc.resyncs());
             println!("---");
+
+            if crossterm::event::poll(Duration::ZERO).is_ok_and(|x| x) {
+                let event = crossterm::event::read().unwrap();
+                if let Some(key_event) = event.as_key_event().filter(|_| event.is_key_press()) {
+                    if key_event.code == KeyCode::Char('r') {
+                        println!(">>> Resetting drift RMS!");
+                        sum_drift_sq = 0;
+                        count_drift = 0;
+                    }
+                }
+            }
+
+
             last_print = system_time_now;
         }
-        std::thread::sleep(Duration::from_millis(100));
+        std::thread::sleep(Duration::from_millis(10));
     }
 }
 

--- a/intel-sgx/insecure-time/src/lib.rs
+++ b/intel-sgx/insecure-time/src/lib.rs
@@ -4,7 +4,6 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "std")]
 extern crate alloc;
 
 use alloc::borrow::ToOwned;
@@ -18,12 +17,10 @@ use std::fs;
 #[cfg(not(target_env = "sgx"))]
 use core::arch::x86_64::__cpuid;
 use core::arch::x86_64::__rdtscp;
-use core::cell::RefCell;
-use core::cmp::{self, PartialEq, PartialOrd};
+use core::cmp::{PartialEq, PartialOrd};
 use core::fmt::{self, Debug, Display, Formatter};
-use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use core::time::Duration;
-use core::ops::Add;
+use core::ops::{Add, RangeInclusive};
 
 const NANOS_PER_SEC: u64 = 1_000_000_000;
 
@@ -44,7 +41,7 @@ impl NativeTime for SystemTime {
         // includes the duration between the two `SystemTime`s
         match self.duration_since(*earlier) {
             Ok(duration) => duration,
-            Err(e) => e.duration()
+            Err(e) => e.duration(),
         }
     }
 
@@ -66,7 +63,7 @@ pub enum Error {
 
 #[cfg(not(target_env = "sgx"))]
 fn cpuid(leaf: u32, eax: &mut u32, ebx: &mut u32, ecx: &mut u32, edx: &mut u32) {
-    unsafe { 
+    unsafe {
         let res = __cpuid(leaf);
         *eax = res.eax;
         *ebx = res.ebx;
@@ -75,50 +72,34 @@ fn cpuid(leaf: u32, eax: &mut u32, ebx: &mut u32, ecx: &mut u32, edx: &mut u32) 
     }
 }
 
-#[derive(Debug, Default)]
-pub struct Ticks(AtomicU64);
-
-impl PartialEq<Ticks> for Ticks {
-    fn eq(&self, other: &Ticks) -> bool {
-        let t = self.0.load(Ordering::Relaxed);
-        let o = other.0.load(Ordering::Relaxed);
-        t.eq(&o)
-    }
-}
-
-impl PartialOrd<Ticks> for Ticks {
-    fn partial_cmp(&self, other: &Ticks) -> Option<cmp::Ordering> {
-        let t = self.0.load(Ordering::Relaxed);
-        let o = other.0.load(Ordering::Relaxed);
-        t.partial_cmp(&o)
-    }
-}
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub struct Ticks(u64);
 
 impl Add for Ticks {
     type Output = Result<Ticks, Error>;
 
+    #[inline]
     fn add(self, other: Self) -> Self::Output {
-        let t0 = self.0.load(Ordering::Relaxed);
-        let t1 = other.0.load(Ordering::Relaxed);
-        t0.checked_add(t1)
+        self.0.checked_add(other.0)
             .ok_or(Error::TypeOverflow)
-            .map(|sum| Ticks(AtomicU64::new(sum)))
+            .map(Ticks)
     }
 }
 
 impl Display for Ticks {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{} ticks", self.0.load(Ordering::Relaxed))
+        write!(f, "{} ticks", self.0)
     }
 }
 
 impl Ticks {
+    #[inline]
     pub fn new(t: u64) -> Self {
-        Ticks(AtomicU64::new(t))
+        Ticks(t)
     }
 
     pub const fn max() -> Self {
-        Ticks(AtomicU64::new(u64::MAX))
+        Ticks(u64::MAX)
     }
 
     pub fn now() -> Self {
@@ -132,26 +113,14 @@ impl Ticks {
         //
         // However, note that an attacker may arbitarily set this value on the
         // host/hypervisor
-        Ticks(Rdtscp::read().into())
+        Ticks(Rdtscp::read())
     }
 
-    pub fn abs_diff(&self, t1: &Ticks) -> Ticks {
-        let t0 = self.0.load(Ordering::Relaxed);
-        let t1 = t1.0.load(Ordering::Relaxed);
-
-        if t1 > t0 {
-            Ticks::new(t1 - t0)
-        } else {
-            Ticks::new(t0 - t1)
-        }
+    pub fn abs_diff(&self, t1: Ticks) -> Ticks {
+        Ticks::new(self.0.abs_diff(t1.0))
     }
 
-    fn set(&self, t: Ticks) {
-        let t = t.0.load(Ordering::Relaxed);
-        self.0.store(t, Ordering::Relaxed);
-    }
-
-    pub fn from_duration(duration: Duration, freq: &Freq) -> Result<Self, Error> {
+    pub fn from_duration(duration: Duration, freq: Freq) -> Result<Self, Error> {
         let freq = freq.as_u64();
         let ticks_secs = duration.as_secs().checked_mul(freq).ok_or(Error::TypeOverflow)?;
         let ticks_nsecs = (duration.subsec_nanos() as u64)
@@ -159,9 +128,9 @@ impl Ticks {
         Ok(Ticks::new(ticks_secs + ticks_nsecs))
     }
 
-    pub fn as_duration_ex(&self, freq: &Freq) -> Duration {
+    pub fn as_duration_ex(&self, freq: Freq) -> Duration {
         let freq = freq.as_u64();
-        let ticks = self.0.load(Ordering::Relaxed);
+        let ticks = self.0;
 
         let time_secs = ticks / freq;
         let time_nsecs = (ticks % freq * NANOS_PER_SEC) / freq;
@@ -170,9 +139,10 @@ impl Ticks {
         Duration::new(time_secs, time_nsecs)
     }
 
-    pub fn elapsed(&self, freq: &Freq) -> Duration {
+    /// estimate elapsed time since TSC had `self`-many ticks
+    pub fn elapsed(&self, freq: Freq) -> Duration {
         let tsc_now = Ticks::now();
-        self.abs_diff(&tsc_now).as_duration_ex(&freq)
+        self.abs_diff(tsc_now).as_duration_ex(freq)
     }
 }
 
@@ -199,43 +169,8 @@ impl Rdtscp {
 }
 
 /// Frequency in ticks per second
-pub struct Freq(AtomicU64);
-
-impl PartialEq<Freq> for Freq {
-    fn eq(&self, other: &Freq) -> bool {
-        let f = self.0.load(Ordering::Relaxed);
-        let o = other.0.load(Ordering::Relaxed);
-        f.eq(&o)
-    }
-}
-
-impl PartialOrd<Freq> for Freq {
-    fn partial_cmp(&self, other: &Freq) -> Option<cmp::Ordering> {
-        let f = self.0.load(Ordering::Relaxed);
-        let o = other.0.load(Ordering::Relaxed);
-        f.partial_cmp(&o)
-    }
-}
-
-impl Debug for Freq {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        let freq = self.as_u64();
-        f.debug_struct("Freq")
-         .field("freq", &freq)
-         .finish()
-    }
-}
-
-impl Freq {
-    fn is_zero(&self) -> bool {
-        self.0.load(Ordering::Relaxed) == 0
-    }
-
-    fn set(&self, f: &Freq) {
-        let f = f.0.load(Ordering::Relaxed);
-        self.0.store(f, Ordering::Relaxed);
-    }
-}
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct Freq(u64);
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum ClockSource {
@@ -244,23 +179,25 @@ pub enum ClockSource {
 
 impl Freq {
     pub fn new(crystal_hz: u32, numerator: u32, denominator: u32) -> Self {
-        Freq::from_u64(crystal_hz as u64 * numerator as u64 / denominator as u64)
+        Freq(crystal_hz as u64 * numerator as u64 / denominator as u64)
     }
 
+    #[inline(always)]
     pub fn from_u64(freq: u64) -> Freq {
         assert!(freq != 0);
-        Freq(freq.into())
+        Freq(freq)
     }
 
+    #[inline(always)]
     pub fn as_u64(&self) -> u64 {
-        self.0.load(Ordering::Relaxed)
+        self.0
     }
 
     pub fn estimate(ticks: Ticks, secs: Duration) -> Freq {
         let nsecs = secs.as_secs() as u128 * NANOS_PER_SEC as u128 + secs.subsec_nanos() as u128;
-        let estimate = ticks.0.load(Ordering::Relaxed) as u128 * NANOS_PER_SEC as u128 / nsecs;
+        let estimate = ticks.0 as u128 * NANOS_PER_SEC as u128 / nsecs;
 
-        Freq(AtomicU64::from(estimate as u64))
+        Freq(estimate as u64)
     }
 
     #[cfg(not(target_env = "sgx"))]
@@ -340,74 +277,48 @@ enum TscMode {
         max_acceptable_drift: Duration,
         // The maximum interval between re-syncing with the external clock source
         max_sync_interval: Duration,
-        // The next time we should contact the external clock source and re-sync
-        next_sync: Ticks,
-        // Learned frequency
-        frequency: Freq,
+        initial_frequency: Option<Freq>,
     },
     NoRdtsc,
 }
 
 enum TimeMode<T: NativeTime> {
     Monotonic {
-        last_time: RefCell<Option<T>>,
-        mutex: AtomicBool,
+        last_time: spin::Mutex<Option<T>>
     },
     NonMonotonic,
 }
 
-// RefCell isn't Sync, but we took care of that using the explicity mutex
-unsafe impl<T: NativeTime> Sync for TimeMode<T> {}
-
 impl<T: NativeTime> TimeMode<T> {
-    pub fn monotonic() -> Self {
+    fn monotonic() -> Self {
         TimeMode::Monotonic {
-            last_time: RefCell::new(None),
-            mutex: AtomicBool::new(false),
+            last_time: spin::Mutex::new(None)
         }
     }
 
-    pub fn non_monotonic() -> Self {
+    fn non_monotonic() -> Self {
         TimeMode::NonMonotonic
     }
 
-    pub fn observe(&self, now: T) -> T {
-        fn lock<T: NativeTime>(mode: &TimeMode<T>) -> Option<&RefCell<Option<T>>> {
-            if let TimeMode::Monotonic { mutex, last_time } = mode {
-                while mutex.compare_exchange(false, true, Ordering::Acquire, Ordering::Acquire).is_err()
-                {}
-                Some(&last_time)
-            } else {
-                None
-            }
-        }
-
-        fn unlock<T: NativeTime>(mode: &TimeMode<T>) {
-            if let TimeMode::Monotonic { mutex, .. } = mode {
-                mutex.store(false, Ordering::Release);
-            }
-        }
-
-        if let Some(last_time) = lock(self) {
-            let mut last_time = last_time.borrow_mut();
-            let now = match last_time.to_owned() {
-                Some(last) if last < now => {
-                    *last_time = Some(now);
-                    now
-                },
-                Some(last) => {
-                    last
-                },
-                None => {
-                    *last_time = Some(now);
-                    now
-                }        
-            };
-            drop(last_time);
-            unlock(self);
-            now
-        } else {
-            now
+    fn observe(&self, now: T) -> T {
+        match self {
+            TimeMode::Monotonic { last_time } => {
+                let mut last_time = last_time.lock();
+                match last_time.to_owned() {
+                    Some(last) if last < now => {
+                        *last_time = Some(now);
+                        now
+                    },
+                    Some(last) => {
+                        last
+                    },
+                    None => {
+                        *last_time = Some(now);
+                        now
+                    }
+                }
+            },
+            TimeMode::NonMonotonic => now,
         }
     }
 }
@@ -423,6 +334,21 @@ pub struct Tsc<T: NativeTime> {
     tsc_mode: TscMode,
     // Time is forced to be monotonic, or not
     time_mode: TimeMode<T>,
+    tsc_state: spin::RwLock<TscState<T>>,
+}
+
+#[derive(Copy, Clone)]
+struct TscState<T> {
+    /// the most recent reading of the external clock that is paird with a TSC reading (`recent_ticks`)
+    recent_native_time: T,
+    /// the most recent reading of the TSC that is paired with a reading of the external clock (`recent_native_time`)
+    recent_ticks: Ticks,
+    /// The next time we should contact the external clock source and re-sync
+    next_sync: Ticks,
+    /// Learned frequency
+    frequency: Freq,
+    /// number of times we estimated the frequency
+    freq_estimations: usize,
 }
 
 pub trait TscBuilder<T: NativeTime> {
@@ -523,22 +449,11 @@ impl<T: NativeTime> TscBuilder<T> for LearningFreqTscBuilder<T> {
 
     fn build(self) -> Tsc<T> {
         let LearningFreqTscBuilder { frequency, max_sync_interval, max_acceptable_drift, frequency_learning_period, time_mode, } = self;
-        // When the initial frequency is set in the builder, we assume we don't need to resync for
-        // `max_sync_interval` duration
-        let (next_sync, frequency, frequency_learning_period) =
-            if let Some((Ok(next_sync), frequency)) = frequency.map(|f| (Ticks::from_duration(max_sync_interval, &f), f)) {
-                // We won't resync until `max_sync_interval`, use the full period to learn the exact
-                // frequency
-                (next_sync, frequency, frequency_learning_period.max(max_sync_interval))
-            } else {
-                (Ticks::new(0), Freq(AtomicU64::from(0)), frequency_learning_period)
-            };
         let tsc_mode = TscMode::Learn {
             max_sync_interval,
             max_acceptable_drift,
-            frequency_learning_period,
-            next_sync,
-            frequency,
+            frequency_learning_period: frequency_learning_period.max(max_sync_interval),
+            initial_frequency: frequency
         };
         Tsc::new(tsc_mode, time_mode)
     }
@@ -573,105 +488,181 @@ impl<T: NativeTime> FixedFreqTscBuilder<T> {
     }
 }
 
+#[derive(Debug)]
 enum ResyncError<T> {
-    WithinFrequencyLearningPeriod(T)
+    UnreliableTscReading(T),
+    UnreliableFreqEstimation(T, Ticks),
 }
 
 impl<T: NativeTime> Tsc<T> {
     fn new(tsc_mode: TscMode, time_mode: TimeMode<T>) -> Self {
         let now = T::now();
         let t0 = if let TscMode::NoRdtsc = tsc_mode { Ticks::default() } else { Ticks::now() };
+
+        let (frequency, max_sync_interval) = match &tsc_mode {
+            TscMode::Fixed { frequency } => (Some(*frequency), Duration::MAX),
+            TscMode::Learn { initial_frequency, max_sync_interval, .. } => (*initial_frequency, *max_sync_interval),
+            TscMode::NoRdtsc => (None, Duration::MAX),
+        };
+        let (next_sync, frequency) =
+            if let Some((Ok(next_sync), frequency)) = frequency.map(|f| (Ticks::from_duration(max_sync_interval, f), f)) {
+                // We won't resync until `max_sync_interval`, use the full period to learn the exact
+                // frequency
+                (next_sync, frequency)
+            } else {
+                (Ticks::new(0), Freq(0))
+            };
         Tsc {
             t0: (t0, now),
             tsc_mode,
             time_mode,
+            tsc_state: spin::RwLock::new(TscState {
+                recent_ticks: t0,
+                recent_native_time: now,
+                next_sync,
+                frequency,
+                freq_estimations: 0,
+            })
         }
     }
 
-    fn resync_clocks(&self, current_freq: &Freq, frequency_learning_period: &Duration, max_acceptable_drift: &Duration, max_sync_interval: &Duration) -> Result<(T, Duration, Freq), ResyncError<T>> {
-        // Fetch actual time
-        let system_now = T::now();
-
-        // Calculate new freq
-        let diff_system = system_now.abs_diff(&self.t0.1);
-        if diff_system < *frequency_learning_period {
-            return Err(ResyncError::WithinFrequencyLearningPeriod(system_now));
-        }
-        let tsc_now = Ticks::now();
-        let estimated_freq = Freq::estimate(self.t0.0.abs_diff(&tsc_now), diff_system);
-
-        // Calculate error
-        let now = self.now_ex(current_freq);
-        let error = system_now.abs_diff(&now);
-
-        // Calculate the maximum interval we need to re-sync
-        let max_sync_interval = if error.is_zero() {
-            // We have a very good clock, don't postpone re-sync inevitably (and don't div by zero)
-            max_sync_interval.to_owned()
-        } else {
-            // Common case, estimate interval based on error and max acceptable error
-            diff_system * max_acceptable_drift.div_duration_f64(error) as u32
+    const ACCEPTABLE_FREQ_RANGE: RangeInclusive<u64> = 50_000_000..=100_000_000_000;
+    fn resync_clocks(max_acceptable_drift: Duration, max_sync_interval: Duration, state: &TscState<T>) -> Result<(T, Ticks, Duration, Freq), ResyncError<T>> {
+        let (system_now, tsc_now) = match Self::get_system_now_and_tsc(Some(state.frequency)) {
+            Ok(st) => st,
+            Err(system_now) => return Err(ResyncError::UnreliableTscReading(system_now)),
         };
 
-        Ok((system_now, max_sync_interval, estimated_freq))
+        // Calculate new freq
+        let diff_system = system_now.abs_diff(&state.recent_native_time);
+        let estimated_freq = Freq::estimate(state.recent_ticks.abs_diff(tsc_now), diff_system);
+
+        if tsc_now.0 < state.recent_ticks.0
+            || (state.freq_estimations > 5 && estimated_freq.as_u64().abs_diff(state.frequency.as_u64()) > state.frequency.as_u64() / 8)
+            || !Self::ACCEPTABLE_FREQ_RANGE.contains(&estimated_freq.as_u64())
+        {
+            return Err(ResyncError::UnreliableFreqEstimation(system_now, tsc_now));
+        }
+        // Calculate error
+        let now = state.recent_native_time + state.recent_ticks.abs_diff(tsc_now).as_duration_ex(state.frequency);
+        let error = system_now.abs_diff(&now);
+
+        // `.min(5.0)` means next sync interval will be at most 5 times the current sync interval.
+        // It also avoids overflow panics.
+        let next_sync_interval = diff_system.mul_f64(max_acceptable_drift.div_duration_f64(error).min(5.0));
+        let next_sync_interval = next_sync_interval.min(max_sync_interval);
+        Ok((system_now, tsc_now, next_sync_interval, estimated_freq))
     }
 
-    fn now_ex(&self, freq: &Freq) -> T {
-        self.t0.1 + self.t0.0.elapsed(freq)
+    /// Gets current system time and tsc. Returns an error if it observes too much
+    /// delay between the two measurements.
+    fn get_system_now_and_tsc(current_freq_estimation: Option<Freq>) -> Result<(T, Ticks), T> {
+        const ACCEPTABLE_LAG: Duration = Duration::from_millis(250);
+        let tsc_before = current_freq_estimation.is_some().then(Ticks::now);
+        // Calling rdtsc _after_ issuing a insecure_time usercall so frequency
+        // will be _over_ estimated rather than under estimated when system is
+        // under heavy load. An under estimated frequency is easier to fix
+        // afterwards when time needs to be monotonic.
+        let system_now = T::now();
+        let tsc_after = Ticks::now();
+        if let (Some(current_freq_estimation), Some(tsc_before)) = (current_freq_estimation, tsc_before) {
+            if tsc_after.abs_diff(tsc_before).as_duration_ex(current_freq_estimation) > ACCEPTABLE_LAG {
+                Err(system_now)
+            } else {
+                Ok((system_now, tsc_after))
+            }
+        } else {
+            Ok((system_now, tsc_after))
+        }
     }
 
-    pub fn now(&self) -> T {
-        let now = match &self.tsc_mode {
+    fn now_internal(&self) -> T {
+        match &self.tsc_mode {
             TscMode::NoRdtsc => T::now(),
-            TscMode::Learn { frequency_learning_period, max_acceptable_drift, max_sync_interval, next_sync, frequency } => {
-                let (tsc_now, f) = if !frequency.is_zero() {
-                    (Ticks::now(), Freq(frequency.as_u64().into()))
+            TscMode::Learn { frequency_learning_period, max_acceptable_drift, max_sync_interval, initial_frequency: _ } => {
+                let state = *self.tsc_state.read();
+                let (tsc_now, state) = if state.frequency.as_u64() != 0 {
+                    (Ticks::now(), state)
                 } else {
-                    // Calling rdtsc _after_ issuing a insecure_time usercall so frequency
-                    // will be _over_ estimated rather than under estimated when system is
-                    // under heavy load. An under estimated frequency is easier to fix
-                    // afterwards when time needs to be monotonic.
-                    let system_now = T::now();
-                    let tsc_now = Ticks::now();
-                    let diff_system = system_now.abs_diff(&self.t0.1);
-                    if diff_system < *frequency_learning_period {
+                    let (system_now, tsc_now) = match Self::get_system_now_and_tsc(None) {
+                        Ok(st) => st,
+                        Err(system_now) => return system_now,
+                    };
+                    let diff_system = system_now.abs_diff(&state.recent_native_time);
+                    if system_now.abs_diff(&self.t0.1) < *frequency_learning_period {
                         // We don't have enough data to estimate frequency correctly
                         return system_now;
                     }
 
-                    let estimated_freq = Freq::estimate(self.t0.0.abs_diff(&tsc_now), diff_system);
-                    frequency.set(&estimated_freq);
-                    (tsc_now, estimated_freq)
+                    let estimated_freq = Freq::estimate(state.recent_ticks.abs_diff(tsc_now), diff_system);
+                    let mut state = self.tsc_state.upgradeable_read().upgrade();
+                    state.frequency = estimated_freq;
+                    (tsc_now, *state)
                 };
 
-                let now = self.now_ex(&f);
-
-                if tsc_now < *next_sync {
-                    now
+                if tsc_now < state.next_sync {
+                    state.recent_native_time + state.recent_ticks.elapsed(state.frequency)
                 } else {
                     // Re-estimate freq when a time threshold is reached
-                    match self.resync_clocks(&f, &frequency_learning_period, &max_acceptable_drift, &max_sync_interval) {
-                        Ok((now, next_sync_interval, estimated_freq)) => {
+                    match Self::resync_clocks(*max_acceptable_drift, *max_sync_interval, &state) {
+                        Ok((now, ticks, next_sync_interval, estimated_freq)) => {
+                            let new_freq_estimations = state.freq_estimations + 1;
+                            if now.abs_diff(&self.t0.1) < *frequency_learning_period {
+                                // We don't have enough data to estimate frequency correctly
+                                return now;
+                            }
+                            // this instead of self.tsc_state.write() to avoid starvation
+                            let mut state = self.tsc_state.upgradeable_read().upgrade();
+                            state.freq_estimations = new_freq_estimations;
                             // When `next_tsc` overflows, the system has been running for over 10
                             // years, or an attacker manipulated the TSC value. As we can't trust TSC
                             // anyway, we do the simple thing and continue trying to sync
-                            let duration = Ticks::from_duration(next_sync_interval, &estimated_freq);
+                            let duration = Ticks::from_duration(next_sync_interval, estimated_freq);
                             if let Ok(next_tsc) = tsc_now + duration.unwrap_or(Ticks::max()) {
-                                next_sync.set(next_tsc);
+                                state.next_sync = next_tsc;
                             }
-                            frequency.set(&estimated_freq);
+                            // exponential averaging to reduce noise
+                            state.frequency = Freq::from_u64(
+                                (estimated_freq.as_u64() * 3 + state.frequency.as_u64() * 7) / 10,
+                            );
+                            state.recent_ticks = ticks;
+                            state.recent_native_time = now;
                             now
                         },
-                        Err(ResyncError::WithinFrequencyLearningPeriod(now)) => now,
+                        Err(ResyncError::UnreliableTscReading(now)) => now,
+                        Err(ResyncError::UnreliableFreqEstimation(now, ticks)) => {
+                            let mut state = self.tsc_state.upgradeable_read().upgrade();
+                            state.recent_ticks = ticks;
+                            state.recent_native_time = now;
+                            now
+                        }
                     }
                 }
             }
             TscMode::Fixed { frequency } => {
-                self.now_ex(&frequency)
+                self.t0.1 + self.t0.0.elapsed(*frequency)
             }
-        };
+        }
+    }
 
+    #[inline]
+    pub fn now(&self) -> T {
+        let now = self.now_internal();
         self.time_mode.observe(now)
+    }
+
+    /// current estimate of the TSC frequency
+    pub fn frequency_estimate(&self) -> Option<Freq> {
+        match &self.tsc_mode {
+            TscMode::Fixed { frequency } => Some(*frequency),
+            TscMode::Learn { .. } => Some(self.tsc_state.read().frequency).filter(|freq| freq.0 != 0),
+            TscMode::NoRdtsc => None,
+        }
+    }
+
+    /// number of clock resyncs and frequency estimations done so far
+    pub fn resyncs(&self) -> usize {
+        self.tsc_state.read().freq_estimations
     }
 }
 
@@ -737,7 +728,7 @@ mod tests {
             std::thread::sleep(Duration::from_secs(2));
             let t1 = (SystemTime::now(), Ticks::now());
 
-            let estimated_freq = Freq::estimate(t1.1.abs_diff(&t0.1), t1.0.duration_since(t0.0).unwrap());
+            let estimated_freq = Freq::estimate(t1.1.abs_diff(t0.1), t1.0.duration_since(t0.0).unwrap());
             let low_estimate = Freq::from_u64(estimated_freq.as_u64() * 99 / 100);
             let high_estimate = Freq::from_u64(estimated_freq.as_u64() * 101 / 100);
             assert!(low_estimate.as_u64() <= freq.as_u64() && freq.as_u64() <= high_estimate.as_u64(), "Expected frequency between {:?} and {:?}, got {:?}", low_estimate, high_estimate, freq);

--- a/intel-sgx/insecure-time/src/lib.rs
+++ b/intel-sgx/insecure-time/src/lib.rs
@@ -514,7 +514,7 @@ impl<T: NativeTime> Tsc<T> {
 
     const ACCEPTABLE_FREQ_RANGE: RangeInclusive<u64> = 50_000_000..=100_000_000_000;
     fn resync_clocks(max_acceptable_drift: Duration, max_sync_interval: Duration, state: &TscState<T>) -> Result<(T, Ticks, Duration, Freq), ResyncError<T>> {
-        let (system_now, tsc_now) = match Self::get_system_now_and_tsc(Some(state.frequency)) {
+        let (system_now, tsc_now) = match Self::get_system_now_and_tsc(max_sync_interval, Some(state.frequency)) {
             Ok(st) => st,
             Err(system_now) => return Err(ResyncError::UnreliableTscReading(system_now)),
         };
@@ -542,17 +542,13 @@ impl<T: NativeTime> Tsc<T> {
 
     /// Gets current system time and tsc. Returns an error if it observes too much
     /// delay between the two measurements.
-    fn get_system_now_and_tsc(current_freq_estimation: Option<Freq>) -> Result<(T, Ticks), T> {
-        const ACCEPTABLE_LAG: Duration = Duration::from_millis(250);
+    fn get_system_now_and_tsc(max_sync_interval: Duration, current_freq_estimation: Option<Freq>) -> Result<(T, Ticks), T> {
         let tsc_before = current_freq_estimation.is_some().then(Ticks::now);
-        // Calling rdtsc _after_ issuing a insecure_time usercall so frequency
-        // will be _over_ estimated rather than under estimated when system is
-        // under heavy load. An under estimated frequency is easier to fix
-        // afterwards when time needs to be monotonic.
         let system_now = T::now();
         let tsc_after = Ticks::now();
         if let (Some(current_freq_estimation), Some(tsc_before)) = (current_freq_estimation, tsc_before) {
-            if tsc_after.abs_diff(tsc_before).as_duration_ex(current_freq_estimation) > ACCEPTABLE_LAG {
+            let acceptable_lag = Duration::from_millis(10).max(max_sync_interval / 1000);
+            if tsc_after.abs_diff(tsc_before).as_duration_ex(current_freq_estimation) > acceptable_lag {
                 Err(system_now)
             } else {
                 Ok((system_now, tsc_after))
@@ -570,7 +566,7 @@ impl<T: NativeTime> Tsc<T> {
                 let (tsc_now, state) = if state.frequency.as_u64() != 0 {
                     (Ticks::now(), state)
                 } else {
-                    let (system_now, tsc_now) = match Self::get_system_now_and_tsc(None) {
+                    let (system_now, tsc_now) = match Self::get_system_now_and_tsc(*max_sync_interval, None) {
                         Ok(st) => st,
                         Err(system_now) => return system_now,
                     };
@@ -597,20 +593,22 @@ impl<T: NativeTime> Tsc<T> {
                                 // We don't have enough data to estimate frequency correctly
                                 return now;
                             }
-                            // this instead of self.tsc_state.write() to avoid starvation
-                            let mut state = self.tsc_state.upgradeable_read().upgrade();
-                            state.freq_estimations = new_freq_estimations;
+                            // exponential averaging to reduce noise
+                            let w = (state.recent_ticks.elapsed(state.frequency).as_secs_f64() * 0.4).clamp(0.001, 0.9);
+                            let new_freq = Freq::from_u64(
+                                (estimated_freq.as_u64() as f64 * w + state.frequency.as_u64() as f64 * (1.0 - w)) as u64
+                            );
                             // When `next_tsc` overflows, the system has been running for over 10
                             // years, or an attacker manipulated the TSC value. As we can't trust TSC
                             // anyway, we do the simple thing and continue trying to sync
-                            let duration = Ticks::from_duration(next_sync_interval, estimated_freq);
-                            if let Ok(next_tsc) = tsc_now + duration.unwrap_or(Ticks::max()) {
+                            let next_sync_ticks = Ticks::from_duration(next_sync_interval, estimated_freq).unwrap_or(Ticks::max());
+                            // this instead of self.tsc_state.write() to avoid starvation
+                            let mut state = self.tsc_state.upgradeable_read().upgrade();
+                            state.freq_estimations = new_freq_estimations;
+                            if let Ok(next_tsc) = tsc_now + next_sync_ticks {
                                 state.next_sync = next_tsc;
                             }
-                            // exponential averaging to reduce noise
-                            state.frequency = Freq::from_u64(
-                                (estimated_freq.as_u64() * 3 + state.frequency.as_u64() * 7) / 10,
-                            );
+                            state.frequency = new_freq;
                             state.recent_ticks = ticks;
                             state.recent_native_time = now;
                             now

--- a/intel-sgx/insecure-time/src/lib.rs
+++ b/intel-sgx/insecure-time/src/lib.rs
@@ -277,7 +277,6 @@ enum TscMode {
         max_acceptable_drift: Duration,
         // The maximum interval between re-syncing with the external clock source
         max_sync_interval: Duration,
-        initial_frequency: Option<Freq>,
     },
     NoRdtsc,
 }
@@ -389,8 +388,6 @@ pub struct LearningFreqTscBuilder<T: NativeTime> {
     frequency_learning_period: Duration,
     // Whether the TSC should be monotonic
     time_mode: TimeMode<T>,
-    // The frequency learned
-    frequency: Option<Freq>,
 }
 
 impl<T: NativeTime> LearningFreqTscBuilder<T> {
@@ -400,17 +397,7 @@ impl<T: NativeTime> LearningFreqTscBuilder<T> {
             max_acceptable_drift: Duration::from_millis(1),
             max_sync_interval: Duration::from_secs(60),
             time_mode: TimeMode::non_monotonic(),
-            frequency: None,
         }
-    }
-
-    pub fn set_initial_frequency(mut self, freq: Freq) -> Self {
-        self.frequency = Some(freq);
-        self
-    }
-
-    pub fn initial_frequency(&self) -> &Option<Freq> {
-        &self.frequency
     }
 
     pub fn set_max_acceptable_drift(mut self, error: Duration) -> Self {
@@ -448,12 +435,11 @@ impl<T: NativeTime> TscBuilder<T> for LearningFreqTscBuilder<T> {
     }
 
     fn build(self) -> Tsc<T> {
-        let LearningFreqTscBuilder { frequency, max_sync_interval, max_acceptable_drift, frequency_learning_period, time_mode, } = self;
+        let LearningFreqTscBuilder { max_sync_interval, max_acceptable_drift, frequency_learning_period, time_mode } = self;
         let tsc_mode = TscMode::Learn {
             max_sync_interval,
             max_acceptable_drift,
             frequency_learning_period: frequency_learning_period.max(max_sync_interval),
-            initial_frequency: frequency
         };
         Tsc::new(tsc_mode, time_mode)
     }
@@ -501,7 +487,7 @@ impl<T: NativeTime> Tsc<T> {
 
         let (frequency, max_sync_interval) = match &tsc_mode {
             TscMode::Fixed { frequency } => (Some(*frequency), Duration::MAX),
-            TscMode::Learn { initial_frequency, max_sync_interval, .. } => (*initial_frequency, *max_sync_interval),
+            TscMode::Learn { max_sync_interval, .. } => (None, *max_sync_interval),
             TscMode::NoRdtsc => (None, Duration::MAX),
         };
         let (next_sync, frequency) =
@@ -579,7 +565,7 @@ impl<T: NativeTime> Tsc<T> {
     fn now_internal(&self) -> T {
         match &self.tsc_mode {
             TscMode::NoRdtsc => T::now(),
-            TscMode::Learn { frequency_learning_period, max_acceptable_drift, max_sync_interval, initial_frequency: _ } => {
+            TscMode::Learn { frequency_learning_period, max_acceptable_drift, max_sync_interval } => {
                 let state = *self.tsc_state.read();
                 let (tsc_now, state) = if state.frequency.as_u64() != 0 {
                     (Ticks::now(), state)
@@ -942,10 +928,8 @@ mod tests {
     fn high_variation_system_time_lag() {
         for monotonic in [false, true] {
             for _run in 0..30 {
-                let freq = Freq::get().unwrap();
                 let tsc_builder: LearningFreqTscBuilder<HighVariationSystemTime> = LearningFreqTscBuilder::new()
-                        .set_monotonic_time()
-                        .set_initial_frequency(freq);
+                        .set_monotonic_time();
                 clock_drift::<_, SystemTime>(tsc_builder, Duration::from_secs(1), &(2 * HighVariationSystemTime::variation()), monotonic);
             }
         }
@@ -956,7 +940,6 @@ mod tests {
     #[cfg(not(target_env = "sgx"))]
     fn high_variation_system_time_drift() {
         let tsc_builder: LearningFreqTscBuilder<HighVariationSystemTime> = LearningFreqTscBuilder::new()
-                .set_initial_frequency(Freq::get().unwrap())
                 .set_frequency_learning_period(Duration::from_secs(120))
                 .set_max_acceptable_drift(Duration::from_millis(1))
                 .set_max_sync_interval(Duration::from_secs(60))

--- a/intel-sgx/insecure-time/src/lib.rs
+++ b/intel-sgx/insecure-time/src/lib.rs
@@ -594,14 +594,14 @@ impl<T: NativeTime> Tsc<T> {
                                 return now;
                             }
                             // exponential averaging to reduce noise
-                            let w = (state.recent_ticks.elapsed(state.frequency).as_secs_f64() * 0.4).clamp(0.001, 0.9);
+                            let w = new_freq_estimate_weight(state.recent_ticks.elapsed(state.frequency));
                             let new_freq = Freq::from_u64(
                                 (estimated_freq.as_u64() as f64 * w + state.frequency.as_u64() as f64 * (1.0 - w)) as u64
                             );
                             // When `next_tsc` overflows, the system has been running for over 10
                             // years, or an attacker manipulated the TSC value. As we can't trust TSC
                             // anyway, we do the simple thing and continue trying to sync
-                            let next_sync_ticks = Ticks::from_duration(next_sync_interval, estimated_freq).unwrap_or(Ticks::max());
+                            let next_sync_ticks = Ticks::from_duration(next_sync_interval, new_freq).unwrap_or(Ticks::max());
                             // this instead of self.tsc_state.write() to avoid starvation
                             let mut state = self.tsc_state.upgradeable_read().upgrade();
                             state.freq_estimations = new_freq_estimations;
@@ -648,6 +648,14 @@ impl<T: NativeTime> Tsc<T> {
     pub fn resyncs(&self) -> usize {
         self.tsc_state.read().freq_estimations
     }
+}
+
+/// calculate the weight of the new frequency estimate for exponential avergaging.
+/// The calculated weight fixes a specific half-life for catching up to the new frequency.
+fn new_freq_estimate_weight(freq_sync_time: Duration) -> f64 {
+    const HALF_LIFE: Duration = Duration::from_secs(30);
+    let cycles_recip = freq_sync_time.div_duration_f64(HALF_LIFE).max(0.001);
+    1.0 - 2f64.powf(-cycles_recip)
 }
 
 #[cfg(test)]
@@ -973,5 +981,17 @@ mod tests {
         // WARNING: Its up to the caller to ensure that the enclave runner used for this test does
         // not enable rdtsc-based time within the enclave
         clock_drift::<_, SystemTime>(tsc_builder, test_duration(), &ADDITIONAL_DRIFT, true);
+    }
+
+    #[test]
+    fn weight_formula_correct() {
+        let mut last_w = 0.0;
+        for t in [0, 100, 1_000, 5_000, 10_000, 15_000, 20_000, 30_000, 60_000, 10_000_000] {
+            let w = crate::new_freq_estimate_weight(Duration::from_millis(t));
+            #[cfg(feature = "std")]
+            std::println!("sync time: {t} ms, w: {w}");
+            assert!(w >= last_w && (0.0..=1.0).contains(&w));
+            last_w = w;
+        }
     }
 }


### PR DESCRIPTION
This PR makes the following improvements:

- Fix the bug in calculating next sync time in `fn resync_clocks()`
  The current buggy behavior is to set next sync time to a long time in the future the first time, and to practically infinity the second time. This means that in the lifetime of a program, the clock is only resynced twice (at most).

- Estimate recent frequency instead of average freq over program lifetime
   The TSC freq can change slightly over time, we want the recent frequency to accurately estimate passed time, not
       the average frequency.
- Keep track of latest system time to have a more accurate estimate of current time
  instead of estimating current time from TSC ticks since program start time.
- Cleanup/simplify the code.
- Make resyncs more robust to unreliable reads of TSC, TSC getting reset, etc.
- Remove `initial_frequency` from `LearningFreqTscBuilder` as it was ignored