### PR TITLE
ipc-queue: fix UB: concurrent aliasing &/&mut refs, casting shared+read-only ref to shared+read-write ref

### DIFF
--- a/ipc-queue/src/fifo.rs
+++ b/ipc-queue/src/fifo.rs
@@ -113,7 +113,7 @@ where
 
 #[cfg(not(target_env = "sgx"))]
 pub(crate) struct FifoBuffer<T> {
-    data: Box<[WithId<T>]>,
+    data: Box<[UnsafeCell<WithId<T>>]>,
     offsets: Box<AtomicUsize>,
 }
 
@@ -125,7 +125,9 @@ impl<T: Transmittable> FifoBuffer<T> {
             "Fifo len should be a power of two"
         );
         let mut data = Vec::with_capacity(len);
-        data.resize_with(len, || WithId { id: AtomicU64::new(0), data: T::default() });
+        data.resize_with(len, || {
+            UnsafeCell::new(WithId { id: AtomicU64::new(0), data: T::default() })
+        });
         Self {
             data: data.into_boxed_slice(),
             offsets: Box::new(AtomicUsize::new(0)),
@@ -186,9 +188,15 @@ impl<T: Transmittable> Fifo<T> {
             UserRef::from_ptr(descriptor.offsets as *const WrapUsize);
 
         }
-        let data_slice = std::slice::from_raw_parts(descriptor.data, descriptor.len);
+        // Cast `*mut WithId<T>` -> `*mut UnsafeCell<WithId<T>>` _before_ making
+        // the slice. Casting the slices would give `data` read-only pointer
+        // provenance.
+        let data = std::slice::from_raw_parts(
+            descriptor.data.cast::<UnsafeCell<WithId<T>>>(),
+            descriptor.len,
+        );
         Self {
-            data: &*(data_slice as *const [WithId<T>] as *const [UnsafeCell<WithId<T>>]),
+            data,
             offsets: &*descriptor.offsets,
             storage: Storage::Static(PhantomData::default()),
         }
@@ -203,7 +211,7 @@ impl<T: Transmittable> Fifo<T> {
         //   and `offsets` point into the `FifoBuffer`.
         unsafe {
             Self {
-                data: &*(buffer.data.as_ref() as *const [WithId<T>] as *const [UnsafeCell<WithId<T>>]),
+                data: std::slice::from_raw_parts(buffer.data.as_ptr(), buffer.data.len()),
                 offsets: &*(buffer.offsets.as_ref() as *const AtomicUsize),
                 storage: Storage::Shared(buffer),
             }
@@ -219,7 +227,7 @@ impl<T: Transmittable> Fifo<T> {
             Storage::Static(_) => panic!("Sender/Receiver created using `from_descriptor()` cannot be turned into DescriptorGuard."),
         };
         let descriptor = FifoDescriptor {
-            data: self.data.as_ptr() as _,
+            data: UnsafeCell::raw_get(self.data.as_ptr()),
             len: self.data.len(),
             offsets: self.offsets,
         };

--- a/ipc-queue/src/fifo.rs
+++ b/ipc-queue/src/fifo.rs
@@ -8,11 +8,8 @@ use std::cell::UnsafeCell;
 use std::marker::PhantomData;
 use std::mem;
 #[cfg(not(target_env = "sgx"))]
-use {
-    std::sync::atomic::AtomicU64,
-    std::sync::Arc,
-};
-use std::sync::atomic::{AtomicUsize, Ordering, Ordering::SeqCst};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering, Ordering::SeqCst};
 
 use fortanix_sgx_abi::{FifoDescriptor, WithId};
 
@@ -256,9 +253,17 @@ impl<T: Transmittable> Fifo<T> {
 
         // 4. Write the data, then the `id`.
         unsafe {
-            let slot = &mut *self.data[new.write_offset()].get();
-            T::write(&mut slot.data, &val.data);
-            slot.id.store(val.id, SeqCst);
+            // NOTE: stay in pointers to avoid a concurrent &/&mut ref with a
+            // concurrent recv'er while they loop.
+            let slot_ptr: *mut WithId<T> = UnsafeCell::raw_get(
+                self.data.as_ptr().add(new.write_offset()),
+            );
+            let slot_data_ptr: *mut T = &raw mut (*slot_ptr).data;
+            T::write(slot_data_ptr, &val.data);
+
+            let slot_id_ptr: *const AtomicU64 = &raw const (*slot_ptr).id;
+            let slot_id: &AtomicU64 = &*slot_id_ptr;
+            slot_id.store(val.id, SeqCst);
         }
 
         // 5. If the queue was empty in step 1, signal the reader to wake up.
@@ -277,22 +282,32 @@ impl<T: Transmittable> Fifo<T> {
         // 3. Add 1 to the read offset.
         let new = current.increment_read_offset();
 
-        let (slot, id) = loop {
+        // NOTE: stay in pointers to avoid a concurrent &/&mut ref with a
+        // concurrent sender while we loop.
+        let (slot_ptr, slot_id): (*mut WithId<T>, &AtomicU64) = unsafe {
+            let slot_ptr = UnsafeCell::raw_get(self.data.as_ptr().add(new.read_offset()));
+            let slot_id_ptr: *const AtomicU64 = &raw const (*slot_ptr).id;
+            let slot_id = &*slot_id_ptr;
+            (slot_ptr, slot_id)
+        };
+        let id = loop {
             // 4. Read the `id` at the new read offset.
-            let slot = unsafe { &mut *self.data[new.read_offset()].get() };
-            let id = slot.id.load(SeqCst);
+            let id = slot_id.load(SeqCst);
 
             // 5. If `id` is `0`, go to step 4 (spin). Spinning is OK because data is
             //    expected to be written imminently.
             if id != 0 {
-                break (slot, id);
+                break id;
             }
         };
 
         // 6. Read the data, then store `0` in the `id`.
-        let data = unsafe { T::read(&slot.data) };
+        let data = unsafe {
+            let slot_data_ptr: *const T = &raw const (*slot_ptr).data;
+            T::read(slot_data_ptr)
+        };
         let val = Identified { id, data };
-        slot.id.store(0, SeqCst);
+        slot_id.store(0, SeqCst);
 
         // 7. Store the new read offset, retrieving the old offsets.
         let before = fetch_adjust(

--- a/ipc-queue/src/fifo.rs
+++ b/ipc-queue/src/fifo.rs
@@ -63,8 +63,7 @@ where
     T: Transmittable,
     S: Synchronizer,
 {
-    let arc = Arc::new(FifoBuffer::new(len));
-    let inner = Fifo::from_arc(arc);
+    let inner = Fifo::new(len);
     let tx = Sender { inner: inner.clone(), synchronizer: s.clone() };
     let rx = Receiver { inner, synchronizer: s };
     (tx, rx)
@@ -76,8 +75,7 @@ where
     T: Transmittable,
     S: AsyncSynchronizer,
 {
-    let arc = Arc::new(FifoBuffer::new(len));
-    let inner = Fifo::from_arc(arc);
+    let inner = Fifo::new(len);
     let tx = AsyncSender { inner: inner.clone(), synchronizer: s.clone() };
     let rx = AsyncReceiver { inner, synchronizer: s, read_epoch: Arc::new(AtomicU64::new(0)) };
     (tx, rx)
@@ -197,12 +195,17 @@ impl<T: Transmittable> Fifo<T> {
     }
 
     #[cfg(not(target_env = "sgx"))]
-    fn from_arc(fifo: Arc<FifoBuffer<T>>) -> Self {
+    fn new(len: usize) -> Self {
+        let buffer = Arc::new(FifoBuffer::new(len));
+        // SAFETY:
+        // - `storage` keeps the backing `FifoBuffer` live until this queue
+        //   handle and all its clones are dropped, so it's safe to have `data`
+        //   and `offsets` point into the `FifoBuffer`.
         unsafe {
             Self {
-                data: &*(fifo.data.as_ref() as *const [WithId<T>] as *const [UnsafeCell<WithId<T>>]),
-                offsets: &*(fifo.offsets.as_ref() as *const AtomicUsize),
-                storage: Storage::Shared(fifo),
+                data: &*(buffer.data.as_ref() as *const [WithId<T>] as *const [UnsafeCell<WithId<T>>]),
+                offsets: &*(buffer.offsets.as_ref() as *const AtomicUsize),
+                storage: Storage::Shared(buffer),
             }
         }
     }
@@ -479,11 +482,17 @@ mod tests {
     #[cfg(not(target_env = "sgx"))]
     #[test]
     fn from_descriptor_send_recv() {
-        let mut buffer = FifoBuffer::<TestValue>::new(2);
+        let mut data = Vec::with_capacity(2);
+        data.resize_with(2, || WithId {
+            id: AtomicU64::new(0),
+            data: TestValue::default(),
+        });
+        let mut data = data.into_boxed_slice();
+        let offsets = Box::new(AtomicUsize::new(0));
         let descriptor = FifoDescriptor {
-            data: buffer.data.as_mut_ptr(),
-            len: buffer.data.len(),
-            offsets: buffer.offsets.as_ref(),
+            data: data.as_mut_ptr(),
+            len: data.len(),
+            offsets: offsets.as_ref(),
         };
 
         let tx = unsafe { Sender::from_descriptor(descriptor, NoopSynchronizer) };

--- a/ipc-queue/src/fifo.rs
+++ b/ipc-queue/src/fifo.rs
@@ -19,6 +19,9 @@ use fortanix_sgx_abi::{FifoDescriptor, WithId};
 #[cfg(target_env = "sgx")]
 use super::{Identified, Transmittable, TryRecvError, TrySendError, UserRef, UserSafeSized};
 
+#[cfg(all(test, target_env = "sgx"))]
+use super::{Receiver, Sender, Synchronizer};
+
 #[cfg(not(target_env = "sgx"))]
 use super::{AsyncReceiver, AsyncSender, AsyncSynchronizer, DescriptorGuard, Identified, Receiver, Sender,
     Synchronizer, Transmittable, TryRecvError, TrySendError};
@@ -372,10 +375,141 @@ mod tests {
     use super::*;
     use crate::test_support::{NoopSynchronizer, TestValue};
     use std::sync::mpsc;
+    #[cfg(target_env = "sgx")]
+    use std::sync::{atomic::{AtomicUsize, AtomicU64}, Arc};
     use std::thread;
 
     fn inner<T, S>(tx: Sender<T, S>) -> Fifo<T> {
         tx.inner
+    }
+
+    /// Helper struct to make a valid `Fifo<TestValue>` with `Storage::Static`.
+    struct StaticFifoStorage {
+        data: Box<[UnsafeCell<WithId<TestValue>>]>,
+        offsets: Box<AtomicUsize>,
+    }
+
+    impl StaticFifoStorage {
+        fn new(len: usize) -> Self {
+            assert!(len.is_power_of_two());
+            let data = (0..len)
+                .map(|_| UnsafeCell::new(WithId {
+                    id: AtomicU64::new(0),
+                    data: TestValue::default(),
+                }))
+                .collect::<Vec<_>>()
+                .into_boxed_slice();
+            Self { data, offsets: Box::new(AtomicUsize::new(0)) }
+        }
+
+        fn fifo(&self) -> Fifo<TestValue> {
+            unsafe {
+                Fifo {
+                    data: std::slice::from_raw_parts(self.data.as_ptr(), self.data.len()),
+                    offsets: &*(self.offsets.as_ref() as *const AtomicUsize),
+                    storage: Storage::Static(PhantomData),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn transmittable_write_read() {
+        let expected = TestValue(42);
+        let mut slot = TestValue::default();
+
+        unsafe {
+            TestValue::write(&mut slot, &expected);
+            assert_eq!(TestValue::read(&slot).0, expected.0);
+        }
+    }
+
+    #[test]
+    fn static_fifo_send_recv() {
+        let storage = StaticFifoStorage::new(2);
+        let fifo = storage.fifo();
+
+        assert!(fifo.try_send_impl(Identified { id: 1, data: TestValue(42) }).unwrap());
+        let (value, was_full, read_wrapped_around) = fifo.try_recv_impl().unwrap();
+
+        assert_eq!(value.id, 1);
+        assert_eq!(value.data.0, 42);
+        assert!(!was_full);
+        assert!(!read_wrapped_around);
+    }
+
+    #[test]
+    fn static_fifo_send_recv_concurrent() {
+        const PRODUCERS: u64 = 2;
+        const VALUES_PER_PRODUCER: u64 = 4;
+
+        let storage = StaticFifoStorage::new(2);
+        let fifo = storage.fifo();
+        let tx = Arc::new(Sender { inner: fifo.clone(), synchronizer: NoopSynchronizer });
+        let rx = Receiver { inner: fifo, synchronizer: NoopSynchronizer };
+        let consumer = thread::spawn(move || {
+            let mut values = Vec::new();
+            for _ in 0..PRODUCERS * VALUES_PER_PRODUCER {
+                values.push(rx.recv().unwrap());
+            }
+            values
+        });
+
+        let mut producers = Vec::new();
+        for producer in 0..PRODUCERS {
+            let tx = tx.clone();
+            producers.push(thread::spawn(move || {
+                for value in 0..VALUES_PER_PRODUCER {
+                    let id = producer * VALUES_PER_PRODUCER + value + 1;
+                    tx.send(Identified { id, data: TestValue(id) }).unwrap();
+                }
+            }));
+        }
+
+        for producer in producers {
+            producer.join().unwrap();
+        }
+        let mut values = consumer.join().unwrap();
+        values.sort_unstable_by_key(|value| value.id);
+        assert!(values.iter().enumerate().all(|(index, value)| {
+            value.id == index as u64 + 1 && value.data.0 == value.id
+        }));
+    }
+
+    #[cfg(not(target_env = "sgx"))]
+    #[test]
+    fn from_descriptor_send_recv() {
+        let mut buffer = FifoBuffer::<TestValue>::new(2);
+        let descriptor = FifoDescriptor {
+            data: buffer.data.as_mut_ptr(),
+            len: buffer.data.len(),
+            offsets: buffer.offsets.as_ref(),
+        };
+
+        let tx = unsafe { Sender::from_descriptor(descriptor, NoopSynchronizer) };
+        let rx = unsafe { Receiver::from_descriptor(descriptor, NoopSynchronizer) };
+
+        tx.try_send(Identified { id: 1, data: TestValue(42) }).unwrap();
+        let value = rx.try_recv().unwrap();
+        assert_eq!(value.id, 1);
+        assert_eq!(value.data.0, 42);
+    }
+
+    #[cfg(not(target_env = "sgx"))]
+    #[test]
+    fn descriptor_guard_keeps_storage_alive() {
+        let (tx, rx) = bounded(2, NoopSynchronizer);
+        drop(rx);
+        let guard = tx.inner.into_descriptor_guard();
+        let descriptor = guard.fifo_descriptor();
+
+        let tx = unsafe { Sender::from_descriptor(descriptor, NoopSynchronizer) };
+        let rx = unsafe { Receiver::from_descriptor(descriptor, NoopSynchronizer) };
+
+        tx.try_send(Identified { id: 1, data: TestValue(42) }).unwrap();
+        let value = rx.try_recv().unwrap();
+        assert_eq!(value.id, 1);
+        assert_eq!(value.data.0, 42);
     }
 
     #[test]

--- a/ipc-queue/src/interface_async.rs
+++ b/ipc-queue/src/interface_async.rs
@@ -138,8 +138,11 @@ mod tests {
     async fn single_sender() {
         do_single_sender(4, 10).await;
         do_single_sender(1, 10).await;
-        do_single_sender(32, 1024).await;
-        do_single_sender(1024, 32).await;
+        #[cfg(not(miri))]
+        {
+            do_single_sender(32, 1024).await;
+            do_single_sender(1024, 32).await;
+        }
     }
 
     async fn do_multi_sender(len: usize, n: u64, senders: u64) {
@@ -173,9 +176,12 @@ mod tests {
     #[tokio::test]
     async fn multi_sender() {
         do_multi_sender(4, 10, 3).await;
-        do_multi_sender(4, 1, 100).await;
-        do_multi_sender(2, 10, 100).await;
-        do_multi_sender(1024, 30, 100).await;
+        #[cfg(not(miri))]
+        {
+            do_multi_sender(4, 1, 100).await;
+            do_multi_sender(2, 10, 100).await;
+            do_multi_sender(1024, 30, 100).await;
+        }
     }
 
     #[tokio::test]
@@ -217,7 +223,12 @@ mod tests {
         assert!(monitor.read_position().is_past(&p2) == Some(true));
         assert!(monitor.read_position().is_past(&p3) == Some(false));
 
-        for i in 0..1000 {
+        #[cfg(miri)]
+        const ROUNDS: usize = 8;
+        #[cfg(not(miri))]
+        const ROUNDS: usize = 1000;
+
+        for i in 0..ROUNDS {
             let n = 1 + (i % LEN);
             let p4 = monitor.write_position();
             for _ in 0..n {

--- a/ipc-queue/src/interface_sync.rs
+++ b/ipc-queue/src/interface_sync.rs
@@ -185,8 +185,11 @@ mod tests {
     fn single_sender() {
         do_single_sender(4, 10);
         do_single_sender(1, 10);
-        do_single_sender(32, 1024);
-        do_single_sender(1024, 32);
+        #[cfg(not(miri))]
+        {
+            do_single_sender(32, 1024);
+            do_single_sender(1024, 32);
+        }
     }
 
     fn do_multi_sender(len: usize, n: u64, senders: u64) {
@@ -216,9 +219,12 @@ mod tests {
     #[test]
     fn multi_sender() {
         do_multi_sender(4, 10, 3);
-        do_multi_sender(4, 1, 100);
-        do_multi_sender(2, 10, 100);
-        do_multi_sender(1024, 30, 100);
+        #[cfg(not(miri))]
+        {
+            do_multi_sender(4, 1, 100);
+            do_multi_sender(2, 10, 100);
+            do_multi_sender(1024, 30, 100);
+        }
     }
 
     #[test]
@@ -319,6 +325,9 @@ mod tests {
     fn try_iter() {
         let s = TestSynchronizer::new();
         let (tx, rx) = bounded(8, s);
+        #[cfg(miri)]
+        const N: u64 = 32;
+        #[cfg(not(miri))]
         const N: u64 = 2048;
 
         let h = thread::spawn(move || {
@@ -343,7 +352,13 @@ mod tests {
     fn try_send_multiple() {
         let s = TestSynchronizer::new();
         let (tx, rx) = bounded(32, s);
+        #[cfg(miri)]
+        const SENDERS: usize = 2;
+        #[cfg(not(miri))]
         const SENDERS: usize = 4;
+        #[cfg(miri)]
+        const N: usize = 8;
+        #[cfg(not(miri))]
         const N: usize = 1024;
         let mut handles = Vec::with_capacity(SENDERS);
 


### PR DESCRIPTION
Fixing a few more miri Undefined Behavior violations.

Running `miri` on `ipc-queue` surfaced two separate issues:

### UB: casting shared+read-only ref to shared+read-write ref

```bash
$ cargo +nightly miri test -p ipc-queue --lib -- basic1
test fifo::tests::basic1 ... error: Undefined Behavior: trying to retag from <155762> for SharedReadWrite permission at alloc51024[0x8], but that tag only grants SharedReadOnly permission for this location
   --> ipc-queue/src/fifo.rs:208:23
    |
208 |                 data: &*(fifo.data.as_ref() as *const [WithId<T>] as *const [UnsafeCell<WithId<T>>]),
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this error occurs as part of retag at alloc51024[0x0..0x200]
# ..


$ cargo +nightly miri test -p ipc-queue --lib -- from_descriptor_roundtrip
test fifo::tests::from_descriptor_roundtrip ... error: Undefined Behavior: trying to retag from <170518> for SharedReadWrite permission at alloc49854[0x8], but that tag only grants SharedReadOnly permission for this location
   --> ipc-queue/src/fifo.rs:198:19
    |
198 |             data: &*(data_slice as *const [WithId<T>] as *const [UnsafeCell<WithId<T>>]),
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this error occurs as part of retag at alloc49854[0x0..0x20]

# ..
```

The problematic code looks like this (intermediate variables added for clarity):

```rust
pub(crate) struct FifoBuffer<T> {
    data: Box<[WithId<T>]>, // <--- Just a regular box slice with no interior-mutability
    offsets: Box<AtomicUsize>,
}

impl<T: Transmittable> Fifo<T> {
    fn from_arc(fifo: Arc<FifoBuffer<T>>) -> Self {
        unsafe {
            //            v--- A shared + _read-only_ ref
            let data_ref: &FifoBuffer<T> = fifo.data.as_ref();
            //        vvvvvvvvvvvv--- &[UnsafeCell<_>] means shared + _read-write_ ref
            let data: &[UnsafeCell<WithId<T>>] = &*(data_ref as *const [WithId<T>] as *const [UnsafeCell<WithId<T>>]);
            Self {
                data,
                offsets: &*(fifo.offsets.as_ref() as *const AtomicUsize),
                storage: Storage::Shared(fifo),
            }
        }
    }
}
```

I think the clearest way to solve this is to just change the `FifoBuffer` representation so that we create a `Box<[UnsafeCell<WithId<T>>]>` slice from the beginning:

```diff
 #[cfg(not(target_env = "sgx"))]
 pub(crate) struct FifoBuffer<T> {
-    data: Box<[WithId<T>]>,
+    data: Box<[UnsafeCell<WithId<T>>]>,
     offsets: Box<AtomicUsize>,
 }
```


### UB: concurrent &/&mut aliases

```bash
$ cargo +nightly miri test -p ipc-queue --lib -- interface_sync::tests::single_sender
test interface_sync::tests::single_sender ... error: Undefined Behavior: Data race detected between (1) atomic store on thread `unnamed-3` and (2) retag write of type `fortanix_sgx_abi::WithId<test_support::TestValue>` on thread `interface_sync:` at alloc150171
   --> ipc-queue/src/fifo.rs:284:33
    |
284 |             let slot = unsafe { &mut *self.data[new.read_offset()].get() };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (2) just happened here
    |
help: and (1) occurred earlier here
   --> ipc-queue/src/fifo.rs:263:13
    |
263 |             slot.id.store(val.id, SeqCst);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: retags occur on all (re)borrows and as well as when references are copied or moved
    = help: retags permit optimizations that insert speculative reads or writes
    = help: therefore from the perspective of data races, a retag has the same implications as a read or write
```

NOTE: the test failures are non-deterministic, since they depend on how miri schedules the threads.

The issue here is that in some thread interleavings, `Fifo::try_send_impl` and `Fifo::try_recv_impl` can concurrently have a `&WithId<T>` and `&mut T` (inside the `WithId<T>`), which is UB.

The solution is to instead stay in raw pointers and avoid refs.