### PR TITLE
feat(dcap-artifact-retrieval): deprecate and disable Intel PCS API version 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Conditionally export PCS_API_KEY and PCCS_URL
+      - name: Conditionally export PCCS_URL
         run: |
-          if [ -n "${{ secrets.PCS_API_KEY }}" ]; then
-            echo "PCS_API_KEY=${{ secrets.PCS_API_KEY }}" >> "$GITHUB_ENV"
-          fi
           if [ -n "${{ vars.PCCS_URL }}" ]; then
             echo "PCCS_URL=${{ vars.PCCS_URL }}" >> "$GITHUB_ENV"
           fi

--- a/intel-sgx/dcap-artifact-retrieval/src/cli.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/cli.rs
@@ -8,7 +8,7 @@
 use std::path::{Path, PathBuf};
 
 use clap::clap_app;
-use pcs::{PckID, DcapArtifactIssuer, WriteOptionsBuilder};
+use pcs::{DcapArtifactIssuer, PckID, WriteOptionsBuilder};
 use reqwest::Url;
 use rustc_serialize::hex::ToHex;
 use serde::de::{value, IntoDeserializer};
@@ -54,10 +54,7 @@ fn download_dcap_artifacts(
         if verbose {
             println!("==[ entry {} ]==", idx);
             println!(" Info:");
-            println!(
-                "   Encr. PPID:  {}",
-                enc_ppid.to_hex(),
-            );
+            println!("   Encr. PPID:  {}", enc_ppid.to_hex(),);
             println!("   pce_id:      {}", &&pckid.pce_id.to_le_bytes().to_hex());
             println!("   cpu svn:     {}", pckid.cpu_svn.as_slice().to_hex());
             println!(
@@ -72,32 +69,39 @@ fn download_dcap_artifacts(
         // instead we mimic it using pckcert API.
         let pckcerts = prov_client.pckcerts_with_fallback(&pckid)?;
 
-        let pckcerts_file = pckcerts.write_to_file(output_dir, pckid.qe_id.as_slice(), WriteOptionsBuilder::new().build())?;
+        let pckcerts_file = pckcerts.write_to_file(
+            output_dir,
+            pckid.qe_id.as_slice(),
+            WriteOptionsBuilder::new().build(),
+        )?;
 
         if verbose {
             println!("   pckcerts:    {}", pckcerts_file.unwrap().display());
         }
 
         let fmspc = pckcerts.fmspc()?;
-        let evaluation_data_numbers = prov_client
-            .sgx_tcb_evaluation_data_numbers()?;
+        let evaluation_data_numbers = prov_client.sgx_tcb_evaluation_data_numbers()?;
 
-        let file = evaluation_data_numbers.write_to_file(output_dir, WriteOptionsBuilder::new().build())?;
+        let file = evaluation_data_numbers
+            .write_to_file(output_dir, WriteOptionsBuilder::new().build())?;
         if verbose {
-            println!("   tcb evaluation data numbers:    {}\n", file.unwrap().display());
+            println!(
+                "   tcb evaluation data numbers:    {}\n",
+                file.unwrap().display()
+            );
         }
 
         for number in evaluation_data_numbers.evaluation_data_numbers()?.numbers() {
-            let tcb_info = prov_client
-                .sgx_tcbinfo(&fmspc, Some(number.number()));
+            let tcb_info = prov_client.sgx_tcbinfo(&fmspc, Some(number.number()));
 
             match tcb_info {
                 Ok(tcb_info) => {
-                    let file = tcb_info.write_to_file(output_dir, WriteOptionsBuilder::new().build())?;
+                    let file =
+                        tcb_info.write_to_file(output_dir, WriteOptionsBuilder::new().build())?;
                     if verbose {
                         println!("   tcb info:    {}", file.unwrap().display());
                     }
-                },
+                }
                 Err(Error::PCSError(StatusCode::Gone, _)) => {
                     if verbose {
                         println!("   tcb info:    Gone (silently ignoring)");
@@ -105,16 +109,15 @@ fn download_dcap_artifacts(
                 }
                 Err(e) => {
                     return Err(e)?;
-                },
+                }
             }
 
-
-            let qe_identity = prov_client
-                .qe_identity(Some(number.number()));
+            let qe_identity = prov_client.qe_identity(Some(number.number()));
 
             match qe_identity {
                 Ok(qe_identity) => {
-                    let file = qe_identity.write_to_file(output_dir, WriteOptionsBuilder::new().build())?;
+                    let file = qe_identity
+                        .write_to_file(output_dir, WriteOptionsBuilder::new().build())?;
                     if verbose {
                         println!("   qe identity: {}\n", file.unwrap().display());
                     }
@@ -126,13 +129,20 @@ fn download_dcap_artifacts(
                 }
                 Err(e) => {
                     return Err(e)?;
-                },
+                }
             }
         }
     }
     let pckcrl = prov_client
         .pckcrl(DcapArtifactIssuer::PCKProcessorCA)
-        .and_then(|crl| crl.write_to_file_as(output_dir, DcapArtifactIssuer::PCKProcessorCA, WriteOptionsBuilder::new().build()).map_err(|e| e.into()))?;
+        .and_then(|crl| {
+            crl.write_to_file_as(
+                output_dir,
+                DcapArtifactIssuer::PCKProcessorCA,
+                WriteOptionsBuilder::new().build(),
+            )
+            .map_err(|e| e.into())
+        })?;
     if verbose {
         println!("==[ generic ]==");
         println!("   PCKProcessorCA Crl:      {}", pckcrl.unwrap().display());
@@ -140,7 +150,14 @@ fn download_dcap_artifacts(
 
     let pckcrl = prov_client
         .pckcrl(DcapArtifactIssuer::PCKPlatformCA)
-        .and_then(|crl| crl.write_to_file_as(output_dir, DcapArtifactIssuer::PCKPlatformCA, WriteOptionsBuilder::new().build()).map_err(|e| e.into()))?;
+        .and_then(|crl| {
+            crl.write_to_file_as(
+                output_dir,
+                DcapArtifactIssuer::PCKPlatformCA,
+                WriteOptionsBuilder::new().build(),
+            )
+            .map_err(|e| e.into())
+        })?;
     if verbose {
         println!("   PCKPlatformCA Crl:      {}", pckcrl.unwrap().display());
     }
@@ -173,9 +190,9 @@ pub fn main() {
 
     fn parse_pcs_version(value: &str) -> Result<PcsVersion, String> {
         match value {
-            "3" => Ok(PcsVersion::V3),
+            "3" => Err(format!("As of May 13, Intel has completed the End-of-Life of the deprecated API versions 3 of Intel PCS")),
             "4" => Ok(PcsVersion::V4),
-            _ => Err(format!("Expected 3 or 4, found `{}`", value)),
+            _ => Err(format!("Expected 4, found `{}`", value)),
         }
     }
 
@@ -215,7 +232,7 @@ pub fn main() {
             (
                 @arg API_VERSION: --("api-version") +takes_value
                 validator(|s| parse_pcs_version(s.as_str()).map(|_| ()))
-                "API version for provisioning service, supported values are 3 and 4. Default: \"4\"."
+                "API version for provisioning service, supported value is 4. Default: \"4\"."
             )
             (
                 @arg API_KEY: --("api-key") +takes_value
@@ -243,11 +260,15 @@ pub fn main() {
     ) {
         (Some(pckid_file), Some(output_dir)) => {
             let verboseness = matches.occurrences_of("VERBOSE");
-            let api_version = parse_pcs_version(matches.value_of("API_VERSION").unwrap_or(DEFAULT_API_VERSION))
-                .expect("validated");
+            let api_version = parse_pcs_version(
+                matches
+                    .value_of("API_VERSION")
+                    .unwrap_or(DEFAULT_API_VERSION),
+            )
+            .expect("validated");
 
-            let origin =
-                parse_origin(matches.value_of("ORIGIN").unwrap_or(DEFAULT_ORIGIN)).expect("validated");
+            let origin = parse_origin(matches.value_of("ORIGIN").unwrap_or(DEFAULT_ORIGIN))
+                .expect("validated");
 
             let fetcher = match matches.is_present("INSECURE") {
                 false => crate::reqwest_client(),

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/azure.rs
@@ -11,7 +11,9 @@ use serde::Deserialize;
 use std::time::Duration;
 
 use super::common::PckCertsApiNotSupported;
-use super::intel::{PckCrlApi, QeIdApi, RootCaCrlApi, TcbEvaluationDataNumbersApi, TcbInfoApi, INTEL_BASE_URL};
+use super::intel::{
+    PckCrlApi, QeIdApi, RootCaCrlApi, TcbEvaluationDataNumbersApi, TcbInfoApi, INTEL_BASE_URL,
+};
 use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PcsVersion, ProvisioningServiceApi,
     StatusCode,
@@ -228,130 +230,118 @@ mod tests {
 
     #[test]
     pub fn pcks_azure() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = AzureProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT)
-                .build(reqwest_client());
-            let root_ca = include_bytes!("../../tests/data/root_SGX_CA_der.cert");
-            let root_cas = [&root_ca[..]];
+        let client = AzureProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT)
+            .build(reqwest_client());
+        let root_ca = include_bytes!("../../tests/data/root_SGX_CA_der.cert");
+        let root_cas = [&root_ca[..]];
 
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
-            {
-                let pck = client
-                    .pckcert(
-                        None,
-                        &pckid.pce_id,
-                        &pckid.cpu_svn,
-                        pckid.pce_isvsvn,
-                        Some(&pckid.qe_id),
-                    )
-                    .unwrap();
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pck = client
+                .pckcert(
+                    None,
+                    &pckid.pce_id,
+                    &pckid.cpu_svn,
+                    pckid.pce_isvsvn,
+                    Some(&pckid.qe_id),
+                )
+                .unwrap();
 
-                let pck = pck.verify(&root_cas, None).unwrap();
-                assert_eq!(
-                    test_helpers::get_cert_subject(&pck.ca_chain().last().unwrap()),
-                    "Intel SGX Root CA"
-                );
-                assert_eq!(
-                    test_helpers::get_cert_subject(&pck.pck_pem()),
-                    "Intel SGX PCK Certificate"
-                );
+            let pck = pck.verify(&root_cas, None).unwrap();
+            assert_eq!(
+                test_helpers::get_cert_subject(&pck.ca_chain().last().unwrap()),
+                "Intel SGX Root CA"
+            );
+            assert_eq!(
+                test_helpers::get_cert_subject(&pck.pck_pem()),
+                "Intel SGX PCK Certificate"
+            );
 
-                let fmspc = pck.fmspc().unwrap();
-                assert!(client.sgx_tcbinfo(&fmspc, None).is_ok());
-            }
+            let fmspc = pck.fmspc().unwrap();
+            assert!(client.sgx_tcbinfo(&fmspc, None).is_ok());
         }
     }
 
     #[test]
     pub fn pck_crl() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = AzureProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT)
-                .build(reqwest_client());
-            assert!(client.pckcrl(DcapArtifactIssuer::PCKProcessorCA).is_ok());
-            assert!(client.pckcrl(DcapArtifactIssuer::PCKPlatformCA).is_ok());
-        }
+        let client = AzureProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT)
+            .build(reqwest_client());
+        assert!(client.pckcrl(DcapArtifactIssuer::PCKProcessorCA).is_ok());
+        assert!(client.pckcrl(DcapArtifactIssuer::PCKPlatformCA).is_ok());
     }
 
     #[test]
     pub fn qe_identity() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = AzureProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT)
-                .build(reqwest_client());
-            assert!(client.qe_identity(None).is_ok());
-        }
+        let client = AzureProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT)
+            .build(reqwest_client());
+        assert!(client.qe_identity(None).is_ok());
     }
 
     #[test]
     pub fn gone_artifacts() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = AzureProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT)
