### PR TITLE
Patch bump `pcs` and `dcap-artifact-retrieval`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-artifact-retrieval"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "assert_matches",
  "backoff",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "pcs"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "b64-ct",

--- a/intel-sgx/dcap-artifact-retrieval/Cargo.toml
+++ b/intel-sgx/dcap-artifact-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-artifact-retrieval"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -45,7 +45,7 @@ rustls-tls = ["reqwest?/rustls-tls"]
 [dev-dependencies]
 assert_matches = "1.5.0"
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
-pcs = { version = "0.8", path = "../pcs", features = ["verify"] }
+pcs = { version = "0.8.3", path = "../pcs", features = ["verify"] }
 
 [build-dependencies]
 mbedtls = { version = ">=0.12.0, <0.14.0", features = ["ssl", "x509"] }

--- a/intel-sgx/pcs/Cargo.toml
+++ b/intel-sgx/pcs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcs"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/pcs/src/lib.rs
+++ b/intel-sgx/pcs/src/lib.rs
@@ -68,7 +68,7 @@ pub trait PlatformType : Clone + Default {
 
 ///Function to attempt deserialize [PlatformType] instance based on the [PlatformType::platform_id] value.
 pub fn deserialize_platform_id<'de, D: Deserializer<'de>, T: PlatformType>(deserializer: D) -> Result<T, D::Error> {
-    let platform_str = <&str>::deserialize(deserializer)?;
+    let platform_str = String::deserialize(deserializer)?;
     if platform_str == T::platform_id() {
         Ok(T::default())
     } else {

--- a/intel-sgx/pcs/src/tcb_info.rs
+++ b/intel-sgx/pcs/src/tcb_info.rs
@@ -269,9 +269,9 @@ impl TdxModuleIdentity {
         self.tcb_levels.iter()
     }
 
-    #[deprecated(since="0.8.3", note = "this function is not supposed to be used externally")]
-    pub fn find_best_tcb_level(&self, _: u64) -> Option<&TdxModuleTcbLevel> {
-        None
+    #[deprecated(since="0.8.3", note = "use `find_tcb_level` instead")]
+    pub fn find_best_tcb_level(&self, level: u64) -> Option<&TdxModuleTcbLevel> {
+        self.find_tcb_level(level)
     }
 
     /// Function to find best TDX TCB level for this TDX Module


### PR DESCRIPTION
We are bumping the `pcs` and `dcap-artifact-retrieval` for the implementation of the Root CA CRL.