### PR TITLE
[RTE-870] Add Root CA CRL to `dcap-artifact-retrieval` tool

### DIFF
--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use std::time::Duration;
 
 use super::common::PckCertsApiNotSupported;
-use super::intel::{PckCrlApi, QeIdApi, TcbEvaluationDataNumbersApi, TcbInfoApi, INTEL_BASE_URL};
+use super::intel::{PckCrlApi, QeIdApi, RootCaCrlApi, TcbEvaluationDataNumbersApi, TcbInfoApi, INTEL_BASE_URL};
 use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PcsVersion, ProvisioningServiceApi,
     StatusCode,
@@ -50,6 +50,7 @@ impl AzureProvisioningClientBuilder {
         let tdx_tcbinfo = TcbInfoApi::new(self.api_version.clone());
         let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
         let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
+        let root_ca_crl = RootCaCrlApi::new();
 
         self.client_builder.build(
             pck_certs,
@@ -60,6 +61,7 @@ impl AzureProvisioningClientBuilder {
             tdx_tcbinfo,
             sgx_evaluation_data_numbers,
             tdx_evaluation_data_numbers,
+            root_ca_crl,
             fetcher,
         )
     }

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -12,16 +12,14 @@
 //! - <https://download.01.org/intel-sgx/dcap-1.1/linux/docs/Intel_SGX_PCK_Certificate_CRL_Spec-1.1.pdf>
 
 use pcs::{
-    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl,
-    PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers,
-    TcbInfo, Unverified,
+    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, RootCaCrl, TcbInfo, Unverified
 };
 use rustc_serialize::hex::ToHex;
 use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::time::Duration;
 
-use super::common::*;
+use super::{common::*, RootCaCrlIn, RootCaCrlService};
 use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PckCertsIn, PckCertsService,
     PckCrlIn, PckCrlService, PcsVersion, ProvisioningServiceApi, QeIdIn, QeIdService, StatusCode,
@@ -68,6 +66,7 @@ impl IntelProvisioningClientBuilder {
         let tdx_tcbinfo = TcbInfoApi::new(self.api_version.clone());
         let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
         let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(INTEL_BASE_URL.into());
+        let root_ca_crl = RootCaCrlApi::new();
 
         self.client_builder.build(
             pck_certs,
@@ -78,6 +77,7 @@ impl IntelProvisioningClientBuilder {
             tdx_tcbinfo,
             sgx_evaluation_data_numbers,
             tdx_evaluation_data_numbers,
+            root_ca_crl,
             fetcher,
         )
     }
@@ -607,6 +607,67 @@ impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi<'i
         let ca_chain =
             parse_issuer_header(&response_headers, TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN)?;
         RawTcbEvaluationDataNumbers::parse(&response_body, ca_chain).map_err(|e| e.into())
+    }
+}
+
+pub struct RootCaCrlApi;
+
+impl RootCaCrlApi {
+    pub fn new() -> Self {
+        RootCaCrlApi
+    }
+}
+
+impl<'inp> RootCaCrlService<'inp> for RootCaCrlApi {
+    fn build_input(
+        &'inp self
+    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
+        RootCaCrlIn
+    }
+}
+
+impl<'inp> ProvisioningServiceApi<'inp> for RootCaCrlApi {
+    type Input = RootCaCrlIn;
+    type Output = RootCaCrl<Unverified>;
+
+    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
+        let url = format!("https://certificates.trustedservices.intel.com/IntelSGXRootCA.crl");
+        Ok((url, Vec::new()))
+    }
+
+    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+        match &status_code {
+            StatusCode::Ok => Ok(()),
+            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
+            StatusCode::Unauthorized => Err(Error::PCSError(
+                status_code,
+                "Failed to authenticate or authorize the request.",
+            )),
+            StatusCode::NotFound => {
+                Err(Error::PCSError(status_code, "Root CA CRL cannot be found"))
+            }
+            StatusCode::InternalServerError => Err(Error::PCSError(
+                status_code,
+                "PCS suffered from an internal server error",
+            )),
+            StatusCode::ServiceUnavailable => Err(Error::PCSError(
+                status_code,
+                "PCS is temporarily unavailable",
+            )),
+            __ => Err(Error::PCSError(
+                status_code,
+                "Unexpected response from PCS server",
+            )),
+        }
+    }
+
+    fn parse_response(
+        &self,
+        response_body: String,
+        response_headers: Vec<(String, String)>,
+        _api_version: PcsVersion,
+    ) -> Result<Self::Output, Error> {
+        RootCaCrl::new_from_pem(&response_body).map_err(|e| Error::ReadResponseError(Cow::Owned(e.to_string().into())))
     }
 }
 
