### PR TITLE
Fix issues with rustc-dep-of-std in `insecure-time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4741,9 +4741,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "783f3f6f6b01e295a669edfc402133a5f2553d1f0e81284b3ba4594e80bdd4a2"
+dependencies = [
+ "rustc-std-workspace-core",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/intel-sgx/insecure-time/Cargo.toml
+++ b/intel-sgx/insecure-time/Cargo.toml
@@ -18,7 +18,8 @@ name = "insecure-time"
 [dependencies]
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-spin = { version = "0.10", default-features = false, features = ["rwlock", "mutex", "spin_mutex"] }
+spin = { version = "0.11", default-features = false, features = ["rwlock", "mutex", "spin_mutex"] }
+
 
 [dev-dependencies]
 rand = "0.8"
@@ -28,7 +29,7 @@ crossterm = "0.29"
 [features]
 default = ["std"]
 estimate_crystal_clock_freq = []
-rustc-dep-of-std = ["alloc", "core"]
+rustc-dep-of-std = ["alloc", "core", "spin/rustc-dep-of-std"]
 std = []
 
 # Features only available during testing:

--- a/intel-sgx/insecure-time/src/lib.rs
+++ b/intel-sgx/insecure-time/src/lib.rs
@@ -652,10 +652,15 @@ impl<T: NativeTime> Tsc<T> {
 
 /// calculate the weight of the new frequency estimate for exponential avergaging.
 /// The calculated weight fixes a specific half-life for catching up to the new frequency.
+/// (see the comments inside the function)
+#[inline]
 fn new_freq_estimate_weight(freq_sync_time: Duration) -> f64 {
     const HALF_LIFE: Duration = Duration::from_secs(30);
     let cycles_recip = freq_sync_time.div_duration_f64(HALF_LIFE).max(0.001);
-    1.0 - 2f64.powf(-cycles_recip)
+    // This would be the correct formula to fix a half-life, but powf is not available in non-std.
+    // 1.0 - 2f64.powf(-cycles_recip)
+    // We do this instead:
+    (cycles_recip / 2.0).min(0.9)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixed issues:
- update to a version of `spin` that supports `rustc-dep-of-std` (see https://github.com/zesterer/spin-rs/pull/188)
- change the weight formula so that it compiles in non-std