### PR TITLE
feat: add async support for `MbedSSLClient`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,7 @@ dependencies = [
  "serde_json",
  "sgx-isa",
  "sgx_pkix",
+ "tokio",
  "url 1.7.2",
  "uuid 0.6.5",
  "uuid 0.8.2",
@@ -2919,6 +2920,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive 1.0.204 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
  "yasna 0.2.2",
 ]
 

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/fortanix/rust-sgx"
 categories = [ "api-bindings" ]
 keywords = [ "sgx" ]
 
+[features]
+default = []
+async = ["dep:tokio", "mbedtls/async-rt"]
+
 [dependencies]
 b64-ct = "0.1.3"
 em-client = { version = "4.0.2", default-features = false, features = ["client"] }
@@ -23,6 +27,7 @@ serde = "1.0"
 serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_json = "1.0"
+tokio = { version = "1.36.0", optional = true }
 url = "1"
 uuid = { version = "0.6.3", features = ["v4", "serde"] }
 uuid_sdkms = { package = "uuid", version = "0.8", features = ["v4", "serde"] }

--- a/em-app/src/mbedtls_hyper.rs
+++ b/em-app/src/mbedtls_hyper.rs
@@ -131,6 +131,40 @@ impl MbedSSLClient {
     }
 }
 
+#[cfg(feature = "async")]
+mod async_io {
+    use tokio::io::{AsyncRead, AsyncWrite};
+
+    use super::*;
+
+    impl MbedSSLClient {
+        pub async fn wrap_stream<T>(
+            &self,
+            stream: T,
+            host: &str,
+        ) -> Result<Context<T>, mbedtls::Error>
+        where
+            T: Unpin + AsyncRead + AsyncWrite + 'static,
+        {
+            let mut context = Context::new(self.rc_config.clone());
+
+            let verify_hostname = match self.verify_hostname {
+                true => Some(
+                    self.override_sni
+                        .as_ref()
+                        .map(|v| v.as_str())
+                        .unwrap_or(host),
+                ),
+                false => None,
+            };
+
+            context.establish_async(stream, verify_hostname).await?;
+
+            Ok(context)
+        }
+    }
+}
+
 impl<T> SslClient<T> for MbedSSLClient
     where T: NetworkStream + Send + Clone + fmt::Debug + Sync
 {

--- a/em-app/src/utils.rs
+++ b/em-app/src/utils.rs
@@ -185,15 +185,33 @@ pub fn get_hyper_connector_pool(ca_chain: Vec<Vec<u8>>) -> Result<Arc<hyper::Cli
 }
 
 pub fn get_mbedtls_hyper_connector_pool(ca_chain: Vec<Vec<u8>>, client_pki: Option<(Arc<MbedtlsList<Certificate>>, Arc<Pk>)>) -> Result<Arc<hyper::Client>, String> {
+    let ssl = get_mbedtls_client(ca_chain, client_pki)?;
+    let connector = HttpsConnector::new(ssl);
+
+    let mut pool = Pool::with_connector(Default::default(), connector);
+    pool.set_idle_timeout(Some(Duration::from_secs(CONNECTION_IDLE_TIMEOUT_SECS)));
+
+    Ok(Arc::new(hyper::Client::with_connector(pool)))
+}
+
+pub fn get_mbedtls_client(
+    ca_chain: Vec<Vec<u8>>,
+    client_pki: Option<(Arc<MbedtlsList<Certificate>>, Arc<Pk>)>,
+) -> Result<MbedSSLClient, String> {
     let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
 
     config.set_rng(Arc::new(mbedtls::rng::Rdrand));
-    config.set_min_version(Version::Tls1_2).map_err(|e| format!("TLS configuration failed: {:?}", e))?;
+    config
+        .set_min_version(Version::Tls1_2)
+        .map_err(|e| format!("TLS configuration failed: {:?}", e))?;
 
     if !ca_chain.is_empty() {
         let mut list = MbedtlsList::<Certificate>::new();
         for i in ca_chain {
-            list.push(Certificate::from_der(&i).map_err(|e| format!("Failed parsing ca cert, error: {:?}", e))?);
+            list.push(
+                Certificate::from_der(&i)
+                    .map_err(|e| format!("Failed parsing ca cert, error: {:?}", e))?,
+            );
         }
 
         config.set_ca_list(Arc::new(list), None);
@@ -203,14 +221,10 @@ pub fn get_mbedtls_hyper_connector_pool(ca_chain: Vec<Vec<u8>>, client_pki: Opti
     }
 
     if let Some((cert, key)) = client_pki {
-        config.push_cert(cert, key).map_err(|e| format!("TLS configuration failed: {:?}", e))?;
+        config
+            .push_cert(cert, key)
+            .map_err(|e| format!("TLS configuration failed: {:?}", e))?;
     }
-    
-    let ssl = MbedSSLClient::new(Arc::new(config), true);
-    let connector = HttpsConnector::new(ssl);
 
-    let mut pool = Pool::with_connector(Default::default(), connector);
-    pool.set_idle_timeout(Some(Duration::from_secs(CONNECTION_IDLE_TIMEOUT_SECS)));
-
-    Ok(Arc::new(hyper::Client::with_connector(pool)))
+    Ok(MbedSSLClient::new(Arc::new(config), true))
 }


### PR DESCRIPTION
Features:
- Split `utils::get_mbedtls_client()` from `utils::get_mbedtls_hyper_connector_pool()` to be able to use it with arbitrary `hyper` versions.
- Add `MbedSSLClient::wrap_stream()` async function behind `async` feature flag. This mirrors `hyper` v0.10 `SslClient::wrap_client()` buf for async use cases (mainly for use with modern `hyper`).