-                .build(reqwest_client());
-            let fmspc = Fmspc::try_from("90806f000000").unwrap();
-            assert_matches!(
-                client.qe_identity(Some(15)),
-                Err(Error::PCSError(StatusCode::Gone, _))
-            );
-            assert_matches!(
-                client.sgx_tcbinfo(&fmspc, Some(15)),
-                Err(Error::PCSError(StatusCode::Gone, _))
-            );
-        }
+        let client = AzureProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT)
+            .build(reqwest_client());
+        let fmspc = Fmspc::try_from("90806f000000").unwrap();
+        assert_matches!(
+            client.qe_identity(Some(15)),
+            Err(Error::PCSError(StatusCode::Gone, _))
+        );
+        assert_matches!(
+            client.sgx_tcbinfo(&fmspc, Some(15)),
+            Err(Error::PCSError(StatusCode::Gone, _))
+        );
     }
 
     #[test]
     pub fn test_pckcerts_with_fallback() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = AzureProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT)
-                .build(reqwest_client());
+        let client = AzureProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT)
+            .build(reqwest_client());
 
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
-            {
-                let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
-                println!("Found {} PCK certs.", pckcerts.as_pck_certs().len());
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
+            println!("Found {} PCK certs.", pckcerts.as_pck_certs().len());
 
-                let tcb_info = client
-                    .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
-                    .unwrap();
-                let tcb_data = tcb_info.data().unwrap();
+            let tcb_info = client
+                .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
+                .unwrap();
+            let tcb_data = tcb_info.data().unwrap();
 
-                let selected = pckcerts
-                    .select_pck(&tcb_data, &pckid.cpu_svn, pckid.pce_isvsvn, pckid.pce_id)
-                    .unwrap();
+            let selected = pckcerts
+                .select_pck(&tcb_data, &pckid.cpu_svn, pckid.pce_isvsvn, pckid.pce_id)
+                .unwrap();
 
-                let pck = client
-                    .pckcert(
-                        Some(&pckid.enc_ppid),
-                        &pckid.pce_id,
-                        &pckid.cpu_svn,
-                        pckid.pce_isvsvn,
-                        Some(&pckid.qe_id),
-                    )
-                    .unwrap();
+            let pck = client
+                .pckcert(
+                    Some(&pckid.enc_ppid),
+                    &pckid.pce_id,
+                    &pckid.cpu_svn,
+                    pckid.pce_isvsvn,
+                    Some(&pckid.qe_id),
+                )
+                .unwrap();
 
-                assert_eq!(
-                    format!("{:?}", selected.sgx_extension().unwrap()),
-                    format!("{:?}", pck.sgx_extension().unwrap())
-                );
-            }
+            assert_eq!(
+                format!("{:?}", selected.sgx_extension().unwrap()),
+                format!("{:?}", pck.sgx_extension().unwrap())
+            );
         }
     }
 
     #[test]
     pub fn sgx_tcb_evaluation_data_numbers() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = AzureProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT)
-                .build(reqwest_client());
-            assert!(client.sgx_tcb_evaluation_data_numbers().is_ok());
-        }
+        let client = AzureProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT)
+            .build(reqwest_client());
+        assert!(client.sgx_tcb_evaluation_data_numbers().is_ok());
     }
 }

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/common.rs
@@ -17,7 +17,8 @@ pub const PCK_CRL_ISSUER_CHAIN_HEADER: &'static str = "SGX-PCK-CRL-Issuer-Chain"
 pub const TCB_INFO_ISSUER_CHAIN_HEADER_V3: &'static str = "SGX-TCB-Info-Issuer-Chain";
 pub const TCB_INFO_ISSUER_CHAIN_HEADER_V4: &'static str = "TCB-Info-Issuer-Chain";
 pub const ENCLAVE_ID_ISSUER_CHAIN_HEADER: &'static str = "SGX-Enclave-Identity-Issuer-Chain";
-pub const TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN: &'static str = "TCB-Evaluation-Data-Numbers-Issuer-Chain";
+pub const TCB_EVALUATION_DATA_NUMBERS_ISSUER_CHAIN: &'static str =
+    "TCB-Evaluation-Data-Numbers-Issuer-Chain";
 
 pub struct PckCertsApiNotSupported;
 
@@ -31,7 +32,7 @@ impl<'inp> PckCertsService<'inp> for PckCertsApiNotSupported {
             enc_ppid,
             pce_id,
             api_key: &None,
-            api_version: PcsVersion::V3, // does not matter, this API is not supported!
+            api_version: PcsVersion::V4, // does not matter, this API is not supported!
         }
     }
 }

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/intel.rs
@@ -12,7 +12,9 @@
 //! - <https://download.01.org/intel-sgx/dcap-1.1/linux/docs/Intel_SGX_PCK_Certificate_CRL_Spec-1.1.pdf>
 
 use pcs::{
-    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, RootCaCrl, TcbInfo, Unverified
+    CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl,
+    PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers,
+    RootCaCrl, TcbInfo, Unverified,
 };
 use rustc_serialize::hex::ToHex;
 use std::borrow::Cow;
@@ -369,9 +371,7 @@ impl<T: PlatformType> TcbInfoApi<T> {
     }
 }
 
-impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> TcbInfoService<'inp, T>
-    for TcbInfoApi<T>
-{
+impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> TcbInfoService<'inp, T> for TcbInfoApi<T> {
     fn build_input(
         &'inp self,
         fmspc: &'inp Fmspc,
@@ -442,6 +442,7 @@ impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi<'i
         }
     }
 
+    #[allow(deprecated)]
     fn parse_response(
         &self,
         response_body: String,
@@ -619,9 +620,7 @@ impl RootCaCrlApi {
 }
 
 impl<'inp> RootCaCrlService<'inp> for RootCaCrlApi {
-    fn build_input(
-        &'inp self
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
+    fn build_input(&'inp self) -> <Self as ProvisioningServiceApi<'inp>>::Input {
         RootCaCrlIn
     }
 }
@@ -630,7 +629,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for RootCaCrlApi {
     type Input = RootCaCrlIn;
     type Output = RootCaCrl<Unverified>;
 
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, _input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
         let url = format!("https://certificates.trustedservices.intel.com/IntelSGXRootCA.crl");
         Ok((url, Vec::new()))
     }
@@ -664,10 +663,11 @@ impl<'inp> ProvisioningServiceApi<'inp> for RootCaCrlApi {
     fn parse_response(
         &self,
         response_body: String,
-        response_headers: Vec<(String, String)>,
+        _response_headers: Vec<(String, String)>,
         _api_version: PcsVersion,
     ) -> Result<Self::Output, Error> {
-        RootCaCrl::new_from_pem(&response_body).map_err(|e| Error::ReadResponseError(Cow::Owned(e.to_string().into())))
+        RootCaCrl::new_from_pem(&response_body)
+            .map_err(|e| Error::ReadResponseError(Cow::Owned(e.to_string().into())))
     }
 }
 
@@ -688,293 +688,236 @@ mod tests {
     };
 
     use crate::provisioning_client::{
-        test_helpers, ProvisioningClientFuncSelector, IntelProvisioningClientBuilder, PcsVersion, ProvisioningClient,
+        test_helpers, IntelProvisioningClientBuilder, PcsVersion, ProvisioningClient,
+        ProvisioningClientFuncSelector,
     };
-    use crate::{Error, reqwest_client, StatusCode};
+    use crate::{reqwest_client, Error, StatusCode};
     use std::hash::DefaultHasher;
 
     const PCKID_TEST_FILE: &str = "./tests/data/pckid_retrieval.csv";
     const OUTPUT_TEST_DIR: &str = "./tests/data/";
     const TIME_RETRY_TIMEOUT: Duration = Duration::from_secs(180);
 
-    fn pcs_api_key() -> Option<String> {
-        let api_key_option = std::env::var("PCS_API_KEY").ok();
-        if let Some(api_key) = api_key_option.as_ref() {
-            assert!(!api_key.is_empty(), "Empty string in PCS_API_KEY");
-        }
-        api_key_option
-    }
-
     #[test]
     pub fn pcks() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            if api_version == PcsVersion::V3 {
-                if let Some(pcs_api_key) = pcs_api_key() {
-                    intel_builder.set_api_key(pcs_api_key);
-                } else {
-                    // Intel SGX PCS version 3 is scheduled to end of life not later than October 31, 2025.
-                    // So we no longer force to test it.
-                    continue;
-                }
-            }
-            let client = intel_builder.build(reqwest_client());
+        let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT);
 
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
-            {
-                let pcks = client
-                    .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
-                    .unwrap();
-                assert_eq!(
-                    test_helpers::get_cert_subject(pcks.ca_chain().last().unwrap()),
-                    "Intel SGX Root CA"
-                );
-                pcks.fmspc().unwrap();
-                pcks.write_to_file(
-                    OUTPUT_TEST_DIR,
-                    pckid.qe_id.as_slice(),
-                    WriteOptionsBuilder::new().build(),
-                )
+        let client = intel_builder.build(reqwest_client());
+
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pcks = client
+                .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
                 .unwrap();
-            }
+            assert_eq!(
+                test_helpers::get_cert_subject(pcks.ca_chain().last().unwrap()),
+                "Intel SGX Root CA"
+            );
+            pcks.fmspc().unwrap();
+            pcks.write_to_file(
+                OUTPUT_TEST_DIR,
+                pckid.qe_id.as_slice(),
+                WriteOptionsBuilder::new().build(),
+            )
+            .unwrap();
         }
     }
 
     #[test]
     pub fn pcks_cached() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            if api_version == PcsVersion::V3 {
-                if let Some(pcs_api_key) = pcs_api_key() {
-                    intel_builder.set_api_key(pcs_api_key);
-                } else {
-                    // Intel SGX PCS version 3 is scheduled to end of life not later than October 31, 2025.
-                    // So we no longer force to test it.
-                    continue;
-                }
-            }
-            let client = intel_builder.build(reqwest_client());
+        let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT);
 
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
+        let client = intel_builder.build(reqwest_client());
+
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pcks = client
+                .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
+                .unwrap();
+
+            // The cache should be populated after initial service call
             {
-                let pcks = client
-                    .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
-                    .unwrap();
+                let mut cache = client.pckcerts_service.cache.lock().unwrap();
 
-                // The cache should be populated after initial service call
-                {
-                    let mut cache = client.pckcerts_service.cache.lock().unwrap();
+                assert!(cache.len() > 0);
 
-                    assert!(cache.len() > 0);
+                let (cached_pcks, _) = {
+                    let mut hasher = DefaultHasher::new();
+                    let input = client
+                        .pckcerts_service
+                        .pcs_service()
+                        .build_input(&pckid.enc_ppid, pckid.pce_id.clone());
+                    input.hash(&mut hasher);
 
-                    let (cached_pcks, _) = {
-                        let mut hasher = DefaultHasher::new();
-                        let input = client
-                            .pckcerts_service
-                            .pcs_service()
-                            .build_input(&pckid.enc_ppid, pckid.pce_id.clone());
-                        input.hash(&mut hasher);
+                    cache
+                        .get_mut(&hasher.finish())
+                        .expect("Can't find key in cache")
+                        .to_owned()
+                };
 
-                        cache
-                            .get_mut(&hasher.finish())
-                            .expect("Can't find key in cache")
-                            .to_owned()
-                    };
-
-                    assert_eq!(pcks.fmspc().unwrap(), cached_pcks.fmspc().unwrap());
-                    assert_eq!(pcks, cached_pcks);
-                }
-
-                // Second service call should return value from cache
-                let pcks_from_service = client
-                    .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
-                    .unwrap();
-
-                assert_eq!(pcks, pcks_from_service);
-                assert_eq!(pcks.fmspc().unwrap(), pcks_from_service.fmspc().unwrap());
+                assert_eq!(pcks.fmspc().unwrap(), cached_pcks.fmspc().unwrap());
+                assert_eq!(pcks, cached_pcks);
             }
