### PR TITLE
sgx-isa: fix UB in Sigstruct::signature_data. test with miri in CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Rust toolchain
         run: |
           rustup target add x86_64-fortanix-unknown-sgx x86_64-unknown-linux-musl
-          rustup toolchain add nightly
+          rustup toolchain add nightly --component miri
           rustup target add x86_64-fortanix-unknown-sgx --toolchain nightly
           rustup update
 
@@ -124,3 +124,6 @@ jobs:
 
       - name: snmalloc correctness test
         run: cd ./examples/mem-correctness-test && cargo run
+
+      - name: Nightly Miri test -p sgx-isa
+        run: cargo +nightly miri test --verbose --locked -p sgx-isa

--- a/intel-sgx/sgx-isa/Cargo.toml
+++ b/intel-sgx/sgx-isa/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://edp.fortanix.com/"
 keywords = ["sgx", "enclave"]
 categories = ["hardware-support"]
 
-[dev-dependencies]
+[target.'cfg(target_env = "sgx")'.dev-dependencies]
 # External dependencies
 mbedtls = { version = ">=0.12.0, <0.14.0", default-features = false, features = ["std"] }
 

--- a/intel-sgx/sgx-isa/src/lib.rs
+++ b/intel-sgx/sgx-isa/src/lib.rs
@@ -903,21 +903,110 @@ impl ReportMacStruct {
     }
 }
 
-#[test]
-fn test_eq() {
-    let mut a = Keyrequest::default();
-    let mut b = Keyrequest::default();
-    assert!(a == b);
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    a.keyname = 22;
-    assert!(a != b);
+    #[test]
+    fn test_eq() {
+        let mut a = Keyrequest::default();
+        let mut b = Keyrequest::default();
+        assert!(a == b);
 
-    b.keyname = 22;
-    assert!(a == b);
+        a.keyname = 22;
+        assert!(a != b);
 
-    a.miscmask = 0xdeadbeef;
-    assert!(a != b);
+        b.keyname = 22;
+        assert!(a == b);
 
-    b.miscmask = 0xdeadbeef;
-    assert!(a == b);
+        a.miscmask = 0xdeadbeef;
+        assert!(a != b);
+
+        b.miscmask = 0xdeadbeef;
+        assert!(a == b);
+    }
+
+    #[test]
+    fn test_struct_roundtrips() {
+        macro_rules! assert_byte_round_trip {
+            ($type:ty) => {{
+                #[cfg(not(feature = "large_array_derive"))]
+                {
+                    let default = <$type>::default();
+                    assert!(AsRef::<[u8]>::as_ref(&default)
+                        .iter()
+                        .all(|byte| *byte == 0));
+                }
+
+                let bytes = [0xa5; <$type>::UNPADDED_SIZE];
+                let value = <$type>::try_copy_from(&bytes).unwrap();
+                let cloned = value.clone();
+                assert!(value == cloned);
+                assert_eq!(AsRef::<[u8]>::as_ref(&value), &bytes[..]);
+            }};
+        }
+
+        assert_byte_round_trip!(Secs);
+        assert_byte_round_trip!(Attributes);
+        assert_byte_round_trip!(Tcs);
+        assert_byte_round_trip!(Pageinfo);
+        assert_byte_round_trip!(Secinfo);
+        assert_byte_round_trip!(Pcmd);
+        assert_byte_round_trip!(Sigstruct);
+        assert_byte_round_trip!(Einittoken);
+        assert_byte_round_trip!(Report);
+        assert_byte_round_trip!(Targetinfo);
+        assert_byte_round_trip!(Keyrequest);
+        assert_byte_round_trip!(ReportType);
+        assert_byte_round_trip!(ReportMacStruct);
+        assert_byte_round_trip!(tdx::TeeTcbInfo);
+        assert_byte_round_trip!(tdx::TdInfoBase);
+        assert_byte_round_trip!(tdx::TdInfoV1);
+        assert_byte_round_trip!(tdx::TdxReportV1);
+
+        let bytes = [0; Report::UNPADDED_SIZE + 1];
+        assert!(Report::try_copy_from(&bytes[..Report::UNPADDED_SIZE - 1]).is_none());
+        assert!(Report::try_copy_from(&bytes).is_none());
+    }
+
+    #[test]
+    fn test_page_type_mut() {
+        let mut flags = SecinfoFlags::R | SecinfoFlags::W | SecinfoFlags::from(PageType::Tcs);
+        assert_eq!(flags.page_type(), PageType::Tcs as u8);
+
+        *flags.page_type_mut() = 0xa5;
+
+        assert_eq!(flags.page_type(), 0xa5);
+        assert!(flags.contains(SecinfoFlags::R | SecinfoFlags::W));
+    }
+
+    #[test]
+    fn test_signature_data() {
+        const PART1_END: usize = 128;
+        const PART2_START: usize = 900;
+        const PART2_END: usize = 1028;
+
+        let mut bytes = [0; Sigstruct::UNPADDED_SIZE];
+        bytes[..PART1_END].fill(0x11);
+        bytes[PART1_END..PART2_START].fill(0x22);
+        bytes[PART2_START..PART2_END].fill(0x33);
+        bytes[PART2_END..].fill(0x44);
+
+        let sigstruct = Sigstruct::try_copy_from(&bytes).unwrap();
+        let (part1, part2) = sigstruct.signature_data();
+
+        assert_eq!(part1, &bytes[..PART1_END]);
+        assert_eq!(part2, &bytes[PART2_START..PART2_END]);
+    }
+
+    #[test]
+    fn test_report_mac_data() {
+        let mut bytes = [0; Report::UNPADDED_SIZE];
+        bytes[..Report::TRUNCATED_SIZE].fill(0x11);
+        bytes[Report::TRUNCATED_SIZE..].fill(0x22);
+
+        let report = Report::try_copy_from(&bytes).unwrap();
+
+        assert_eq!(&report.mac_data()[..], &bytes[..Report::TRUNCATED_SIZE]);
+    }
 }