@@ -1258,5 +1319,19 @@ mod tests {
     #[test]
     pub fn tdx_tcb_evaluation_data_numbers() {
         tcb_evaluation_data_numbers_test_base::<platform::TDX>()
+    }
+
+    #[test]
+    pub fn root_ca_crl() {
+
+        let mut intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT);
+
+        let client = intel_builder.build(reqwest_client());
+        let root_ca_crl = client.root_ca_crl().unwrap();
+
+        let root_ca = include_bytes!("../../../pcs/tests/data/root_SGX_CA_der.cert");
+        let root_cas = [&root_ca[..]];
+        root_ca_crl.verify(&root_cas).unwrap();
     }
 }

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, SystemTime};
 use lru_cache::LruCache;
 use num_enum::TryFromPrimitive;
 use pcs::{
-    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PckID, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, TcbComponentType, TcbInfo, Unverified, platform
+    platform, CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PckID, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, RootCaCrl, TcbComponentType, TcbInfo, Unverified
 };
 #[cfg(feature = "reqwest")]
 use reqwest::blocking::{Client as ReqwestClient, Response as ReqwestResponse};
@@ -275,6 +275,21 @@ pub trait TcbEvaluationDataNumbersService<'inp, T: PlatformTypeForTcbInfo>:
         -> <Self as ProvisioningServiceApi<'inp>>::Input;
 }
 