+
+            // Second service call should return value from cache
+            let pcks_from_service = client
+                .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
+                .unwrap();
+
+            assert_eq!(pcks, pcks_from_service);
+            assert_eq!(pcks.fmspc().unwrap(), pcks_from_service.fmspc().unwrap());
         }
     }
 
     #[test]
     pub fn pck() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            if api_version == PcsVersion::V3 {
-                if let Some(pcs_api_key) = pcs_api_key() {
-                    intel_builder.set_api_key(pcs_api_key);
-                } else {
-                    // Intel SGX PCS version 3 is scheduled to end of life not later than October 31, 2025.
-                    // So we no longer force to test it.
-                    continue;
-                }
-            }
-            let client = intel_builder.build(reqwest_client());
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
-            {
-                let pck = client
-                    .pckcert(
-                        Some(&pckid.enc_ppid),
-                        &pckid.pce_id,
-                        &pckid.cpu_svn,
-                        pckid.pce_isvsvn,
-                        None,
-                    )
-                    .unwrap();
-                assert_eq!(
-                    test_helpers::get_cert_subject(pck.ca_chain().last().unwrap()),
-                    "Intel SGX Root CA"
-                );
-            }
+        let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT);
+
+        let client = intel_builder.build(reqwest_client());
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pck = client
+                .pckcert(
+                    Some(&pckid.enc_ppid),
+                    &pckid.pce_id,
+                    &pckid.cpu_svn,
+                    pckid.pce_isvsvn,
+                    None,
+                )
+                .unwrap();
+            assert_eq!(
+                test_helpers::get_cert_subject(pck.ca_chain().last().unwrap()),
+                "Intel SGX Root CA"
+            );
         }
     }
 
     #[test]
     pub fn pck_cached() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let root_ca = include_bytes!("../../tests/data/root_SGX_CA_der.cert");
-            let root_cas = [&root_ca[..]];
-            let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            if api_version == PcsVersion::V3 {
-                if let Some(pcs_api_key) = pcs_api_key() {
-                    intel_builder.set_api_key(pcs_api_key);
-                } else {
-                    // Intel SGX PCS version 3 is scheduled to end of life not later than October 31, 2025.
-                    // So we no longer force to test it.
-                    continue;
-                }
-            }
-            let client = intel_builder.build(reqwest_client());
-            let crl_processor = client
-                .pckcrl(DcapArtifactIssuer::PCKProcessorCA)
-                .unwrap()
-                .crl_as_pem()
-                .to_owned();
-            let crl_platform = client
-                .pckcrl(DcapArtifactIssuer::PCKPlatformCA)
-                .unwrap()
-                .crl_as_pem()
-                .to_owned();
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
+        let root_ca = include_bytes!("../../tests/data/root_SGX_CA_der.cert");
+        let root_cas = [&root_ca[..]];
+        let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT);
+
+        let client = intel_builder.build(reqwest_client());
+        let crl_processor = client
+            .pckcrl(DcapArtifactIssuer::PCKProcessorCA)
+            .unwrap()
+            .crl_as_pem()
+            .to_owned();
+        let crl_platform = client
+            .pckcrl(DcapArtifactIssuer::PCKPlatformCA)
+            .unwrap()
+            .crl_as_pem()
+            .to_owned();
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pck = client
+                .pckcert(
+                    Some(&pckid.enc_ppid),
+                    &pckid.pce_id,
+                    &pckid.cpu_svn,
+                    pckid.pce_isvsvn,
+                    None,
+                )
+                .unwrap();
+            let pck = pck
+                .clone()
+                .verify(&root_cas, Some(&crl_processor))
+                .or(pck.clone().verify(&root_cas, Some(&crl_platform)))
+                .unwrap();
+
+            // The cache should be populated after initial service call
             {
-                let pck = client
-                    .pckcert(
+                let mut cache = client.pckcert_service.cache.lock().unwrap();
+
+                assert!(cache.len() > 0);
+
+                let (cached_pck, _) = {
+                    let mut hasher = DefaultHasher::new();
+                    let input = client.pckcert_service.pcs_service().build_input(
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
                         pckid.pce_isvsvn,
                         None,
-                    )
-                    .unwrap();
-                let pck = pck
-                    .clone()
-                    .verify(&root_cas, Some(&crl_processor))
-                    .or(pck.clone().verify(&root_cas, Some(&crl_platform)))
-                    .unwrap();
-
-                // The cache should be populated after initial service call
-                {
-                    let mut cache = client.pckcert_service.cache.lock().unwrap();
-
-                    assert!(cache.len() > 0);
-
-                    let (cached_pck, _) = {
-                        let mut hasher = DefaultHasher::new();
-                        let input = client.pckcert_service.pcs_service().build_input(
-                            Some(&pckid.enc_ppid),
-                            &pckid.pce_id,
-                            &pckid.cpu_svn,
-                            pckid.pce_isvsvn,
-                            None,
-                        );
-                        input.hash(&mut hasher);
-
-                        cache
-                            .get_mut(&hasher.finish())
-                            .expect("Can't find key in cache")
-                            .to_owned()
-                    };
-
-                    assert_eq!(
-                        pck.fmspc().unwrap(),
-                        cached_pck
-                            .clone()
-                            .verify(&root_cas, None)
-                            .unwrap()
-                            .fmspc()
-                            .unwrap()
                     );
-                    assert_eq!(pck.ca_chain(), cached_pck.ca_chain());
-                }
+                    input.hash(&mut hasher);
 
-                // Second service call should return value from cache
-                let pck_from_service = client
-                    .pckcert(
-                        Some(&pckid.enc_ppid),
-                        &pckid.pce_id,
-                        &pckid.cpu_svn,
-                        pckid.pce_isvsvn,
-                        None,
-                    )
-                    .unwrap();
+                    cache
+                        .get_mut(&hasher.finish())
+                        .expect("Can't find key in cache")
+                        .to_owned()
+                };
 
                 assert_eq!(
                     pck.fmspc().unwrap(),
-                    pck_from_service
+                    cached_pck
                         .clone()
                         .verify(&root_cas, None)
                         .unwrap()
                         .fmspc()
                         .unwrap()
                 );
-                assert_eq!(pck.ca_chain(), pck_from_service.ca_chain());
+                assert_eq!(pck.ca_chain(), cached_pck.ca_chain());
             }
+
+            // Second service call should return value from cache
+            let pck_from_service = client
+                .pckcert(
+                    Some(&pckid.enc_ppid),
+                    &pckid.pce_id,
+                    &pckid.cpu_svn,
+                    pckid.pce_isvsvn,
+                    None,
+                )
+                .unwrap();
+
+            assert_eq!(
+                pck.fmspc().unwrap(),
+                pck_from_service
+                    .clone()
+                    .verify(&root_cas, None)
+                    .unwrap()
+                    .fmspc()
+                    .unwrap()
+            );
+            assert_eq!(pck.ca_chain(), pck_from_service.ca_chain());
         }
     }
 
     #[test]
     pub fn tcb_info() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            if api_version == PcsVersion::V3 {
-                if let Some(pcs_api_key) = pcs_api_key() {
-                    intel_builder.set_api_key(pcs_api_key);
-                } else {
-                    // Intel SGX PCS version 3 is scheduled to end of life not later than October 31, 2025.
-                    // So we no longer force to test it.
-                    continue;
-                }
-            }
-            let client = intel_builder.build(reqwest_client());
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
-            {
-                let pckcerts = client
-                    .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
-                    .unwrap();
-                assert!(client
-                    .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
-                    .and_then(|tcb| {
-                        Ok(tcb
-                            .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
-                            .unwrap())
-                    })
-                    .is_ok());
-            }
+        let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT);
+
+        let client = intel_builder.build(reqwest_client());
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pckcerts = client
+                .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
+                .unwrap();
+            assert!(client
+                .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
+                .and_then(|tcb| {
+                    Ok(tcb
+                        .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
+                        .unwrap())
+                })
+                .is_ok());
         }
     }
 
@@ -1054,57 +997,47 @@ mod tests {
 
     #[test]
     pub fn tcb_info_cached() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            if api_version == PcsVersion::V3 {
-                if let Some(pcs_api_key) = pcs_api_key() {
-                    intel_builder.set_api_key(pcs_api_key);
-                } else {
-                    // Intel SGX PCS version 3 is scheduled to end of life not later than October 31, 2025.
-                    // So we no longer force to test it.
-                    continue;
-                }
-            }
-            let client = intel_builder.build(reqwest_client());
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
+        let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT);
+
+        let client = intel_builder.build(reqwest_client());
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pckcerts = client
+                .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
+                .unwrap();
+            let fmspc = pckcerts.fmspc().unwrap();
+            let tcb_info = client.sgx_tcbinfo(&fmspc, None).unwrap();
+
+            // The cache should be populated after initial service call
             {
-                let pckcerts = client
-                    .pckcerts(&pckid.enc_ppid, pckid.pce_id.clone())
-                    .unwrap();
-                let fmspc = pckcerts.fmspc().unwrap();
-                let tcb_info = client.sgx_tcbinfo(&fmspc, None).unwrap();
+                let mut cache = client.sgx_tcbinfo_service.cache.lock().unwrap();
 
-                // The cache should be populated after initial service call
-                {
-                    let mut cache = client.sgx_tcbinfo_service.cache.lock().unwrap();
+                assert!(cache.len() > 0);
 
-                    assert!(cache.len() > 0);
+                let (cached_tcb_info, _) = {
+                    let mut hasher = DefaultHasher::new();
+                    let input = client
+                        .sgx_tcbinfo_service
+                        .pcs_service()
+                        .build_input(&fmspc, None);
+                    input.hash(&mut hasher);
 
-                    let (cached_tcb_info, _) = {
-                        let mut hasher = DefaultHasher::new();
-                        let input = client
-                            .sgx_tcbinfo_service
-                            .pcs_service()
-                            .build_input(&fmspc, None);
-                        input.hash(&mut hasher);
+                    cache
+                        .get_mut(&hasher.finish())
+                        .expect("Can't find key in cache")
+                        .to_owned()
+                };
 
-                        cache
-                            .get_mut(&hasher.finish())
-                            .expect("Can't find key in cache")
-                            .to_owned()
-                    };
-
-                    assert_eq!(tcb_info, cached_tcb_info);
-                }
-
-                // Second service call should return value from cache
-                let tcb_info_from_service = client.sgx_tcbinfo(&fmspc, None).unwrap();
-
-                assert_eq!(tcb_info, tcb_info_from_service);
+                assert_eq!(tcb_info, cached_tcb_info);
             }
