### PR TITLE
[PROD-11482] Bump versions for async-usercalls and ipc-queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-usercalls"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "crossbeam-channel",
  "fnv",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "ipc-queue"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "fortanix-sgx-abi",
  "futures 0.3.31",

--- a/intel-sgx/async-usercalls/Cargo.toml
+++ b/intel-sgx/async-usercalls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-usercalls"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"
@@ -16,7 +16,7 @@ categories = ["asynchronous"]
 
 [dependencies]
 # Project dependencies
-ipc-queue = { version = "0.5.1", path = "../../ipc-queue" }
+ipc-queue = { version = "0.5.2", path = "../../ipc-queue" }
 fortanix-sgx-abi = { version = "0.6.0", path = "../fortanix-sgx-abi" }
 
 # External dependencies

--- a/intel-sgx/enclave-runner-sgx/Cargo.toml
+++ b/intel-sgx/enclave-runner-sgx/Cargo.toml
@@ -24,7 +24,7 @@ sgxs = { version = "0.8.1", path = "../sgxs" }
 fortanix-sgx-abi = { version = "0.6.0", path = "../fortanix-sgx-abi" }
 sgx-isa = { version = ">=0.4.0, <0.6.0", path = "../sgx-isa" }
 insecure-time = { version = "0.3", path = "../insecure-time", features = ["estimate_crystal_clock_freq"] }
-ipc-queue = { version = "0.5.1", path = "../../ipc-queue" }
+ipc-queue = { version = "0.5.2", path = "../../ipc-queue" }
 enclave-runner = { version = "0.8.0", path = "../../enclave-runner" }
 
 # External dependencies

--- a/ipc-queue/Cargo.toml
+++ b/ipc-queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-queue"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"


### PR DESCRIPTION
This is followup PR of https://github.com/fortanix/rust-sgx/pull/939, in that PR I forgot ipc-queue 0.5.1 and async-usercalls 0.7.1 are already yanked versions.

So I need to bump versions for async-usercalls and ipc-queue to 0.7.2 and 0.5.2 respectively.