+#[derive(Hash)]
+pub struct RootCaCrlIn;
+
+impl WithApiVersion for RootCaCrlIn {
+    fn api_version(&self) -> PcsVersion {
+        PcsVersion::V4
+    }
+}
+
+pub trait RootCaCrlService<'inp>:
+    ProvisioningServiceApi<'inp, Input = RootCaCrlIn, Output = RootCaCrl<Unverified>>
+{
+    fn build_input(&'inp self) -> <Self as ProvisioningServiceApi<'inp>>::Input;
+}
+
 pub struct ClientBuilder {
     retry_timeout: Option<Duration>,
     cache_capacity: usize,
@@ -301,7 +316,7 @@ impl ClientBuilder {
         self
     }
 
-    pub(crate) fn build<PSS, PS, PC, QS, TS, TDS, ES, TES, F>(
+    pub(crate) fn build<PSS, PS, PC, QS, TS, TDS, ES, TES, RCC, F>(
         self,
         pckcerts_service: PSS,
         pckcert_service: PS,
@@ -311,6 +326,7 @@ impl ClientBuilder {
         tdx_tcbinfo_service: TDS,
         sgx_tcb_evaluation_data_numbers_service: ES,
         tdx_tcb_evaluation_data_numbers_service: TES,
+        root_ca_crl_service: RCC,
         fetcher: F,
     ) -> Client<F>
     where
@@ -322,6 +338,7 @@ impl ClientBuilder {
         TDS: for<'a> TcbInfoService<'a, platform::TDX> + Sync + Send + 'static,
         ES: for<'a> TcbEvaluationDataNumbersService<'a, platform::SGX> + Sync + Send + 'static,
         TES: for<'a> TcbEvaluationDataNumbersService<'a, platform::TDX> + Sync + Send + 'static,
+        RCC: for<'a> RootCaCrlService<'a> + Sync + Send + 'static,
         F: for<'a> Fetcher<'a>,
     {
         Client::new(
@@ -333,6 +350,7 @@ impl ClientBuilder {
             tdx_tcbinfo_service,
             sgx_tcb_evaluation_data_numbers_service,
             tdx_tcb_evaluation_data_numbers_service,
+            root_ca_crl_service,
             fetcher,
             self.retry_timeout,
             self.cache_capacity,
@@ -495,11 +513,12 @@ pub struct Client<F: for<'a> Fetcher<'a>> {
     tdx_tcbinfo_service: CachedService<TcbInfo<platform::TDX>, dyn for<'a> TcbInfoService<'a, platform::TDX> + Sync + Send>,
     sgx_tcb_evaluation_data_numbers_service: CachedService<RawTcbEvaluationDataNumbers<platform::SGX>, dyn for<'a> TcbEvaluationDataNumbersService<'a, platform::SGX> + Sync + Send>,
     tdx_tcb_evaluation_data_numbers_service: CachedService<RawTcbEvaluationDataNumbers<platform::TDX>, dyn for<'a> TcbEvaluationDataNumbersService<'a, platform::TDX> + Sync + Send>,
+    root_ca_crl_service: CachedService<RootCaCrl<Unverified>, dyn for<'a> RootCaCrlService<'a> + Sync + Send>,
     fetcher: F,
 }
 
 impl<F: for<'a> Fetcher<'a>> Client<F> {
-    fn new<PSS, PS, PC, QS, TS, TDS, ES, TES>(
+    fn new<PSS, PS, PC, QS, TS, TDS, ES, TES, RCC>(
         pckcerts_service: PSS,
         pckcert_service: PS,
         pckcrl_service: PC,
@@ -508,6 +527,7 @@ impl<F: for<'a> Fetcher<'a>> Client<F> {
         tdx_tcbinfo_service: TDS,
         sgx_tcb_evaluation_data_numbers_service: ES,
         tdx_tcb_evaluation_data_numbers_service: TES,
+        root_ca_crl_service: RCC,
         fetcher: F,
         retry_timeout: Option<Duration>,
         cache_capacity: usize,
@@ -522,6 +542,7 @@ impl<F: for<'a> Fetcher<'a>> Client<F> {
         TDS: for<'a> TcbInfoService<'a, platform::TDX> + Sync + Send + 'static,
         ES: for<'a> TcbEvaluationDataNumbersService<'a, platform::SGX> + Sync + Send + 'static,
         TES: for<'a> TcbEvaluationDataNumbersService<'a, platform::TDX> + Sync + Send + 'static,
+        RCC: for<'a> RootCaCrlService<'a> + Sync + Send + 'static,
     {
         Client {
             pckcerts_service: CachedService::new(
@@ -583,6 +604,14 @@ impl<F: for<'a> Fetcher<'a>> Client<F> {
             tdx_tcb_evaluation_data_numbers_service: CachedService::new(
                 BackoffService::new(
                     PcsService::new(Box::new(tdx_tcb_evaluation_data_numbers_service)),
+                    retry_timeout.clone(),
+                ),
+                cache_capacity,
+                cache_shelf_time,
+            ),
+            root_ca_crl_service: CachedService::new(
+                BackoffService::new(
+                    PcsService::new(Box::new(root_ca_crl_service)),
                     retry_timeout.clone(),
                 ),
                 cache_capacity,
@@ -693,6 +722,8 @@ pub trait ProvisioningClient {
     fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error>;
 
     fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error>;
+
+    fn root_ca_crl(&self) -> Result<RootCaCrl<Unverified>, Error>;
 }
 
 
@@ -778,6 +809,11 @@ impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F> {
         let input = self.tdx_tcb_evaluation_data_numbers_service.pcs_service().build_input();
         self.tdx_tcb_evaluation_data_numbers_service.call_service(&self.fetcher, &input)
 
+    }
+
+    fn root_ca_crl(&self) -> Result<RootCaCrl<Unverified>, Error> {
+        let input = self.root_ca_crl_service.pcs_service().build_input();
+        self.root_ca_crl_service.call_service(&self.fetcher, &input)
     }
 }
 

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
@@ -12,15 +12,16 @@
 
 use std::borrow::Cow;
 use std::marker::PhantomData;
+use std::num::ParseIntError;
 use std::time::Duration;
 
 
 use pcs::{
-    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCrl, PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, TcbInfo, Unverified, platform
+    platform, CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCrl, PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RootCaCrl, TcbInfo, Unverified
 };
 use rustc_serialize::hex::{FromHex, ToHex};
 
-use super::common::*;
+use super::{common::*, RootCaCrlIn, RootCaCrlService};
 use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PckCrlIn, PckCrlService, PcsVersion,
     ProvisioningServiceApi, QeIdIn, QeIdService, StatusCode, TcbInfoIn, TcbInfoService,
@@ -57,9 +58,10 @@ impl PccsProvisioningClientBuilder {
         let tdx_tcbinfo = TcbInfoApi::<platform::TDX>::new(self.base_url.clone(), self.api_version);
         let sgx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(self.base_url.clone());
         let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(self.base_url.clone());
+        let root_ca_crl = RootCaCrlApi::new(self.base_url.clone());
 
         self.client_builder
-            .build(pck_certs, pck_cert, pck_crl, qeid, sgx_tcbinfo, tdx_tcbinfo, sgx_evaluation_data_numbers, tdx_evaluation_data_numbers, fetcher)
+            .build(pck_certs, pck_cert, pck_crl, qeid, sgx_tcbinfo, tdx_tcbinfo, sgx_evaluation_data_numbers, tdx_evaluation_data_numbers, root_ca_crl, fetcher)
     }
 }
 
@@ -428,6 +430,79 @@ impl<'inp> ProvisioningServiceApi<'inp> for QeIdApi {
         let ca_chain = parse_issuer_header(&response_headers, ENCLAVE_ID_ISSUER_CHAIN_HEADER)?;
         let id = QeIdentitySigned::parse(&response_body, ca_chain)?;
         Ok(id)
+    }
+}
+
+pub struct RootCaCrlApi {
+    base_url: Cow<'static, str>,
+}
+
+impl RootCaCrlApi {
+    pub fn new(base_url: Cow<'static, str>) -> Self {
+        RootCaCrlApi {
+            base_url
+        }
+    }
+}
+
+impl<'inp> RootCaCrlService<'inp> for RootCaCrlApi {
+    fn build_input(
+        &'inp self
+    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
+        RootCaCrlIn
+    }
+}
+
+impl<'inp> ProvisioningServiceApi<'inp> for RootCaCrlApi {
+    type Input = RootCaCrlIn;
+    type Output = RootCaCrl<Unverified>;
+
+    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
+        let url = format!("{}/sgx/certification/v4/rootcacrl", self.base_url);
+        Ok((url, Vec::new()))
+    }
+
+    fn validate_response(&self, status_code: StatusCode) -> Result<(), Error> {
+        match &status_code {
+            StatusCode::Ok => Ok(()),
+            StatusCode::BadRequest => Err(Error::PCSError(status_code, "Invalid parameter")),
+            StatusCode::Unauthorized => Err(Error::PCSError(
+                status_code,
+                "Failed to authenticate or authorize the request.",
+            )),
+            StatusCode::NotFound => {
+                Err(Error::PCSError(status_code, "Root CA CRL cannot be found"))
+            }
+            StatusCode::InternalServerError => Err(Error::PCSError(
+                status_code,
+                "PCS suffered from an internal server error",
+            )),
+            StatusCode::ServiceUnavailable => Err(Error::PCSError(
+                status_code,
+                "PCS is temporarily unavailable",
+            )),
+            __ => Err(Error::PCSError(
+                status_code,
+                "Unexpected response from PCS server",
+            )),
+        }
+    }
+
+    fn parse_response(
+        &self,
+        response_body: String,
+        response_headers: Vec<(String, String)>,
+        _api_version: PcsVersion,
+    ) -> Result<Self::Output, Error> {
+        pub fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
+            (0..s.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
+                .collect()
+        }
+
+        let der = decode_hex(&response_body).map_err(|_| Error::ReadResponseError(Cow::Borrowed("Cannot parse CRL repsonse")))?;
+        RootCaCrl::new(&der).map_err(|e| Error::ReadResponseError(Cow::Owned(e.to_string().into())))
     }
 }
 
@@ -910,5 +985,15 @@ mod tests {
                     .unwrap();
             assert_eq!(tcb_info.tcb_evaluation_data_number(), u64::from(number));
         }
+    }
+
+    #[test]
+    pub fn root_ca_crl() {
+        let client = make_client(PcsVersion::V4);
+        let root_ca_crl = client.root_ca_crl().unwrap();
+
+        let root_ca = include_bytes!("../../../pcs/tests/data/root_SGX_CA_der.cert");
+        let root_cas = [&root_ca[..]];
+        root_ca_crl.verify(&root_cas).unwrap();
     }
 }


### PR DESCRIPTION
Adding the functionality to retrieve the Root CA CRL via the `dcap-artifact-retrieval` tool. For Intel PCS, we directly download from the fixed URL. For the PCCS, it contacts the PCCS server to retrieve the CRL.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #926 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #925 
<!-- GitButler Footer Boundary Bottom -->

