### PR TITLE
[RTE-941]: Relax initramfs interface types.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "fortanix-vme-initramfs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cpio",
  "derivative",

--- a/fortanix-vme/fortanix-vme-eif/Cargo.toml
+++ b/fortanix-vme/fortanix-vme-eif/Cargo.toml
@@ -8,7 +8,7 @@ description = "Eif image builder for VME enclaves."
 
 [dependencies]
 aws-nitro-enclaves-image-format = "0.5"
-fortanix-vme-initramfs = { version = "0.1", path = "../fortanix-vme-initramfs" }
+fortanix-vme-initramfs = { version = "0.2", path = "../fortanix-vme-initramfs" }
 serde_json = "1.0"
 sha2 = "0.9"
 tempfile = "3"

--- a/fortanix-vme/fortanix-vme-initramfs/Cargo.toml
+++ b/fortanix-vme/fortanix-vme-initramfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortanix-vme-initramfs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"

--- a/fortanix-vme/fortanix-vme-initramfs/src/fs_tree.rs
+++ b/fortanix-vme/fortanix-vme-initramfs/src/fs_tree.rs
@@ -2,6 +2,7 @@ use crate::{Error, ReadSeek, DEFAULT_GID, DEFAULT_UID};
 use cpio::NewcBuilder;
 use derivative::Derivative;
 use normalize_path::NormalizePath;
+use std::ffi::OsString;
 use std::fmt;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