+
+            // Second service call should return value from cache
+            let tcb_info_from_service = client.sgx_tcbinfo(&fmspc, None).unwrap();
+
+            assert_eq!(tcb_info, tcb_info_from_service);
         }
     }
 
@@ -1114,28 +1047,18 @@ mod tests {
             DcapArtifactIssuer::PCKProcessorCA,
             DcapArtifactIssuer::PCKPlatformCA,
         ] {
-            for api_version in [PcsVersion::V3, PcsVersion::V4] {
-                let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
-                    .set_retry_timeout(TIME_RETRY_TIMEOUT);
-                if api_version == PcsVersion::V3 {
-                    if let Some(pcs_api_key) = pcs_api_key() {
-                        intel_builder.set_api_key(pcs_api_key);
-                    } else {
-                        // Intel SGX PCS version 3 is scheduled to end of life not later than October 31, 2025.
-                        // So we no longer force to test it.
-                        continue;
-                    }
-                }
-                let client = intel_builder.build(reqwest_client());
-                assert!(client
-                    .pckcrl(ca)
-                    .and_then(|crl| {
-                        Ok(crl
-                            .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
-                            .unwrap())
-                    })
-                    .is_ok());
-            }
+            let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+                .set_retry_timeout(TIME_RETRY_TIMEOUT);
+
+            let client = intel_builder.build(reqwest_client());
+            assert!(client
+                .pckcrl(ca)
+                .and_then(|crl| {
+                    Ok(crl
+                        .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
+                        .unwrap())
+                })
+                .is_ok());
         }
     }
 
@@ -1145,97 +1068,21 @@ mod tests {
             DcapArtifactIssuer::PCKProcessorCA,
             DcapArtifactIssuer::PCKPlatformCA,
         ] {
-            for api_version in [PcsVersion::V3, PcsVersion::V4] {
-                let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
-                    .set_retry_timeout(TIME_RETRY_TIMEOUT);
-                if api_version == PcsVersion::V3 {
-                    if let Some(pcs_api_key) = pcs_api_key() {
-                        intel_builder.set_api_key(pcs_api_key);
-                    } else {
-                        // Intel SGX PCS version 3 is scheduled to end of life not later than October 31, 2025.
-                        // So we no longer force to test it.
-                        continue;
-                    }
-                }
-                let client = intel_builder.build(reqwest_client());
-                let pckcrl = client.pckcrl(ca).unwrap();
-
-                // The cache should be populated after initial service call
-                {
-                    let mut cache = client.pckcrl_service.cache.lock().unwrap();
-
-                    assert!(cache.len() > 0);
-
-                    let (cached_pckcrl, _) = {
-                        let mut hasher = DefaultHasher::new();
-                        let input = client.pckcrl_service.pcs_service().build_input(ca);
-                        input.hash(&mut hasher);
-
-                        cache
-                            .get_mut(&hasher.finish())
-                            .expect("Can't find key in cache")
-                            .to_owned()
-                    };
-
-                    assert_eq!(pckcrl, cached_pckcrl);
-                }
-
-                // Second service call should return value from cache
-                let pckcrl_from_service = client.pckcrl(ca).unwrap();
-
-                assert_eq!(pckcrl, pckcrl_from_service);
-            }
-        }
-    }
-
-    #[test]
-    pub fn qe_identity() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
+            let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
                 .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            if api_version == PcsVersion::V3 {
-                if let Some(pcs_api_key) = pcs_api_key() {
-                    intel_builder.set_api_key(pcs_api_key);
-                } else {
-                    // Intel SGX PCS version 3 is scheduled to end of life not later than October 31, 2025.
-                    // So we no longer force to test it.
-                    continue;
-                }
-            }
-            let client = intel_builder.build(reqwest_client());
-            let qe_id = client.qe_identity(None).unwrap();
-            assert!(qe_id
-                .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
-                .is_ok());
-        }
-    }
 
-    #[test]
-    pub fn qe_identity_cached() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let mut intel_builder = IntelProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            if api_version == PcsVersion::V3 {
-                if let Some(pcs_api_key) = pcs_api_key() {
-                    intel_builder.set_api_key(pcs_api_key);
-                } else {
-                    // Intel SGX PCS version 3 is scheduled to end of life not later than October 31, 2025.
-                    // So we no longer force to test it.
-                    continue;
-                }
-            }
             let client = intel_builder.build(reqwest_client());
-            let qe_id = client.qe_identity(None).unwrap();
+            let pckcrl = client.pckcrl(ca).unwrap();
 
             // The cache should be populated after initial service call
             {
-                let mut cache = client.qeid_service.cache.lock().unwrap();
+                let mut cache = client.pckcrl_service.cache.lock().unwrap();
 
                 assert!(cache.len() > 0);
 
-                let (cached_qeid, _) = {
+                let (cached_pckcrl, _) = {
                     let mut hasher = DefaultHasher::new();
-                    let input = client.qeid_service.pcs_service().build_input(None);
+                    let input = client.pckcrl_service.pcs_service().build_input(ca);
                     input.hash(&mut hasher);
 
                     cache
@@ -1244,26 +1091,76 @@ mod tests {
                         .to_owned()
                 };
 
-                assert_eq!(qe_id, cached_qeid);
+                assert_eq!(pckcrl, cached_pckcrl);
             }
 
             // Second service call should return value from cache
-            let qeid_from_service = client.qe_identity(None).unwrap();
+            let pckcrl_from_service = client.pckcrl(ca).unwrap();
 
-            assert_eq!(qe_id, qeid_from_service);
+            assert_eq!(pckcrl, pckcrl_from_service);
         }
     }
 
     #[test]
-    pub fn gone_artifacts() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let intel_builder = IntelProvisioningClientBuilder::new(api_version)
-                .set_retry_timeout(TIME_RETRY_TIMEOUT);
-            let client = intel_builder.build(reqwest_client());
-            let fmspc = Fmspc::try_from("90806f000000").unwrap();
-            assert_matches!(client.qe_identity(Some(15)), Err(Error::PCSError(StatusCode::Gone, _)));
-            assert_matches!(client.sgx_tcbinfo(&fmspc, Some(15)), Err(Error::PCSError(StatusCode::Gone, _)));
+    pub fn qe_identity() {
+        let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT);
+
+        let client = intel_builder.build(reqwest_client());
+        let qe_id = client.qe_identity(None).unwrap();
+        assert!(qe_id
+            .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
+            .is_ok());
+    }
+
+    #[test]
+    pub fn qe_identity_cached() {
+        let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT);
+
+        let client = intel_builder.build(reqwest_client());
+        let qe_id = client.qe_identity(None).unwrap();
+
+        // The cache should be populated after initial service call
+        {
+            let mut cache = client.qeid_service.cache.lock().unwrap();
+
+            assert!(cache.len() > 0);
+
+            let (cached_qeid, _) = {
+                let mut hasher = DefaultHasher::new();
+                let input = client.qeid_service.pcs_service().build_input(None);
+                input.hash(&mut hasher);
+
+                cache
+                    .get_mut(&hasher.finish())
+                    .expect("Can't find key in cache")
+                    .to_owned()
+            };
+
+            assert_eq!(qe_id, cached_qeid);
         }
+
+        // Second service call should return value from cache
+        let qeid_from_service = client.qe_identity(None).unwrap();
+
+        assert_eq!(qe_id, qeid_from_service);
+    }
+
+    #[test]
+    pub fn gone_artifacts() {
+        let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+            .set_retry_timeout(TIME_RETRY_TIMEOUT);
+        let client = intel_builder.build(reqwest_client());
+        let fmspc = Fmspc::try_from("90806f000000").unwrap();
+        assert_matches!(
+            client.qe_identity(Some(15)),
+            Err(Error::PCSError(StatusCode::Gone, _))
+        );
+        assert_matches!(
+            client.sgx_tcbinfo(&fmspc, Some(15)),
+            Err(Error::PCSError(StatusCode::Gone, _))
+        );
     }
 
     fn tcb_evaluation_data_numbers_test_base<T: PartialEq>()
