### PR TITLE
[RTE-1113] Add extended prod id support to signer - Part 2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4536,7 +4536,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "byteorder 1.5.0",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs-tools"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "aesm-client",
  "anyhow",

--- a/intel-sgx/aesm-client/Cargo.toml
+++ b/intel-sgx/aesm-client/Cargo.toml
@@ -26,7 +26,7 @@ test-sgx = []
 
 [dependencies]
 # Project dependencies
-sgxs = { version = "0.8.0", path = "../sgxs", optional = true }
+sgxs = { version = "0.9.0", path = "../sgxs", optional = true }
 sgx-isa = { version = ">=0.4.1, <0.7.0", path = "../sgx-isa"}
 
 # External dependencies

--- a/intel-sgx/dcap-ql/Cargo.toml
+++ b/intel-sgx/dcap-ql/Cargo.toml
@@ -55,6 +55,6 @@ yasna = { version = "0.3", features = ["num-bigint", "bit-vec"], optional = true
 [dev-dependencies]
 mbedtls = { version = ">=0.12.0, <0.14.0" }
 report-test = { version = "0.5.0", path = "../report-test" }
-sgxs = { version = "0.8.0", path = "../sgxs" }
+sgxs = { version = "0.9.0", path = "../sgxs" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/intel-sgx/enclave-runner-sgx/Cargo.toml
+++ b/intel-sgx/enclave-runner-sgx/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["fake-vdso/.gitignore", "fake-vdso/Makefile", "fake-vdso/main.S"]
 
 [dependencies]
 # Project dependencies
-sgxs = { version = "0.8.1", path = "../sgxs" }
+sgxs = { version = "0.9.0", path = "../sgxs" }
 fortanix-sgx-abi = { version = "0.6.0", path = "../fortanix-sgx-abi" }
 sgx-isa = { version = ">=0.4.0, <0.7.0", path = "../sgx-isa" }
 insecure-time = { version = "0.3", path = "../insecure-time", features = ["estimate_crystal_clock_freq"] }

--- a/intel-sgx/fortanix-sgx-tools/Cargo.toml
+++ b/intel-sgx/fortanix-sgx-tools/Cargo.toml
@@ -24,7 +24,7 @@ aesm-client = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] 
 sgxs-loaders = { version = "0.5.0", path = "../sgxs-loaders" }
 enclave-runner-sgx = { version = "0.1.0", path = "../enclave-runner-sgx" }
 enclave-runner = { version = "0.8.0", path = "../../enclave-runner" }
-sgxs = { version = "0.8.0", path = "../sgxs" }
+sgxs = { version = "0.9.0", path = "../sgxs" }
 sgx-isa = { version = ">=0.4.0, <0.7.0", path = "../sgx-isa" }
 
 # External dependencies

--- a/intel-sgx/report-test/Cargo.toml
+++ b/intel-sgx/report-test/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["development-tools"]
 # Project dependencies
 "enclave-runner-sgx" = { version = "0.1.0", path = "../enclave-runner-sgx" }
 "enclave-runner" = { version = "0.8.0", path = "../../enclave-runner" }
-"sgxs" = { version = "0.8.0", path = "../sgxs" }
+"sgxs" = { version = "0.9.0", path = "../sgxs" }
 "sgx-isa" = { version = ">=0.4.0, <0.7.0", path = "../sgx-isa" }
 
 # External dependencies

--- a/intel-sgx/sgxs-loaders/Cargo.toml
+++ b/intel-sgx/sgxs-loaders/Cargo.toml
@@ -25,7 +25,7 @@ no_sgx_enclave_common = []
 
 [dependencies]
 # Project dependencies
-sgxs = { version = "0.8.0", path = "../sgxs" }
+sgxs = { version = "0.9.0", path = "../sgxs" }
 sgx-isa = { version = ">=0.4.0, <0.7.0", path = "../sgx-isa" }
 
 # External dependencies

--- a/intel-sgx/sgxs-tools/Cargo.toml
+++ b/intel-sgx/sgxs-tools/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/sgx_detect/main.rs"
 sgxs = { version = "0.9.0", path = "../sgxs", features = ["crypto-openssl"] }
 sgxs-loaders = { version = "0.5.0", path = "../sgxs-loaders" }
 aesm-client = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
-sgx-isa = { version = ">=0.4.0, <0.7.0", path = "../sgx-isa" }
+sgx-isa = { version = "0.6.0", path = "../sgx-isa" }
 report-test = { version = "0.5.0", path = "../report-test" }
 enclave-runner-sgx = { version = "0.1.0", path = "../enclave-runner-sgx" }
 enclave-runner = { version = "0.8.0", path = "../../enclave-runner" }

--- a/intel-sgx/sgxs-tools/Cargo.toml
+++ b/intel-sgx/sgxs-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-tools"
-version = "0.9.4"
+version = "0.10.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
@@ -25,7 +25,7 @@ path = "src/sgx_detect/main.rs"
 
 [dependencies]
 # Project dependencies
-sgxs = { version = "0.8.0", path = "../sgxs", features = ["crypto-openssl"] }
+sgxs = { version = "0.9.0", path = "../sgxs", features = ["crypto-openssl"] }
 sgxs-loaders = { version = "0.5.0", path = "../sgxs-loaders" }
 aesm-client = { version = "0.6.0", path = "../aesm-client", features = ["sgxs"] }
 sgx-isa = { version = ">=0.4.0, <0.7.0", path = "../sgx-isa" }

--- a/intel-sgx/sgxs-tools/src/bin/sgxs-sign.rs
+++ b/intel-sgx/sgxs-tools/src/bin/sgxs-sign.rs
@@ -159,10 +159,6 @@ fn do_sign<'a>(matches: &clap::ArgMatches<'a>, key: &PKey<pkey::Private>) -> Sig
         signer.miscselect(sel, !mask);
     }
 