@@ -206,7 +207,7 @@ impl FsTreeEntry {
 
     pub fn symlink<P: AsRef<Path>, U: AsRef<Path>>(path: P, mode: u32, target: U) -> Self {
         let path = path.as_ref().to_path_buf();
-        let target = target.as_ref().to_path_buf();
+        let target = target.as_ref().into();
 
         Self {
             path,
@@ -225,7 +226,7 @@ pub enum FsTreeEntryInner {
         content: Box<dyn ReadSeek>,
     },
     Symlink {
-        target: PathBuf,
+        target: OsString,
     },
 }
 
@@ -240,8 +241,7 @@ impl FsTreeEntry {
             FsTreeEntryInner::Directory => Box::new(Cursor::new([] as [u8; 0])),
             FsTreeEntryInner::File { content } => content,
             FsTreeEntryInner::Symlink { target } => {
-                let os_string = target.into_os_string();
-                Box::new(Cursor::new(os_string.into_encoded_bytes()))
+                Box::new(Cursor::new(target.into_encoded_bytes()))
             }
         };
         Ok((builder, content))

--- a/fortanix-vme/fortanix-vme-initramfs/src/fs_tree.rs
+++ b/fortanix-vme/fortanix-vme-initramfs/src/fs_tree.rs
@@ -121,14 +121,14 @@ impl FsTree {
         self
     }
 
-    pub fn add_symlink<P: AsRef<Path>>(self, path: P, target: &str) -> FsTree {
+    pub fn add_symlink<P: AsRef<Path>, U: AsRef<Path>>(self, path: P, target: U) -> FsTree {
         self.add_symlink_with_permissions(path, target, DEFAULT_SYMLINK_PERMS)
     }
 
-    pub fn add_symlink_with_permissions<P: AsRef<Path>>(
+    pub fn add_symlink_with_permissions<P: AsRef<Path>, U: AsRef<Path>>(
         mut self,
         path: P,
-        target: &str,
+        target: U,
         mode: u32,
     ) -> FsTree {
         let path = Self::normalize_path(path);
@@ -138,7 +138,7 @@ impl FsTree {
             self.add_directory_with_parents(parent, DEFAULT_DIR_PERMS);
         }
 
-        let entry = FsTreeEntry::symlink(path, mode, target.to_owned());
+        let entry = FsTreeEntry::symlink(path, mode, target);
 
         self.0.push(entry);
         self
@@ -184,7 +184,9 @@ pub struct FsTreeEntry {
 }
 
 impl FsTreeEntry {
-    pub fn dir(path: PathBuf, mode: u32) -> Self {
+    pub fn dir<P: AsRef<Path>>(path: P, mode: u32) -> Self {
+        let path = path.as_ref().to_path_buf();
+
         Self {
             path,
             mode,
@@ -192,7 +194,9 @@ impl FsTreeEntry {
         }
     }
 
-    pub fn file(path: PathBuf, mode: u32, content: Box<dyn ReadSeek>) -> Self {
+    pub fn file<P: AsRef<Path>>(path: P, mode: u32, content: Box<dyn ReadSeek>) -> Self {
+        let path = path.as_ref().to_path_buf();
+
         Self {
             path,
             mode,
@@ -200,7 +204,10 @@ impl FsTreeEntry {
         }
     }
 
-    pub fn symlink(path: PathBuf, mode: u32, target: String) -> Self {
+    pub fn symlink<P: AsRef<Path>, U: AsRef<Path>>(path: P, mode: u32, target: U) -> Self {
+        let path = path.as_ref().to_path_buf();
+        let target = target.as_ref().to_path_buf();
+
         Self {
             path,
             mode,
@@ -218,7 +225,7 @@ pub enum FsTreeEntryInner {
         content: Box<dyn ReadSeek>,
     },
     Symlink {
-        target: String,
+        target: PathBuf,
     },
 }
 
@@ -232,7 +239,10 @@ impl FsTreeEntry {
         let content = match self.inner {
             FsTreeEntryInner::Directory => Box::new(Cursor::new([] as [u8; 0])),
             FsTreeEntryInner::File { content } => content,
-            FsTreeEntryInner::Symlink { target } => Box::new(Cursor::new(target.into_bytes())),
+            FsTreeEntryInner::Symlink { target } => {
+                let os_string = target.into_os_string();
+                Box::new(Cursor::new(os_string.into_encoded_bytes()))
+            }
         };
         Ok((builder, content))
     }

--- a/fortanix-vme/fortanix-vme-initramfs/src/fs_tree.rs
+++ b/fortanix-vme/fortanix-vme-initramfs/src/fs_tree.rs
@@ -58,7 +58,7 @@ impl FsTree {
         self
     }
 
-    fn dir_exists(&self, dir: &PathBuf) -> bool {
+    fn dir_exists(&self, dir: &Path) -> bool {
         self.0
             .iter()
             .any(|e| matches!(e, FsTreeEntry { path, inner: FsTreeEntryInner::Directory, .. } if path == dir))
@@ -71,7 +71,7 @@ impl FsTree {
                 break;
             }
 
-            let path_buf = dir.into();
+            let path_buf = dir.to_path_buf();
             if self.dir_exists(&path_buf) {
                 break;
             }
@@ -326,34 +326,6 @@ mod tests {
             make_file("./nsm.ko", Cursor::new(content.clone())),
             make_symlink("./rootfs/bin/sh", "dash"),
         ]);
-        assert!(files.eq_metadata(&expected));
-    }
-
-    #[test]
-    fn test_structure_with_paths() {
-        let content = vec![0, 1, 2, 3, 4];
-        let files = FsTree::new()
-            .add_file(Path::new("rootfs/bin/a.out"), Cursor::new(content.clone()))
-            .add_file(
-                PathBuf::from("rootfs/bin/b.out"),
-                Cursor::new(content.clone()),
-            )
-            .add_directory(Path::new("rootfs/dev_a"))
-            .add_directory(PathBuf::from("rootfs/dev_b"))
-            .add_symlink(Path::new("rootfs/bin/sh_a"), "dash")
-            .add_symlink(PathBuf::from("rootfs/bin/sh_b"), "dash");
-
-        let expected = FsTree(vec![
-            make_directory("./rootfs"),
-            make_directory("./rootfs/bin"),
-            make_file("./rootfs/bin/a.out", Cursor::new(content.clone())),
-            make_file("./rootfs/bin/b.out", Cursor::new(content.clone())),
-            make_directory("./rootfs/dev_a"),
-            make_directory("./rootfs/dev_b"),
-            make_symlink("./rootfs/bin/sh_a", "dash"),
-            make_symlink("./rootfs/bin/sh_b", "dash"),
-        ]);
-
         assert!(files.eq_metadata(&expected));
     }
 

--- a/fortanix-vme/fortanix-vme-initramfs/src/fs_tree.rs
+++ b/fortanix-vme/fortanix-vme-initramfs/src/fs_tree.rs
@@ -44,11 +44,15 @@ impl FsTree {
         self.0.iter().zip(&other.0).all(|(l, r)| l.eq_metadata(r))
     }
 
-    pub fn add_directory(self, dirname: &str) -> FsTree {
+    pub fn add_directory<P: AsRef<Path>>(self, dirname: P) -> FsTree {
         self.add_directory_with_permissions(dirname, DEFAULT_DIR_PERMS)
     }
 
-    pub fn add_directory_with_permissions(mut self, dirname: &str, mode: u32) -> FsTree {
+    pub fn add_directory_with_permissions<P: AsRef<Path>>(
+        mut self,
+        dirname: P,
+        mode: u32,
+    ) -> FsTree {
         let path = Self::normalize_path(dirname);
         self.add_directory_with_parents(path.as_path(), mode);
         self
@@ -81,21 +85,26 @@ impl FsTree {
         self.0.extend(to_add.into_iter().rev());
     }
 
-    pub fn add_executable<T>(self, basename: &str, content: T) -> FsTree
+    pub fn add_executable<T, P: AsRef<Path>>(self, basename: P, content: T) -> FsTree
     where
         T: ReadSeek + 'static,
     {
         self.add_file_with_permissions(basename, content, DEFAULT_EXEC_PERMS)
     }
 
-    pub fn add_file<T>(self, basename: &str, content: T) -> FsTree
+    pub fn add_file<T, P: AsRef<Path>>(self, basename: P, content: T) -> FsTree
     where
         T: ReadSeek + 'static,
     {
         self.add_file_with_permissions(basename, content, DEFAULT_FILE_PERMS)
     }
 
-    pub fn add_file_with_permissions<T>(mut self, basename: &str, content: T, mode: u32) -> FsTree
+    pub fn add_file_with_permissions<T, P: AsRef<Path>>(
+        mut self,
+        basename: P,
+        content: T,
+        mode: u32,
+    ) -> FsTree
     where
         T: ReadSeek + 'static,
     {
@@ -112,11 +121,16 @@ impl FsTree {
         self
     }
 
-    pub fn add_symlink(self, path: &str, target: &str) -> FsTree {
+    pub fn add_symlink<P: AsRef<Path>>(self, path: P, target: &str) -> FsTree {
         self.add_symlink_with_permissions(path, target, DEFAULT_SYMLINK_PERMS)
     }
 
-    pub fn add_symlink_with_permissions(mut self, path: &str, target: &str, mode: u32) -> FsTree {
+    pub fn add_symlink_with_permissions<P: AsRef<Path>>(
+        mut self,
+        path: P,
+        target: &str,
+        mode: u32,
+    ) -> FsTree {
         let path = Self::normalize_path(path);
 
         // Add parents first
@@ -135,9 +149,9 @@ impl FsTree {
     /// This function performs standard path normalization, removes any leading
     /// absolute root separators (`/`), and prepends the internal `./`
     /// prefix to ensure the path is relative for the initramfs environment.
-    pub(crate) fn normalize_path(basename: &str) -> PathBuf {
+    pub(crate) fn normalize_path<P: AsRef<Path>>(basename: P) -> PathBuf {
         // Do the regular normalization first
-        let normalized = Path::new(basename).normalize();
+        let normalized = basename.as_ref().normalize();
         // Normalized path may begin with "/", drop it if exists
         let stripped = if let Ok(stripped) = normalized.strip_prefix("/") {
             stripped
@@ -312,6 +326,34 @@ mod tests {
             make_file("./nsm.ko", Cursor::new(content.clone())),
             make_symlink("./rootfs/bin/sh", "dash"),
         ]);
+        assert!(files.eq_metadata(&expected));
+    }
+
+    #[test]
+    fn test_structure_with_paths() {
+        let content = vec![0, 1, 2, 3, 4];
+        let files = FsTree::new()
+            .add_file(Path::new("rootfs/bin/a.out"), Cursor::new(content.clone()))
+            .add_file(
+                PathBuf::from("rootfs/bin/b.out"),
+                Cursor::new(content.clone()),
+            )
+            .add_directory(Path::new("rootfs/dev_a"))
+            .add_directory(PathBuf::from("rootfs/dev_b"))
+            .add_symlink(Path::new("rootfs/bin/sh_a"), "dash")
+            .add_symlink(PathBuf::from("rootfs/bin/sh_b"), "dash");
+
+        let expected = FsTree(vec![
+            make_directory("./rootfs"),
+            make_directory("./rootfs/bin"),
+            make_file("./rootfs/bin/a.out", Cursor::new(content.clone())),
+            make_file("./rootfs/bin/b.out", Cursor::new(content.clone())),
+            make_directory("./rootfs/dev_a"),
+            make_directory("./rootfs/dev_b"),
+            make_symlink("./rootfs/bin/sh_a", "dash"),
+            make_symlink("./rootfs/bin/sh_b", "dash"),
+        ]);
+
         assert!(files.eq_metadata(&expected));
     }
 

--- a/fortanix-vme/fortanix-vme-initramfs/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-initramfs/src/lib.rs
@@ -115,7 +115,12 @@ impl<R: Read> Initramfs<R> {
                 }
                 FsTreeEntryInner::Symlink { target } => {
                     // Verify content (target)
-                    Initramfs::verify_entry_content(&mut reader, path, target.as_bytes())?;
+                    let os_string = target.into_os_string();
+                    Initramfs::verify_entry_content(
+                        &mut reader,
+                        path,
+                        &os_string.into_encoded_bytes(),
+                    )?;
                 }
             }
             reader = Initramfs::next(reader)?;

--- a/fortanix-vme/fortanix-vme-initramfs/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-initramfs/src/lib.rs
@@ -99,26 +99,23 @@ impl<R: Read> Initramfs<R> {
         let mut reader = NewcReader::new(decoder).map_err(Error::ReadError)?;
 
         for fs_entry in fs_tree.0.into_iter() {
-            let path_str = fs_entry
-                .path
-                .as_path()
-                .to_str()
-                .ok_or(Error::PathError(fs_entry.path.display().to_string()))?;
             let mode = fs_entry.mode;
-            Initramfs::verify_entry(&reader, path_str, DEFAULT_UID, DEFAULT_GID, mode)?;
+            let path = fs_entry.path;
+
+            Initramfs::verify_entry(&reader, &path, DEFAULT_UID, DEFAULT_GID, mode)?;
             match fs_entry.inner {
                 FsTreeEntryInner::File { mut content } => {
                     // Verify content
                     let mut buf = Vec::new();
                     content.read_to_end(&mut buf).map_err(Error::ReadError)?;
-                    Initramfs::verify_entry_content(&mut reader, path_str, &buf)?;
+                    Initramfs::verify_entry_content(&mut reader, path, &buf)?;
                 }
                 FsTreeEntryInner::Directory => {
                     // No content to verify
                 }
                 FsTreeEntryInner::Symlink { target } => {
                     // Verify content (target)
-                    Initramfs::verify_entry_content(&mut reader, path_str, target.as_bytes())?;
+                    Initramfs::verify_entry_content(&mut reader, path, target.as_bytes())?;
                 }
             }
             reader = Initramfs::next(reader)?;
@@ -131,8 +128,8 @@ impl<R: Read> Initramfs<R> {
         Ok(())
     }
 
-    pub fn read_entry_by_path(self, path: &str) -> Result<Vec<u8>, Error> {
-        let normalized = FsTree::normalize_path(path);
+    pub fn read_entry_by_path<P: AsRef<Path>>(self, path: P) -> Result<Vec<u8>, Error> {
+        let normalized = FsTree::normalize_path(path.as_ref());
         let decoder = GzDecoder::new(self.0);
         let mut reader = NewcReader::new(decoder).map_err(Error::ReadError)?;
         loop {
@@ -149,21 +146,23 @@ impl<R: Read> Initramfs<R> {
             reader = Initramfs::next(reader)?;
         }
 
-        Err(Error::PathError(path.to_owned()))
+        Err(Error::PathError(format!("{}", path.as_ref().display())))
     }
 
-    fn verify_entry(
+    fn verify_entry<P: AsRef<Path>>(
         reader: &NewcReader<R>,
-        path: &str,
+        path: P,
         uid: u32,
         gid: u32,
         mode: u32,
     ) -> Result<(), Error> {
         let entry = reader.entry();
-        if entry.name() != path {
+        let path_ref = path.as_ref();
+
+        if entry.name() != path_ref {
             return Err(Error::wrong_entry_name(
                 entry.name().to_string(),
-                path.to_string(),
+                format!("{}", path_ref.display()),
             ));
         }
         if entry.uid() != uid {
@@ -178,16 +177,20 @@ impl<R: Read> Initramfs<R> {
         Ok(())
     }
 
-    fn verify_entry_content(
+    fn verify_entry_content<P: AsRef<Path>>(
         reader: &mut NewcReader<R>,
-        path: &str,
+        path: P,
         expected: &[u8],
     ) -> Result<(), Error> {
         let data = Self::read_entry_content(reader)?;
         if data != expected {
             let found = String::from_utf8_lossy(&data).to_string();
             let expected = String::from_utf8_lossy(expected).to_string();
-            return Err(Error::unexpected_data(path.to_string(), found, expected));
+            return Err(Error::unexpected_data(
+                format!("{}", path.as_ref().display()),
+                found,
+                expected,
+            ));
         }
 
         Ok(())

--- a/fortanix-vme/fortanix-vme-initramfs/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-initramfs/src/lib.rs
@@ -115,11 +115,10 @@ impl<R: Read> Initramfs<R> {
                 }
                 FsTreeEntryInner::Symlink { target } => {
                     // Verify content (target)
-                    let os_string = target.into_os_string();
                     Initramfs::verify_entry_content(
                         &mut reader,
                         &path,
-                        &os_string.into_encoded_bytes(),
+                        &target.into_encoded_bytes(),
                     )?;
                 }
             }

--- a/fortanix-vme/fortanix-vme-initramfs/src/lib.rs
+++ b/fortanix-vme/fortanix-vme-initramfs/src/lib.rs
@@ -108,7 +108,7 @@ impl<R: Read> Initramfs<R> {
                     // Verify content
                     let mut buf = Vec::new();
                     content.read_to_end(&mut buf).map_err(Error::ReadError)?;
-                    Initramfs::verify_entry_content(&mut reader, path, &buf)?;
+                    Initramfs::verify_entry_content(&mut reader, &path, &buf)?;
                 }
                 FsTreeEntryInner::Directory => {
                     // No content to verify
@@ -118,7 +118,7 @@ impl<R: Read> Initramfs<R> {
                     let os_string = target.into_os_string();
                     Initramfs::verify_entry_content(
                         &mut reader,
-                        path,
+                        &path,
                         &os_string.into_encoded_bytes(),
                     )?;
                 }
@@ -154,20 +154,19 @@ impl<R: Read> Initramfs<R> {
         Err(Error::PathError(format!("{}", path.as_ref().display())))
     }
 
-    fn verify_entry<P: AsRef<Path>>(
+    fn verify_entry(
         reader: &NewcReader<R>,
-        path: P,
+        path: &Path,
         uid: u32,
         gid: u32,
         mode: u32,
     ) -> Result<(), Error> {
         let entry = reader.entry();
-        let path_ref = path.as_ref();
 
-        if entry.name() != path_ref {
+        if entry.name() != path {
             return Err(Error::wrong_entry_name(
                 entry.name().to_string(),
-                format!("{}", path_ref.display()),
+                format!("{}", path.display()),
             ));
         }
         if entry.uid() != uid {
@@ -182,17 +181,18 @@ impl<R: Read> Initramfs<R> {
         Ok(())
     }
 
-    fn verify_entry_content<P: AsRef<Path>>(
+    fn verify_entry_content(
         reader: &mut NewcReader<R>,
-        path: P,
+        path: &Path,
         expected: &[u8],
     ) -> Result<(), Error> {
         let data = Self::read_entry_content(reader)?;
         if data != expected {
             let found = String::from_utf8_lossy(&data).to_string();
             let expected = String::from_utf8_lossy(expected).to_string();
+
             return Err(Error::unexpected_data(
-                format!("{}", path.as_ref().display()),
+                format!("{}", path.display()),
                 found,
                 expected,
             ));


### PR DESCRIPTION
Influnced by `std::fs` and after talking with @tvsfx i've decided to add support for Path like object to initramfs interface.