@@ -1323,8 +1220,7 @@ mod tests {
 
     #[test]
     pub fn root_ca_crl() {
-
-        let mut intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
+        let intel_builder = IntelProvisioningClientBuilder::new(PcsVersion::V4)
             .set_retry_timeout(TIME_RETRY_TIMEOUT);
 
         let client = intel_builder.build(reqwest_client());

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/mod.rs
@@ -15,7 +15,9 @@ use std::time::{Duration, SystemTime};
 use lru_cache::LruCache;
 use num_enum::TryFromPrimitive;
 use pcs::{
-    platform, CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts, PckCrl, PckID, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers, RootCaCrl, TcbComponentType, TcbInfo, Unverified
+    platform, CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCerts,
+    PckCrl, PckID, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RawTcbEvaluationDataNumbers,
+    RootCaCrl, TcbComponentType, TcbInfo, Unverified,
 };
 #[cfg(feature = "reqwest")]
 use reqwest::blocking::{Client as ReqwestClient, Response as ReqwestResponse};
@@ -119,6 +121,9 @@ pub enum StatusCode {
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum PcsVersion {
+    #[deprecated(
+        note = "As of May 13, Intel has completed the End-of-Life of the deprecated API versions 2 and 3 of Intel PCS."
+    )]
     V3 = 3,
     V4 = 4,
 }
@@ -218,7 +223,10 @@ impl WithApiVersion for PckCrlIn {
 pub trait PckCrlService<'inp>:
     ProvisioningServiceApi<'inp, Input = PckCrlIn, Output = PckCrl<Unverified>>
 {
-    fn build_input(&'inp self, ca: DcapArtifactIssuer) -> <Self as ProvisioningServiceApi<'inp>>::Input;
+    fn build_input(
+        &'inp self,
+        ca: DcapArtifactIssuer,
+    ) -> <Self as ProvisioningServiceApi<'inp>>::Input;
 }
 
 #[derive(Hash)]
@@ -236,7 +244,10 @@ impl WithApiVersion for QeIdIn {
 pub trait QeIdService<'inp>:
     ProvisioningServiceApi<'inp, Input = QeIdIn, Output = QeIdentitySigned>
 {
-    fn build_input(&'inp self, tcb_evaluation_data_number: Option<u16>) -> <Self as ProvisioningServiceApi<'inp>>::Input;
+    fn build_input(
+        &'inp self,
+        tcb_evaluation_data_number: Option<u16>,
+    ) -> <Self as ProvisioningServiceApi<'inp>>::Input;
 }
 
 #[derive(Hash)]
@@ -255,8 +266,11 @@ impl WithApiVersion for TcbInfoIn<'_> {
 pub trait TcbInfoService<'inp, T: PlatformTypeForTcbInfo>:
     ProvisioningServiceApi<'inp, Input = TcbInfoIn<'inp>, Output = TcbInfo<T>>
 {
-    fn build_input(&'inp self, fmspc: &'inp Fmspc, tcb_evaluation_data_number: Option<u16>)
-        -> <Self as ProvisioningServiceApi<'inp>>::Input;
+    fn build_input(
+        &'inp self,
+        fmspc: &'inp Fmspc,
+        tcb_evaluation_data_number: Option<u16>,
+    ) -> <Self as ProvisioningServiceApi<'inp>>::Input;
 }
 
 #[derive(Hash)]
@@ -269,10 +283,13 @@ impl WithApiVersion for TcbEvaluationDataNumbersIn {
 }
 
 pub trait TcbEvaluationDataNumbersService<'inp, T: PlatformTypeForTcbInfo>:
-    ProvisioningServiceApi<'inp, Input = TcbEvaluationDataNumbersIn, Output = RawTcbEvaluationDataNumbers<T>>
+    ProvisioningServiceApi<
+    'inp,
+    Input = TcbEvaluationDataNumbersIn,
+    Output = RawTcbEvaluationDataNumbers<T>,
+>
 {
-    fn build_input(&self)
-        -> <Self as ProvisioningServiceApi<'inp>>::Input;
+    fn build_input(&self) -> <Self as ProvisioningServiceApi<'inp>>::Input;
 }
 
 #[derive(Hash)]
@@ -509,11 +526,24 @@ pub struct Client<F: for<'a> Fetcher<'a>> {
         CachedService<PckCert<Unverified>, dyn for<'a> PckCertService<'a> + Sync + Send>,
     pckcrl_service: CachedService<PckCrl<Unverified>, dyn for<'a> PckCrlService<'a> + Sync + Send>,
     qeid_service: CachedService<QeIdentitySigned, dyn for<'a> QeIdService<'a> + Sync + Send>,
-    sgx_tcbinfo_service: CachedService<TcbInfo<platform::SGX>, dyn for<'a> TcbInfoService<'a, platform::SGX> + Sync + Send>,
-    tdx_tcbinfo_service: CachedService<TcbInfo<platform::TDX>, dyn for<'a> TcbInfoService<'a, platform::TDX> + Sync + Send>,
-    sgx_tcb_evaluation_data_numbers_service: CachedService<RawTcbEvaluationDataNumbers<platform::SGX>, dyn for<'a> TcbEvaluationDataNumbersService<'a, platform::SGX> + Sync + Send>,
-    tdx_tcb_evaluation_data_numbers_service: CachedService<RawTcbEvaluationDataNumbers<platform::TDX>, dyn for<'a> TcbEvaluationDataNumbersService<'a, platform::TDX> + Sync + Send>,
-    root_ca_crl_service: CachedService<RootCaCrl<Unverified>, dyn for<'a> RootCaCrlService<'a> + Sync + Send>,
+    sgx_tcbinfo_service: CachedService<
+        TcbInfo<platform::SGX>,
+        dyn for<'a> TcbInfoService<'a, platform::SGX> + Sync + Send,
+    >,
+    tdx_tcbinfo_service: CachedService<
+        TcbInfo<platform::TDX>,
+        dyn for<'a> TcbInfoService<'a, platform::TDX> + Sync + Send,
+    >,
+    sgx_tcb_evaluation_data_numbers_service: CachedService<
+        RawTcbEvaluationDataNumbers<platform::SGX>,
+        dyn for<'a> TcbEvaluationDataNumbersService<'a, platform::SGX> + Sync + Send,
+    >,
+    tdx_tcb_evaluation_data_numbers_service: CachedService<
+        RawTcbEvaluationDataNumbers<platform::TDX>,
+        dyn for<'a> TcbEvaluationDataNumbersService<'a, platform::TDX> + Sync + Send,
+    >,
+    root_ca_crl_service:
+        CachedService<RootCaCrl<Unverified>, dyn for<'a> RootCaCrlService<'a> + Sync + Send>,
     fetcher: F,
 }
 
@@ -634,9 +664,17 @@ pub trait ProvisioningClient {
         qe_id: Option<&QeId>,
     ) -> Result<PckCert<Unverified>, Error>;
 
-    fn sgx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error>;
+    fn sgx_tcbinfo(
+        &self,
+        fmspc: &Fmspc,
+        evaluation_data_number: Option<u16>,
+    ) -> Result<TcbInfo<platform::SGX>, Error>;
 
-    fn tdx_tcbinfo(&self, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error>;
+    fn tdx_tcbinfo(
+        &self,
+        fmspc: &Fmspc,
+        evaluation_data_number: Option<u16>,
+    ) -> Result<TcbInfo<platform::TDX>, Error>;
 
     fn pckcrl(&self, ca: DcapArtifactIssuer) -> Result<PckCrl<Unverified>, Error>;
 
@@ -657,7 +695,10 @@ pub trait ProvisioningClient {
     ///
     /// Note that PCK certs for some TCB levels may be missing.
     fn pckcerts_with_fallback(&self, pck_id: &PckID) -> Result<PckCerts, Error> {
-        let get_and_collect = |collection: &mut BTreeMap<([u8; 16], u16), PckCert<Unverified>>, cpu_svn: &[u8; 16], pce_svn: u16| -> Result<PckCert<Unverified>, Error> {
+        let get_and_collect = |collection: &mut BTreeMap<([u8; 16], u16), PckCert<Unverified>>,
+                               cpu_svn: &[u8; 16],
+                               pce_svn: u16|
+         -> Result<PckCert<Unverified>, Error> {
             let pck_cert = self.pckcert(
                 Some(&pck_id.enc_ppid),
                 &pck_id.pce_id,
@@ -668,7 +709,10 @@ pub trait ProvisioningClient {
 
             // Getting PCK cert using CPUSVN from PCKID
             let ptcb = pck_cert.platform_tcb()?;
-            collection.insert((ptcb.cpusvn, ptcb.tcb_components.pce_svn()), pck_cert.clone());
+            collection.insert(
+                (ptcb.cpusvn, ptcb.tcb_components.pce_svn()),
+                pck_cert.clone(),
+            );
             Ok(pck_cert)
         };
 
@@ -699,9 +743,12 @@ pub trait ProvisioningClient {
             //    also try with highest microcode version of both components. We found cases where
             //    fetching the PCK Cert that exactly matched the TCB level, did not result in a PCK
             //    Cert for that level
-            let early_ucode_idx = tcb_data.tcb_component_index(TcbComponentType::EarlyMicrocodeUpdate);
-            let late_ucode_idx = tcb_data.tcb_component_index(TcbComponentType::LateMicrocodeUpdate);
-            if let (Some(early_ucode_idx), Some(late_ucode_idx)) = (early_ucode_idx, late_ucode_idx) {
+            let early_ucode_idx =
+                tcb_data.tcb_component_index(TcbComponentType::EarlyMicrocodeUpdate);
+            let late_ucode_idx =
+                tcb_data.tcb_component_index(TcbComponentType::LateMicrocodeUpdate);
+            if let (Some(early_ucode_idx), Some(late_ucode_idx)) = (early_ucode_idx, late_ucode_idx)
+            {
                 let early_ucode = cpu_svn[early_ucode_idx];
                 let late_ucode = cpu_svn[late_ucode_idx];
                 if early_ucode < late_ucode {
@@ -719,39 +766,59 @@ pub trait ProvisioningClient {
             .map_err(|e| Error::PCSDecodeError(format!("{}", e).into()))
     }
 
-    fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error>;
+    fn sgx_tcb_evaluation_data_numbers(
+        &self,
+    ) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error>;
 
-    fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error>;
+    fn tdx_tcb_evaluation_data_numbers(
+        &self,
+    ) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error>;
 
     fn root_ca_crl(&self) -> Result<RootCaCrl<Unverified>, Error>;
 }
 
-
 pub trait ProvisioningClientFuncSelector: PlatformTypeForTcbInfo {
-    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<Self>, Error>;
-    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<Self>, Error>;
+    fn get_tcb_evaluation_data_numbers(
+        pc: &dyn ProvisioningClient,
+    ) -> Result<RawTcbEvaluationDataNumbers<Self>, Error>;
+    fn get_tcbinfo(
+        pc: &dyn ProvisioningClient,
+        fmspc: &Fmspc,
+        evaluation_data_number: Option<u16>,
+    ) -> Result<TcbInfo<Self>, Error>;
 }
 
 impl ProvisioningClientFuncSelector for platform::SGX {
-    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
+    fn get_tcb_evaluation_data_numbers(
+        pc: &dyn ProvisioningClient,
+    ) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
         pc.sgx_tcb_evaluation_data_numbers()
     }
 
-    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
+    fn get_tcbinfo(
+        pc: &dyn ProvisioningClient,
+        fmspc: &Fmspc,
+        evaluation_data_number: Option<u16>,
+    ) -> Result<TcbInfo<platform::SGX>, Error> {
         pc.sgx_tcbinfo(fmspc, evaluation_data_number)
     }
 }
 
 impl ProvisioningClientFuncSelector for platform::TDX {
-    fn get_tcb_evaluation_data_numbers(pc: &dyn ProvisioningClient) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
+    fn get_tcb_evaluation_data_numbers(
+        pc: &dyn ProvisioningClient,
+    ) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
         pc.tdx_tcb_evaluation_data_numbers()
     }
 
-    fn get_tcbinfo(pc: &dyn ProvisioningClient, fmspc: &Fmspc, evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
+    fn get_tcbinfo(
+        pc: &dyn ProvisioningClient,
+        fmspc: &Fmspc,
+        evaluation_data_number: Option<u16>,
+    ) -> Result<TcbInfo<platform::TDX>, Error> {
         pc.tdx_tcbinfo(fmspc, evaluation_data_number)
     }
 }
-
 
 impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F> {
     fn pckcerts(&self, encrypted_ppid: &EncPpid, pce_id: PceId) -> Result<PckCerts, Error> {
@@ -780,13 +847,27 @@ impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F> {
         self.pckcert_service.call_service(&self.fetcher, &input)
     }
 
-    fn sgx_tcbinfo(&self, fmspc: &Fmspc, tcb_evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::SGX>, Error> {
-        let input = self.sgx_tcbinfo_service.pcs_service().build_input(fmspc, tcb_evaluation_data_number);
+    fn sgx_tcbinfo(
+        &self,
+        fmspc: &Fmspc,
+        tcb_evaluation_data_number: Option<u16>,
+    ) -> Result<TcbInfo<platform::SGX>, Error> {
+        let input = self
+            .sgx_tcbinfo_service
+            .pcs_service()
+            .build_input(fmspc, tcb_evaluation_data_number);
         self.sgx_tcbinfo_service.call_service(&self.fetcher, &input)
     }
 
-    fn tdx_tcbinfo(&self, fmspc: &Fmspc, tcb_evaluation_data_number: Option<u16>) -> Result<TcbInfo<platform::TDX>, Error> {
-        let input = self.tdx_tcbinfo_service.pcs_service().build_input(fmspc, tcb_evaluation_data_number);
+    fn tdx_tcbinfo(
+        &self,
+        fmspc: &Fmspc,
+        tcb_evaluation_data_number: Option<u16>,
+    ) -> Result<TcbInfo<platform::TDX>, Error> {
+        let input = self
+            .tdx_tcbinfo_service
+            .pcs_service()
+            .build_input(fmspc, tcb_evaluation_data_number);
         self.tdx_tcbinfo_service.call_service(&self.fetcher, &input)
     }
 
@@ -795,20 +876,37 @@ impl<F: for<'a> Fetcher<'a>> ProvisioningClient for Client<F> {
         self.pckcrl_service.call_service(&self.fetcher, &input)
     }
 
-    fn qe_identity(&self, tcb_evaluation_data_number: Option<u16>) -> Result<QeIdentitySigned, Error> {
-        let input = self.qeid_service.pcs_service().build_input(tcb_evaluation_data_number);
+    fn qe_identity(
+        &self,
+        tcb_evaluation_data_number: Option<u16>,
+    ) -> Result<QeIdentitySigned, Error> {
+        let input = self
+            .qeid_service
+            .pcs_service()
+            .build_input(tcb_evaluation_data_number);
         self.qeid_service.call_service(&self.fetcher, &input)
     }
 
-    fn sgx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
-        let input = self.sgx_tcb_evaluation_data_numbers_service.pcs_service().build_input();
-        self.sgx_tcb_evaluation_data_numbers_service.call_service(&self.fetcher, &input)
+    fn sgx_tcb_evaluation_data_numbers(
+        &self,
+    ) -> Result<RawTcbEvaluationDataNumbers<platform::SGX>, Error> {
+        let input = self
+            .sgx_tcb_evaluation_data_numbers_service
+            .pcs_service()
+            .build_input();
+        self.sgx_tcb_evaluation_data_numbers_service
+            .call_service(&self.fetcher, &input)
     }
 
-    fn tdx_tcb_evaluation_data_numbers(&self) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
-        let input = self.tdx_tcb_evaluation_data_numbers_service.pcs_service().build_input();
-        self.tdx_tcb_evaluation_data_numbers_service.call_service(&self.fetcher, &input)
-
+    fn tdx_tcb_evaluation_data_numbers(
+        &self,
+    ) -> Result<RawTcbEvaluationDataNumbers<platform::TDX>, Error> {
+        let input = self
+            .tdx_tcb_evaluation_data_numbers_service
+            .pcs_service()
+            .build_input();
+        self.tdx_tcb_evaluation_data_numbers_service
+            .call_service(&self.fetcher, &input)
     }
 
     fn root_ca_crl(&self) -> Result<RootCaCrl<Unverified>, Error> {
@@ -942,7 +1040,7 @@ mod tests {
 
     impl WithApiVersion for MockInput {
         fn api_version(&self) -> PcsVersion {
-            PcsVersion::V3
+            PcsVersion::V4
         }
     }
 

--- a/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
+++ b/intel-sgx/dcap-artifact-retrieval/src/provisioning_client/pccs.rs
@@ -15,19 +15,19 @@ use std::marker::PhantomData;
 use std::num::ParseIntError;
 use std::time::Duration;
 
-
 use pcs::{
-    platform, CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCrl, PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RootCaCrl, TcbInfo, Unverified
+    platform, CpuSvn, DcapArtifactIssuer, EncPpid, Fmspc, PceId, PceIsvsvn, PckCert, PckCrl,
+    PlatformType, PlatformTypeForTcbInfo, QeId, QeIdentitySigned, RootCaCrl, TcbInfo, Unverified,
 };
 use rustc_serialize::hex::{FromHex, ToHex};
 
+use super::intel::TcbEvaluationDataNumbersApi;
 use super::{common::*, RootCaCrlIn, RootCaCrlService};
 use super::{
     Client, ClientBuilder, Fetcher, PckCertIn, PckCertService, PckCrlIn, PckCrlService, PcsVersion,
     ProvisioningServiceApi, QeIdIn, QeIdService, StatusCode, TcbInfoIn, TcbInfoService,
 };
-use super::intel::TcbEvaluationDataNumbersApi;
-use crate::{Error, provisioning_client::PlatformApiTag};
+use crate::{provisioning_client::PlatformApiTag, Error};
 
 pub struct PccsProvisioningClientBuilder {
     base_url: Cow<'static, str>,
@@ -60,8 +60,18 @@ impl PccsProvisioningClientBuilder {
         let tdx_evaluation_data_numbers = TcbEvaluationDataNumbersApi::new(self.base_url.clone());
         let root_ca_crl = RootCaCrlApi::new(self.base_url.clone());
 
-        self.client_builder
-            .build(pck_certs, pck_cert, pck_crl, qeid, sgx_tcbinfo, tdx_tcbinfo, sgx_evaluation_data_numbers, tdx_evaluation_data_numbers, root_ca_crl, fetcher)
+        self.client_builder.build(
+            pck_certs,
+            pck_cert,
+            pck_crl,
+            qeid,
+            sgx_tcbinfo,
+            tdx_tcbinfo,
+            sgx_evaluation_data_numbers,
+            tdx_evaluation_data_numbers,
+            root_ca_crl,
+            fetcher,
+        )
     }
 }
 
@@ -189,7 +199,10 @@ impl PckCrlApi {
 }
 
 impl<'inp> PckCrlService<'inp> for PckCrlApi {
-    fn build_input(&'inp self, ca: DcapArtifactIssuer) -> <Self as ProvisioningServiceApi<'inp>>::Input {
+    fn build_input(
+        &'inp self,
+        ca: DcapArtifactIssuer,
+    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
         PckCrlIn {
             api_version: self.api_version,
             ca,
@@ -209,8 +222,11 @@ impl<'inp> ProvisioningServiceApi<'inp> for PckCrlApi {
             DcapArtifactIssuer::PCKProcessorCA => "processor",
             DcapArtifactIssuer::PCKPlatformCA => "platform",
             DcapArtifactIssuer::SGXRootCA => {
-                return Err(Error::PCSError(StatusCode::BadRequest, "Invalid ca parameter"));
-            },
+                return Err(Error::PCSError(
+                    StatusCode::BadRequest,
+                    "Invalid ca parameter",
+                ));
+            }
         };
         let url = format!(
             "{}/sgx/certification/v{}/pckcrl?ca={}",
@@ -263,7 +279,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for PckCrlApi {
 pub struct TcbInfoApi<T> {
     base_url: Cow<'static, str>,
     api_version: PcsVersion,
-    type_: PhantomData<T>
+    type_: PhantomData<T>,
 }
 
 impl<T: PlatformType> TcbInfoApi<T> {
@@ -271,7 +287,7 @@ impl<T: PlatformType> TcbInfoApi<T> {
         TcbInfoApi {
             base_url,
             api_version,
-            type_: PhantomData
+            type_: PhantomData,
         }
     }
 }
@@ -293,7 +309,9 @@ impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> TcbInfoService<'inp, T> f
 /// Implementation of Get TCB Info API (section 3.3 of [reference]).
 ///
 /// [reference]: <https://download.01.org/intel-sgx/sgx-dcap/1.22/linux/docs/SGX_DCAP_Caching_Service_Design_Guide.pdf>
-impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi<'inp> for TcbInfoApi<T> {
+impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi<'inp>
+    for TcbInfoApi<T>
+{
     type Input = TcbInfoIn<'inp>;
     type Output = TcbInfo<T>;
 
@@ -303,11 +321,19 @@ impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi<'i
         let url = if let Some(evaluation_data_number) = input.tcb_evaluation_data_number {
             format!(
                 "{}/{}/certification/v{}/tcb?fmspc={}&tcbEvaluationDataNumber={}",
-                self.base_url, T::tag(), api_version, fmspc, evaluation_data_number)
+                self.base_url,
+                T::tag(),
+                api_version,
+                fmspc,
+                evaluation_data_number
+            )
         } else {
             format!(
                 "{}/{}/certification/v{}/tcb?fmspc={}&update=early",
-                self.base_url, T::tag(), api_version, fmspc,
+                self.base_url,
+                T::tag(),
+                api_version,
+                fmspc,
             )
         };
         Ok((url, Vec::new()))
@@ -338,6 +364,7 @@ impl<'inp, T: PlatformTypeForTcbInfo + PlatformApiTag> ProvisioningServiceApi<'i
         }
     }
 
+    #[allow(deprecated)]
     fn parse_response(
         &self,
         response_body: String,
@@ -368,7 +395,10 @@ impl QeIdApi {
 }
 
 impl<'inp> QeIdService<'inp> for QeIdApi {
-    fn build_input(&'inp self, tcb_evaluation_data_number: Option<u16>) -> <Self as ProvisioningServiceApi<'inp>>::Input {
+    fn build_input(
+        &'inp self,
+        tcb_evaluation_data_number: Option<u16>,
+    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
         QeIdIn {
             api_version: self.api_version,
             tcb_evaluation_data_number,
@@ -439,16 +469,12 @@ pub struct RootCaCrlApi {
 
 impl RootCaCrlApi {
     pub fn new(base_url: Cow<'static, str>) -> Self {
-        RootCaCrlApi {
-            base_url
-        }
+        RootCaCrlApi { base_url }
     }
 }
 
 impl<'inp> RootCaCrlService<'inp> for RootCaCrlApi {
-    fn build_input(
-        &'inp self
-    ) -> <Self as ProvisioningServiceApi<'inp>>::Input {
+    fn build_input(&'inp self) -> <Self as ProvisioningServiceApi<'inp>>::Input {
         RootCaCrlIn
     }
 }
@@ -457,7 +483,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for RootCaCrlApi {
     type Input = RootCaCrlIn;
     type Output = RootCaCrl<Unverified>;
 
-    fn build_request(&self, input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
+    fn build_request(&self, _input: &Self::Input) -> Result<(String, Vec<(String, String)>), Error> {
         let url = format!("{}/sgx/certification/v4/rootcacrl", self.base_url);
         Ok((url, Vec::new()))
     }
@@ -491,7 +517,7 @@ impl<'inp> ProvisioningServiceApi<'inp> for RootCaCrlApi {
     fn parse_response(
         &self,
         response_body: String,
-        response_headers: Vec<(String, String)>,
+        _response_headers: Vec<(String, String)>,
         _api_version: PcsVersion,
     ) -> Result<Self::Output, Error> {
         pub fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
@@ -501,7 +527,8 @@ impl<'inp> ProvisioningServiceApi<'inp> for RootCaCrlApi {
                 .collect()
         }
 
-        let der = decode_hex(&response_body).map_err(|_| Error::ReadResponseError(Cow::Borrowed("Cannot parse CRL repsonse")))?;
+        let der = decode_hex(&response_body)
+            .map_err(|_| Error::ReadResponseError(Cow::Borrowed("Cannot parse CRL repsonse")))?;
         RootCaCrl::new(&der).map_err(|e| Error::ReadResponseError(Cow::Owned(e.to_string().into())))
     }
 }
@@ -516,7 +543,8 @@ mod tests {
     use std::time::Duration;
 
     use pcs::{
-        EnclaveIdentity, Fmspc, PckID, RawTcbEvaluationDataNumbers, TcbEvaluationDataNumbers, WriteOptionsBuilder, platform
+        platform, EnclaveIdentity, Fmspc, PckID, RawTcbEvaluationDataNumbers,
+        TcbEvaluationDataNumbers, WriteOptionsBuilder,
     };
 
     use super::Client;
@@ -541,37 +569,35 @@ mod tests {
         url
     }
 
-    fn make_client(api_version: PcsVersion) -> Client<ReqwestClient> {
+    fn make_client() -> Client<ReqwestClient> {
         let url = &*PCCS_URL.get_or_init(pccs_url_from_env);
-        PccsProvisioningClientBuilder::new(api_version, url)
+        PccsProvisioningClientBuilder::new(PcsVersion::V4, url)
             .set_retry_timeout(TIME_RETRY_TIMEOUT)
             .build(reqwest_client_insecure_tls())
     }
 
     #[test]
     pub fn pck() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = make_client(api_version);
+        let client = make_client();
 
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
-            {
-                let pck = client
-                    .pckcert(
-                        Some(&pckid.enc_ppid),
-                        &pckid.pce_id,
-                        &pckid.cpu_svn,
-                        pckid.pce_isvsvn,
-                        Some(&pckid.qe_id),
-                    )
-                    .unwrap();
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pck = client
+                .pckcert(
+                    Some(&pckid.enc_ppid),
+                    &pckid.pce_id,
+                    &pckid.cpu_svn,
+                    pckid.pce_isvsvn,
+                    Some(&pckid.qe_id),
+                )
+                .unwrap();
 
-                assert_eq!(
-                    test_helpers::get_cert_subject(pck.ca_chain().last().unwrap()),
-                    "Intel SGX Root CA"
-                );
-            }
+            assert_eq!(
+                test_helpers::get_cert_subject(pck.ca_chain().last().unwrap()),
+                "Intel SGX Root CA"
+            );
         }
     }
 
@@ -579,145 +605,144 @@ mod tests {
     pub fn pck_cached() {
         let root_ca = include_bytes!("../../tests/data/root_SGX_CA_der.cert");
         let root_cas = [&root_ca[..]];
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = make_client(api_version);
+        let client = make_client();
 
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pck = client
+                .pckcert(
+                    Some(&pckid.enc_ppid),
+                    &pckid.pce_id,
+                    &pckid.cpu_svn,
+                    pckid.pce_isvsvn,
+                    Some(&pckid.qe_id),
+                )
+                .unwrap();
+
+            let pck = pck.verify(&root_cas, None).unwrap();
+
+            // The cache should be populated after initial service call
             {
-                let pck = client
-                    .pckcert(
+                let mut cache = client.pckcert_service.cache.lock().unwrap();
+
+                assert!(cache.len() > 0);
+
+                let (cached_pck, _) = {
+                    let mut hasher = DefaultHasher::new();
+                    let input = client.pckcert_service.pcs_service().build_input(
                         Some(&pckid.enc_ppid),
                         &pckid.pce_id,
                         &pckid.cpu_svn,
                         pckid.pce_isvsvn,
                         Some(&pckid.qe_id),
-                    )
-                    .unwrap();
-
-                let pck = pck.verify(&root_cas, None).unwrap();
-
-                // The cache should be populated after initial service call
-                {
-                    let mut cache = client.pckcert_service.cache.lock().unwrap();
-
-                    assert!(cache.len() > 0);
-
-                    let (cached_pck, _) = {
-                        let mut hasher = DefaultHasher::new();
-                        let input = client.pckcert_service.pcs_service().build_input(
-                            Some(&pckid.enc_ppid),
-                            &pckid.pce_id,
-                            &pckid.cpu_svn,
-                            pckid.pce_isvsvn,
-                            Some(&pckid.qe_id),
-                        );
-                        input.hash(&mut hasher);
-
-                        cache
-                            .get_mut(&hasher.finish())
-                            .expect("Can't find key in cache")
-                            .to_owned()
-                    };
-
-                    assert_eq!(
-                        pck.fmspc().unwrap(),
-                        cached_pck
-                            .clone()
-                            .verify(&root_cas, None)
-                            .unwrap()
-                            .fmspc()
-                            .unwrap()
                     );
-                    assert_eq!(pck.ca_chain(), cached_pck.ca_chain());
-                }
+                    input.hash(&mut hasher);
 
-                // Second service call should return value from cache
-                let pck_from_service = client
-                    .pckcert(
-                        Some(&pckid.enc_ppid),
-                        &pckid.pce_id,
-                        &pckid.cpu_svn,
-                        pckid.pce_isvsvn,
-                        Some(&pckid.qe_id),
-                    )
-                    .unwrap();
+                    cache
+                        .get_mut(&hasher.finish())
+                        .expect("Can't find key in cache")
+                        .to_owned()
+                };
 
                 assert_eq!(
                     pck.fmspc().unwrap(),
-                    pck_from_service
+                    cached_pck
                         .clone()
                         .verify(&root_cas, None)
                         .unwrap()
                         .fmspc()
                         .unwrap()
                 );
-                assert_eq!(pck.ca_chain(), pck_from_service.ca_chain());
+                assert_eq!(pck.ca_chain(), cached_pck.ca_chain());
             }
-        }
-    }
 
-    #[test]
-    pub fn test_pckcerts_with_fallback() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = make_client(api_version);
-
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
-            {
-                let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
-                println!("Found {} PCK certs.", pckcerts.as_pck_certs().len());
-
-                let tcb_info = client.sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None).unwrap();
-                let tcb_data = tcb_info.data().unwrap();
-
-                let selected = pckcerts
-                    .select_pck(&tcb_data, &pckid.cpu_svn, pckid.pce_isvsvn, pckid.pce_id)
-                    .unwrap();
-
-                let pck = client
-                    .pckcert(
+            // Second service call should return value from cache
+            let pck_from_service = client
+                .pckcert(
                     Some(&pckid.enc_ppid),
                     &pckid.pce_id,
                     &pckid.cpu_svn,
                     pckid.pce_isvsvn,
                     Some(&pckid.qe_id),
-                    )
-                    .unwrap();
+                )
+                .unwrap();
 
-                assert_eq!(
-                    format!("{:?}", selected.sgx_extension().unwrap()),
-                    format!("{:?}", pck.sgx_extension().unwrap())
-                );
-            }
+            assert_eq!(
+                pck.fmspc().unwrap(),
+                pck_from_service
+                    .clone()
+                    .verify(&root_cas, None)
+                    .unwrap()
+                    .fmspc()
+                    .unwrap()
+            );
+            assert_eq!(pck.ca_chain(), pck_from_service.ca_chain());
+        }
+    }
+
+    #[test]
+    pub fn test_pckcerts_with_fallback() {
+        let client = make_client();
+
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
+            println!("Found {} PCK certs.", pckcerts.as_pck_certs().len());
+
+            let tcb_info = client
+                .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
+                .unwrap();
+            let tcb_data = tcb_info.data().unwrap();
+
+            let selected = pckcerts
+                .select_pck(&tcb_data, &pckid.cpu_svn, pckid.pce_isvsvn, pckid.pce_id)
+                .unwrap();
+
+            let pck = client
+                .pckcert(
+                    Some(&pckid.enc_ppid),
+                    &pckid.pce_id,
+                    &pckid.cpu_svn,
+                    pckid.pce_isvsvn,
+                    Some(&pckid.qe_id),
+                )
+                .unwrap();
+
+            assert_eq!(
+                format!("{:?}", selected.sgx_extension().unwrap()),
+                format!("{:?}", pck.sgx_extension().unwrap())
+            );
         }
     }
 
     #[test]
     pub fn tcb_info() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = make_client(api_version);
+        let client = make_client();
 
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
-            {
-                let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
 
-                assert!(client
-                    .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
-                    .and_then(|tcb| { Ok(tcb.write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build()).unwrap()) })
-                    .is_ok());
-            }
+            assert!(client
+                .sgx_tcbinfo(&pckcerts.fmspc().unwrap(), None)
+                .and_then(|tcb| {
+                    Ok(tcb
+                        .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
+                        .unwrap())
+                })
+                .is_ok());
         }
     }
 
     #[test]
     pub fn tcb_info_tdx() {
-
-        let client = make_client(PcsVersion::V4);
+        let client = make_client();
         let root_ca = include_bytes!("../../tests/data/root_SGX_CA_der.cert");
         let root_cas = [&root_ca[..]];
 
@@ -750,14 +775,12 @@ mod tests {
 
     #[test]
     pub fn tcb_info_with_evaluation_data_number() {
-        let client = make_client(PcsVersion::V4);
+        let client = make_client();
         for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
             .unwrap()
             .iter()
         {
-            let pckcerts = client
-                .pckcerts_with_fallback(&pckid)
-                .unwrap();
+            let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
 
             let fmspc = pckcerts.fmspc().unwrap();
 
@@ -782,136 +805,43 @@ mod tests {
                     // API query with update="standard" will return QE Identity with TCB Evaluation Data Number M.
                     // A 410 Gone response is returned when the inputted TCB Evaluation Data Number is < M,
                     // so we ignore these TCB Evaluation Data Numbers.
-                    Err(super::Error::PCSError(status_code, _)) if status_code == super::StatusCode::Gone => continue,
-                    res @Err(_) => res.unwrap(),
+                    Err(super::Error::PCSError(status_code, _))
+                        if status_code == super::StatusCode::Gone =>
+                    {
+                        continue
+                    }
+                    res @ Err(_) => res.unwrap(),
                 };
-                tcb.write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build()).unwrap();
+                tcb.write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
+                    .unwrap();
             }
         }
     }
 
     #[test]
     pub fn tcb_info_cached() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = make_client(api_version);
+        let client = make_client();
 
-            for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
-                .unwrap()
-                .iter()
-            {
-                let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
-                let fmspc = pckcerts.fmspc().unwrap();
-                let tcb_info = client.sgx_tcbinfo(&fmspc, None).unwrap();
-
-                // The cache should be populated after initial service call
-                {
-                    let mut cache = client.sgx_tcbinfo_service.cache.lock().unwrap();
-
-                    assert!(cache.len() > 0);
-
-                    let (cached_tcb_info, _) = {
-                        let mut hasher = DefaultHasher::new();
-                        let input = client
-                            .sgx_tcbinfo_service
-                            .pcs_service()
-                            .build_input(&fmspc, None);
-                        input.hash(&mut hasher);
-
-                        cache
-                            .get_mut(&hasher.finish())
-                            .expect("Can't find key in cache")
-                            .to_owned()
-                    };
-
-                    assert_eq!(tcb_info, cached_tcb_info);
-                }
-
-                // Second service call should return value from cache
-                let tcb_info_from_service = client.sgx_tcbinfo(&fmspc, None).unwrap();
-
-                assert_eq!(tcb_info, tcb_info_from_service);
-            }
-        }
-    }
-
-    #[test]
-    pub fn pckcrl() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = make_client(api_version);
-            assert!(client
-                .pckcrl(DcapArtifactIssuer::PCKProcessorCA)
-                .and_then(|crl| Ok(crl.write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build()).unwrap()))
-                .is_ok());
-            assert!(client
-                .pckcrl(DcapArtifactIssuer::PCKPlatformCA)
-                .and_then(|crl| Ok(crl.write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build()).unwrap()))
-                .is_ok());
-        }
-    }
-
-    #[test]
-    pub fn pckcrl_cached() {
-        for ca in [
-            DcapArtifactIssuer::PCKProcessorCA,
-            DcapArtifactIssuer::PCKPlatformCA,
-        ] {
-            for api_version in [PcsVersion::V3, PcsVersion::V4] {
-                let client = make_client(api_version);
-                let pckcrl = client.pckcrl(ca).unwrap();
-
-                // The cache should be populated after initial service call
-                {
-                    let mut cache = client.pckcrl_service.cache.lock().unwrap();
-
-                    assert!(cache.len() > 0);
-
-                    let (cached_pckcrl, _) = {
-                        let mut hasher = DefaultHasher::new();
-                        let input = client.pckcrl_service.pcs_service().build_input(ca);
-                        input.hash(&mut hasher);
-
-                        cache
-                            .get_mut(&hasher.finish())
-                            .expect("Can't find key in cache")
-                            .to_owned()
-                    };
-
-                    assert_eq!(pckcrl, cached_pckcrl);
-                }
-
-                // Second service call should return value from cache
-                let pckcrl_from_service = client.pckcrl(ca).unwrap();
-
-                assert_eq!(pckcrl, pckcrl_from_service);
-            }
-        }
-    }
-
-    #[test]
-    pub fn qe_identity() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = make_client(api_version);
-            let qe_id = client.qe_identity(None);
-            assert!(qe_id.is_ok());
-            assert!(qe_id.unwrap().write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build()).is_ok());
-        }
-    }
-
-    #[test]
-    pub fn qe_identity_cached() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = make_client(api_version);
-            let qe_id = client.qe_identity(None).unwrap();
+        for pckid in PckID::parse_file(&PathBuf::from(PCKID_TEST_FILE).as_path())
+            .unwrap()
+            .iter()
+        {
+            let pckcerts = client.pckcerts_with_fallback(&pckid).unwrap();
+            let fmspc = pckcerts.fmspc().unwrap();
+            let tcb_info = client.sgx_tcbinfo(&fmspc, None).unwrap();
 
             // The cache should be populated after initial service call
             {
-                let mut cache = client.qeid_service.cache.lock().unwrap();
+                let mut cache = client.sgx_tcbinfo_service.cache.lock().unwrap();
 
                 assert!(cache.len() > 0);
 
-                let (cached_qeid, _) = {
+                let (cached_tcb_info, _) = {
                     let mut hasher = DefaultHasher::new();
-                    let input = client.qeid_service.pcs_service().build_input(None);
+                    let input = client
+                        .sgx_tcbinfo_service
+                        .pcs_service()
+                        .build_input(&fmspc, None);
                     input.hash(&mut hasher);
 
                     cache
@@ -920,31 +850,130 @@ mod tests {
                         .to_owned()
                 };
 
-                assert_eq!(qe_id, cached_qeid);
+                assert_eq!(tcb_info, cached_tcb_info);
             }
 
             // Second service call should return value from cache
-            let qeid_from_service = client.qe_identity(None).unwrap();
+            let tcb_info_from_service = client.sgx_tcbinfo(&fmspc, None).unwrap();
 
-            assert_eq!(qe_id, qeid_from_service);
+            assert_eq!(tcb_info, tcb_info_from_service);
         }
     }
 
     #[test]
-    pub fn gone_artifacts() {
-        for api_version in [PcsVersion::V3, PcsVersion::V4] {
-            let client = make_client(api_version);
-            let fmspc = Fmspc::try_from("90806f000000").unwrap();
-            assert_matches!(client.qe_identity(Some(15)), Err(Error::PCSError(StatusCode::Gone, _)));
-            assert_matches!(client.sgx_tcbinfo(&fmspc, Some(15)), Err(Error::PCSError(StatusCode::Gone, _)));
+    pub fn pckcrl() {
+        let client = make_client();
+        assert!(client
+            .pckcrl(DcapArtifactIssuer::PCKProcessorCA)
+            .and_then(|crl| Ok(crl
+                .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
+                .unwrap()))
+            .is_ok());
+        assert!(client
+            .pckcrl(DcapArtifactIssuer::PCKPlatformCA)
+            .and_then(|crl| Ok(crl
+                .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
+                .unwrap()))
+            .is_ok());
+    }
+
+    #[test]
+    pub fn pckcrl_cached() {
+        for ca in [
+            DcapArtifactIssuer::PCKProcessorCA,
+            DcapArtifactIssuer::PCKPlatformCA,
+        ] {
+            let client = make_client();
+            let pckcrl = client.pckcrl(ca).unwrap();
+
+            // The cache should be populated after initial service call
+            {
+                let mut cache = client.pckcrl_service.cache.lock().unwrap();
+
+                assert!(cache.len() > 0);
+
+                let (cached_pckcrl, _) = {
+                    let mut hasher = DefaultHasher::new();
+                    let input = client.pckcrl_service.pcs_service().build_input(ca);
+                    input.hash(&mut hasher);
+
+                    cache
+                        .get_mut(&hasher.finish())
+                        .expect("Can't find key in cache")
+                        .to_owned()
+                };
+
+                assert_eq!(pckcrl, cached_pckcrl);
+            }
+
+            // Second service call should return value from cache
+            let pckcrl_from_service = client.pckcrl(ca).unwrap();
+
+            assert_eq!(pckcrl, pckcrl_from_service);
         }
+    }
+
+    #[test]
+    pub fn qe_identity() {
+        let client = make_client();
+        let qe_id = client.qe_identity(None);
+        assert!(qe_id.is_ok());
+        assert!(qe_id
+            .unwrap()
+            .write_to_file(OUTPUT_TEST_DIR, WriteOptionsBuilder::new().build())
+            .is_ok());
+    }
+
+    #[test]
+    pub fn qe_identity_cached() {
+        let client = make_client();
+        let qe_id = client.qe_identity(None).unwrap();
+
+        // The cache should be populated after initial service call
+        {
+            let mut cache = client.qeid_service.cache.lock().unwrap();
+
+            assert!(cache.len() > 0);
+
+            let (cached_qeid, _) = {
+                let mut hasher = DefaultHasher::new();
+                let input = client.qeid_service.pcs_service().build_input(None);
+                input.hash(&mut hasher);
+
+                cache
+                    .get_mut(&hasher.finish())
+                    .expect("Can't find key in cache")
+                    .to_owned()
+            };
+
+            assert_eq!(qe_id, cached_qeid);
+        }
+
+        // Second service call should return value from cache
+        let qeid_from_service = client.qe_identity(None).unwrap();
+
+        assert_eq!(qe_id, qeid_from_service);
+    }
+
+    #[test]
+    pub fn gone_artifacts() {
+        let client = make_client();
+        let fmspc = Fmspc::try_from("90806f000000").unwrap();
+        assert_matches!(
+            client.qe_identity(Some(15)),
+            Err(Error::PCSError(StatusCode::Gone, _))
+        );
+        assert_matches!(
+            client.sgx_tcbinfo(&fmspc, Some(15)),
+            Err(Error::PCSError(StatusCode::Gone, _))
+        );
     }
 
     #[test]
     pub fn tcb_evaluation_data_numbers() {
         let root_ca = include_bytes!("../../tests/data/root_SGX_CA_der.cert");
         let root_cas = [&root_ca[..]];
-        let client = make_client(PcsVersion::V4);
+        let client = make_client();
         let eval_numbers = client.sgx_tcb_evaluation_data_numbers().unwrap();
 
         let eval_numbers2 = serde_json::ser::to_vec(&eval_numbers)
@@ -970,26 +999,31 @@ mod tests {
                 // API query with update="standard" will return QE Identity with TCB Evaluation Data Number M.
                 // A 410 Gone response is returned when the inputted TCB Evaluation Data Number is < M,
                 // so we ignore these TCB Evaluation Data Numbers.
-                Err(super::Error::PCSError(status_code, _)) if status_code == super::StatusCode::Gone => continue,
-                res @Err(_) => res.unwrap(),
+                Err(super::Error::PCSError(status_code, _))
+                    if status_code == super::StatusCode::Gone =>
+                {
+                    continue
+                }
+                res @ Err(_) => res.unwrap(),
             };
-            let verified_qe_id = qe_identity
-                .verify(&root_cas, EnclaveIdentity::QE)
-                .unwrap();
-            assert_eq!(verified_qe_id.tcb_evaluation_data_number(), u64::from(number));
+            let verified_qe_id = qe_identity.verify(&root_cas, EnclaveIdentity::QE).unwrap();
+            assert_eq!(
+                verified_qe_id.tcb_evaluation_data_number(),
+                u64::from(number)
+            );
 
             let tcb_info = client
-                    .sgx_tcbinfo(&fmspc, Some(number))
-                    .unwrap()
-                    .verify(&root_cas, 2)
-                    .unwrap();
+                .sgx_tcbinfo(&fmspc, Some(number))
+                .unwrap()
+                .verify(&root_cas, 2)
+                .unwrap();
             assert_eq!(tcb_info.tcb_evaluation_data_number(), u64::from(number));
         }
     }
 
     #[test]
     pub fn root_ca_crl() {
-        let client = make_client(PcsVersion::V4);
+        let client = make_client();
         let root_ca_crl = client.root_ca_crl().unwrap();
 
         let root_ca = include_bytes!("../../../pcs/tests/data/root_SGX_CA_der.cert");


### PR DESCRIPTION
Intel has completed the End-of-Life (EOL) process for version 3 of the Provisioning Certification Service (PCS) API as of May 13. This commit updates the retrieval tool to align with this status.

Changes:
- Added `#[deprecated]` attribute to `PcsVersion::V3`.
- Updated CLI validator to return an error when version 3 is requested, providing a message about the EOL status.
- Updated Azure, Intel, and PCCS provisioning client tests to exclusively use API version 4.
- Updated default internal constants to use version 4.
- Applied general code formatting and cleanup (rustfmt) across affected source files.
- Remove usage of PCS_API_KEY secret from CI workflow