-    let isvextprodid = matches
-        .value_of("isvextprodid")
-        .map(parse_num::<u128>)
-        .unwrap_or_default();
 
     let (mut attributes, attributemask) = matches
         .value_of("attributes/attributemask")
@@ -180,10 +176,10 @@ fn do_sign<'a>(matches: &clap::ArgMatches<'a>, key: &PKey<pkey::Private>) -> Sig
         attributes |= sgx_isa::AttributesFlags::DEBUG.bits();
         attributemask &= !(sgx_isa::AttributesFlags::DEBUG.bits());
     }
-    // If extended product id is has a value
-    // make KSS essential. Hosts without KSS support
-    // would fail on enclave launch.
-    if isvextprodid > 0 {
+
+    // If an extended product ID is provided, make KSS mandatory.
+    // Hosts without KSS support will fail to launch the enclave.
+    if matches.is_present("isvextprodid") {
         attributes |= sgx_isa::AttributesFlags::KSS.bits();
         attributemask |= sgx_isa::AttributesFlags::KSS.bits();
     }
@@ -203,9 +199,10 @@ fn do_sign<'a>(matches: &clap::ArgMatches<'a>, key: &PKey<pkey::Private>) -> Sig
         .map(parse_num::<u32>)
         .map(|v| signer.swdefined(v));
 
-    if isvextprodid > 0 {
-        signer.isvextprodid(isvextprodid.to_le_bytes());
-    }
+    matches
+        .value_of("isvextprodid")
+        .map(parse_num::<u128>)
+        .map(|v| signer.isvextprodid(v.to_le_bytes()));
 
     matches
         .value_of("isvprodid")

--- a/intel-sgx/sgxs-tools/src/bin/sgxs-sign.rs
+++ b/intel-sgx/sgxs-tools/src/bin/sgxs-sign.rs
@@ -115,6 +115,7 @@ fn args_desc<'a>() -> clap::App<'a, 'a> {
         .arg(Arg::with_name("32bit")                              .long("32")                                                           .help("Unsets the MODE64BIT bit in the ATTRIBUTES field, sets MODE64BIT in the ATTRIBUTEMASK field"))
         .arg(Arg::with_name("debug")                   .short("d").long("debug")                                                        .help("Sets the DEBUG bit in the ATTRIBUTES field, unsets the DEBUG bit in the ATTRIBUTEMASK field"))
         .arg(Arg::with_name("date")                               .long("date")      .value_name("YYYYMMDD").validator(date_validate)   .help("Sets the DATE field (default: today)"))
+        .arg(Arg::with_name("isvextprodid")                       .long("isvextprodid").takes_value(true)   .validator(num_validate)    .help("Sets the ISVEXTPRODID field (default: 0)"))
         .arg(Arg::with_name("isvprodid")               .short("p").long("isvprodid") .takes_value(true)     .validator(num_validate)    .help("Sets the ISVPRODID field (default: 0)"))
         .arg(Arg::with_name("isvsvn")                  .short("v").long("isvsvn")    .takes_value(true)     .validator(num_validate)    .help("Sets the ISVSVN field (default: 0)"))
         .arg(Arg::with_name("key-file")                .short("k").long("key")       .value_name("FILE")    .required(true)             .help("Sets the path to the PEM-encoded RSA private key"))
@@ -158,6 +159,11 @@ fn do_sign<'a>(matches: &clap::ArgMatches<'a>, key: &PKey<pkey::Private>) -> Sig
         signer.miscselect(sel, !mask);
     }
 
+    let isvextprodid = matches
+        .value_of("isvextprodid")
+        .map(parse_num::<u128>)
+        .unwrap_or_default();
+
     let (mut attributes, attributemask) = matches
         .value_of("attributes/attributemask")
         .map(parse_num_num::<u64>)