--- a/intel-sgx/sgx-isa/src/lib.rs
+++ b/intel-sgx/sgx-isa/src/lib.rs
@@ -587,18 +587,27 @@ pub struct Sigstruct {
 impl Sigstruct {
     pub const UNPADDED_SIZE: usize = 1808;
 
-    /// Returns that part of the `Sigstruct` that is signed. The returned
+    /// Returns the part of the `Sigstruct` that is signed. The returned
     /// slices should be concatenated for hashing.
     pub fn signature_data(&self) -> (&[u8], &[u8]) {
-        unsafe {
-            let part1_start = &(self.header) as *const _ as *const u8;
-            let part1_end = &(self.modulus) as *const _ as *const u8 as usize;
-            let part2_start = &(self.miscselect) as *const _ as *const u8;
-            let part2_end = &(self._reserved4) as *const _ as *const u8 as usize;
+        use core::mem::offset_of;
 
+        const PART1_LEN: usize = offset_of!(Sigstruct, modulus);
+        const PART2_START: usize = offset_of!(Sigstruct, miscselect);
+        const PART2_LEN: usize = offset_of!(Sigstruct, _reserved4) - PART2_START;
+
+        // sig-data := [ header || .. || _reserved1 ] || [ miscselect || .. || isvsvn ]
+        //
+        // SAFETY:
+        // - Both slices are computed from field offsets and lie within `self`.
+        // - Reading `self` bytes as `u8` is valid, as the type is repr(C)
+        //   without any uninit padding bytes.
+        // - The returned slices inherit `self`'s lifetime.
+        let p = self as *const Self as *const u8;
+        unsafe {
             (
-                slice::from_raw_parts(part1_start, part1_end - (part1_start as usize)),
-                slice::from_raw_parts(part2_start, part2_end - (part2_start as usize)),
+                slice::from_raw_parts(p, PART1_LEN),
+                slice::from_raw_parts(p.add(PART2_START), PART2_LEN),
             )
         }
     }


### PR DESCRIPTION
miri surfaced some UB in `Sigstruct::signature_data` under the default stacked borrows model:

```
$ cargo +nightly miri test -p sgx-isa --lib test_signature_data
test test_signature_data ... error: Undefined Behavior: trying to retag from <458630> for SharedReadOnly permission at alloc138652[0x10], but that tag does not exist in the borrow stack for this location
   --> intel-sgx/sgx-isa/src/lib.rs:600:17
    |
600 |                 slice::from_raw_parts(part1_start, part1_end - (part1_start as usize)),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this error occurs as part of retag at alloc138652[0x0..0x80]
    |
```

The issue is the `part1_start` pointer extending past the scope of its original "allocation" (the `self.header` field), which is UB under stacked borrows.

Instead, we can use [`std::mem::offset_of!`](https://doc.rust-lang.org/stable/std/mem/macro.offset_of.html) to just get the actual field offsets instead of deriving them on-the-fly. We can then offset directly from the `self` pointer to get our slices, which stays within the pointer's "allocation" (i.e., all of `Sigstruct`).

---

I've also added a few small unit tests to exercise the `unsafe` blocks in `sgx-isa` (at least, the ones that aren't cfg'd for SGX).

It would be nice if we could get `miri` checking things more systematically, so I've added a `cargo miri test -p sgx-isa` step in CI. This is definitely optional, but I'd like to slowly expand our coverage to more rust-sgx crates if possible.