### PR TITLE
[RTE-1139]: Fix enclave-runner-sgx build on nightly toolchain.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,7 +1468,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2746,7 +2746,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2905,9 +2905,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mbedtls"
-version = "0.13.4"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a545c48509913588baddc2fe51779e391e5992afd38be29f96d4831841fd303"
+checksum = "632b09ec03d9faf449ab6d33993c30fc85584dcf550cd6e28f00b619589118dd"
 dependencies = [
  "bitflags 1.2.1",
  "byteorder 1.5.0",
@@ -4163,7 +4163,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4894,7 +4894,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/intel-sgx/dcap-provider/src/lib.rs
+++ b/intel-sgx/dcap-provider/src/lib.rs
@@ -322,7 +322,7 @@ pub extern "C" fn sgx_ql_get_quote_config(
         }
         .clone();
 
-        if pckcert.certchain.len() > u32::max_value() as usize {
+        if pckcert.certchain.len() > u32::MAX as usize {
             error!(
                 "Returned PCK certificate too large: {} bytes",
                 pckcert.certchain.len()

--- a/intel-sgx/enclave-runner-sgx/src/usercalls/mod.rs
+++ b/intel-sgx/enclave-runner-sgx/src/usercalls/mod.rs
@@ -1495,7 +1495,7 @@ impl<'tcs> IOHandlerInput<'tcs> {
             return Err(IoErrorKind::InvalidInput.into());
         }
 
-        assert!((EV_ALL | EV_ABORT) <= u8::max_value().into());
+        assert!((EV_ALL | EV_ABORT) <= u8::MAX.into());
         assert!((EV_ALL & EV_ABORT) == 0);
         Ok(())
     }

--- a/intel-sgx/pcs/src/pckcrt.rs
+++ b/intel-sgx/pcs/src/pckcrt.rs
@@ -560,7 +560,7 @@ impl PckCerts {
         // Sort PCK certs by applicable TCB level. If two certs are in the same TCB
         // level, maintain existing ordering (stable sort). PCK certs without a TCB
         // level are sorted last.
-        pck_certs.sort_by_cached_key(|cert| cert.find_sgx_tcb_level_idx(tcb_info).unwrap_or(usize::max_value()));
+        pck_certs.sort_by_cached_key(|cert| cert.find_sgx_tcb_level_idx(tcb_info).unwrap_or(usize::MAX));
         pck_certs
     }
 


### PR DESCRIPTION
Fixes enclave-runner-sgx build error on the latest nightly toolchain.