@@ -174,6 +180,13 @@ fn do_sign<'a>(matches: &clap::ArgMatches<'a>, key: &PKey<pkey::Private>) -> Sig
         attributes |= sgx_isa::AttributesFlags::DEBUG.bits();
         attributemask &= !(sgx_isa::AttributesFlags::DEBUG.bits());
     }
+    // If extended product id is has a value
+    // make KSS essential. Hosts without KSS support
+    // would fail on enclave launch.
+    if isvextprodid > 0 {
+        attributes |= sgx_isa::AttributesFlags::KSS.bits();
+        attributemask |= sgx_isa::AttributesFlags::KSS.bits();
+    }
     let attributes = AttributesFlags::from_bits(attributes).unwrap_or_else(|| {
         println!("WARNING: Dropping unknown bits in input ATTRIBUTES!");
         AttributesFlags::from_bits_truncate(attributes)
@@ -189,6 +202,11 @@ fn do_sign<'a>(matches: &clap::ArgMatches<'a>, key: &PKey<pkey::Private>) -> Sig
         .value_of("swdefined")
         .map(parse_num::<u32>)
         .map(|v| signer.swdefined(v));
+
+    if isvextprodid > 0 {
+        signer.isvextprodid(isvextprodid.to_le_bytes());
+    }
+
     matches
         .value_of("isvprodid")
         .map(parse_num::<u16>)

--- a/intel-sgx/sgxs-tools/src/bin/sgxs-sign.rs
+++ b/intel-sgx/sgxs-tools/src/bin/sgxs-sign.rs
@@ -115,7 +115,7 @@ fn args_desc<'a>() -> clap::App<'a, 'a> {
         .arg(Arg::with_name("32bit")                              .long("32")                                                           .help("Unsets the MODE64BIT bit in the ATTRIBUTES field, sets MODE64BIT in the ATTRIBUTEMASK field"))
         .arg(Arg::with_name("debug")                   .short("d").long("debug")                                                        .help("Sets the DEBUG bit in the ATTRIBUTES field, unsets the DEBUG bit in the ATTRIBUTEMASK field"))
         .arg(Arg::with_name("date")                               .long("date")      .value_name("YYYYMMDD").validator(date_validate)   .help("Sets the DATE field (default: today)"))
-        .arg(Arg::with_name("isvextprodid")                       .long("isvextprodid").takes_value(true)   .validator(num_validate)    .help("Sets the ISVEXTPRODID field (default: 0)"))
+        .arg(Arg::with_name("isvextprodid")                       .long("isvextprodid").takes_value(true)   .validator(num_validate)    .help("Sets the ISVEXTPRODID field"))
         .arg(Arg::with_name("isvprodid")               .short("p").long("isvprodid") .takes_value(true)     .validator(num_validate)    .help("Sets the ISVPRODID field (default: 0)"))
         .arg(Arg::with_name("isvsvn")                  .short("v").long("isvsvn")    .takes_value(true)     .validator(num_validate)    .help("Sets the ISVSVN field (default: 0)"))
         .arg(Arg::with_name("key-file")                .short("k").long("key")       .value_name("FILE")    .required(true)             .help("Sets the path to the PEM-encoded RSA private key"))

--- a/intel-sgx/sgxs/Cargo.toml
+++ b/intel-sgx/sgxs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/sgxs/src/sigstruct.rs
+++ b/intel-sgx/sgxs/src/sigstruct.rs
@@ -66,6 +66,7 @@ pub struct Signer {
     miscmask: u32,
     attributes: Attributes,
     attributemask: [u64; 2],
+    isvextprodid: [u8; 16],
     isvprodid: u16,
     isvsvn: u16,
     enclavehash: EnclaveHash,
@@ -92,6 +93,7 @@ impl Signer {
                 xfrm: 0x3,
             },
             attributemask: [!abi::AttributesFlags::DEBUG.bits(), !0x3],
+            isvextprodid: [0; 16],
             isvprodid: 0,
             isvsvn: 0,
             enclavehash,
@@ -142,7 +144,7 @@ impl Signer {
             attributemask: self.attributemask,
             enclavehash: self.enclavehash.hash,
             _reserved3: [0; 16],
-            isvextprodid: [0; 16],
+            isvextprodid: self.isvextprodid,
             isvprodid: self.isvprodid,
             isvsvn: self.isvsvn,
             _reserved4: [0; 12],
@@ -207,6 +209,11 @@ impl Signer {
 
     pub fn swdefined(&mut self, swdefined: u32) -> &mut Self {
         self.swdefined = swdefined;
+        self
+    }
+
+    pub fn isvextprodid(&mut self, isvextprodid: [u8; 16]) -> &mut Self {
+        self.isvextprodid = isvextprodid;
         self
     }
 


### PR DESCRIPTION
This PR add signer support for the recently added `ISVEXTPRODID` field (see the base branch) of `SIGSTRUCT`. Argument parsed to `Signer` is parsed as `u128` which aligns with the `ISVEXTPRODID` field size (i.e `[u8; 16]`).
