### PR TITLE
[RTE-1140] Fix AESM v2.30 Compatibility Issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aesm-client"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "byteorder 1.5.0",

--- a/intel-sgx/aesm-client/Cargo.toml
+++ b/intel-sgx/aesm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesm-client"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/aesm-client/src/imp/aesm_protobuf/mod.rs
+++ b/intel-sgx/aesm-client/src/imp/aesm_protobuf/mod.rs
@@ -157,12 +157,13 @@ impl AesmClient {
 
         req.set_att_key_id(att_key_id.clone());
         req.set_b_pub_key_id(false);
-        
+        req.set_buf_size(0);
+
         let res = self.transact(req)?;
         let buf_size = res.pub_key_id_size();
 
         let mut req = InitQuoteExRequest::new();
-        
+
         req.set_att_key_id(att_key_id);
         req.set_b_pub_key_id(true);
         req.set_buf_size(buf_size);

--- a/intel-sgx/aesm-client/src/lib.rs
+++ b/intel-sgx/aesm-client/src/lib.rs
@@ -396,4 +396,41 @@ mod tests {
             false
         });
     }
+
+    #[test]
+    fn test_get_quote_full() {
+        use sgxs_loaders::isgx::Device as IsgxDevice;
+
+        const SGX_QL_ALG_ECDSA_P256: u32 = 2;
+
+        let mut device = IsgxDevice::new()
+            .map_err(|err| anyhow::Error::from(err).context("Error opening SGX device"))?
+            .einittoken_provider(AesmClient::new())
+            .build();
+
+        let client = AesmClient::new();
+
+        let key_ids = client
+            .get_supported_att_key_ids()
+            .map_err(|err| anyhow::Error::from(err).context("AESM communication error getting attestation key ID"))?;
+
+        let ecdsa_key_id = key_ids
+            .into_iter()
+            .find(|id| SGX_QL_ALG_ECDSA_P256 == get_algorithm_id(id))
+            .ok_or(anyhow!("No appropriate attestation key ID"))?;
+
+        let quote_info = client
+            .init_quote_ex(ecdsa_key_id.clone())
+            .map_err(|err| anyhow::Error::from(err).context("Error during quote initialization"))?;
+
+        let ti = Targetinfo::try_copy_from(quote_info.target_info()).unwrap();
+        let report = report_test::report(&ti, &mut device).unwrap();
+
+        let res = client
+            .get_quote_ex(ecdsa_key_id, report.as_ref().to_owned(), None, vec![0; 16])
+            .map_err(|err| anyhow::Error::from(err).context("Error obtaining quote"))?;
+
+        let quote = Quote::parse(res.quote()).map_err(|err| err.context("Error parsing quote"))?;
+        let QuoteHeader::V3 { user_data, .. } = quote.header();
+    }
 }


### PR DESCRIPTION
PSW v2.30 release includes a breaking changes in compatibility to its protobuf definition from `optional` to `required`. The workaround is to always supply the argument with zero value.

Related PR in Intel:
https://github.com/intel/confidential-computing.sgx/pull/1107

Although it is actually against the norm to change protobuf definition after it has been published (https://protobuf.dev/programming-guides/proto3/), we can expect that this behavior may persist moving forward as it has been already published. Specifying zero value should be backward compatible with previous AESM version, or should Intel decides to revert the changes in future version.