### PR TITLE
[RTE-1179]: Add build script to check stabilized features.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "ipc-queue",
  "lazy_static",
  "rand 0.8.5",
+ "rustc_version",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4293,9 +4293,9 @@ dependencies = [
 
 [[package]]
 name = "sdkms"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b12e3cb05862db268118482cbad26eee384b479de1924fe5404028e3444481a"
+checksum = "6d2e70f9b18786894511f918b4d95cc7b0db138cce7b7ee05a7be6fb4a25e3ee"
 dependencies = [
  "bitflags 1.2.1",
  "chrono",
@@ -4304,7 +4304,6 @@ dependencies = [
  "rustc-serialize",
  "serde",
  "serde_json",
- "url 1.7.2",
  "uuid 0.8.2",
 ]
 

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -18,7 +18,7 @@ mbedtls = { version = ">=0.12.0, <0.14.0", default-features = false, features = 
 pkix = ">=0.1.2, <0.3.0"
 
 rustc-serialize = "0.3.24"
-sdkms = { version = "0.3", default-features = false }
+sdkms = { version = "0.3.1", default-features = false }
 serde = "1.0"
 serde_bytes = "0.11"
 serde_derive = "1.0"

--- a/intel-sgx/async-usercalls/Cargo.toml
+++ b/intel-sgx/async-usercalls/Cargo.toml
@@ -2,6 +2,7 @@
 name = "async-usercalls"
 version = "0.7.2"
 authors = ["Fortanix, Inc."]
+build = "build.rs"
 license = "MPL-2.0"
 edition = "2018"
 description = """

--- a/intel-sgx/async-usercalls/Cargo.toml
+++ b/intel-sgx/async-usercalls/Cargo.toml
@@ -28,6 +28,9 @@ fnv = "1.0"               # MIT/Apache-2.0
 [dev-dependencies]
 rand = "0.8"
 
+[build-dependencies]
+rustc_version = "0.4.1"   # MIT/Apache-2.0
+
 # For cargo test --target x86_64-fortanix-unknown-sgx
 [package.metadata.fortanix-sgx]
 threads = 128

--- a/intel-sgx/async-usercalls/build.rs
+++ b/intel-sgx/async-usercalls/build.rs
@@ -1,0 +1,28 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+// Enables configuration for non-stable features that are stabilized later.
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rustc-check-cfg=cfg(no_never_type)");
+
+    let minor = match rustc_minor_version() {
+        Some(minor) => minor,
+        None => return,
+    };
+    if minor < 100 {
+        println!("cargo:rustc-cfg=no_never_type");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
+}

--- a/intel-sgx/async-usercalls/build.rs
+++ b/intel-sgx/async-usercalls/build.rs
@@ -1,28 +1,12 @@
-use std::env;
-use std::process::Command;
-use std::str;
+use rustc_version::version;
 
 // Enables configuration for non-stable features that are stabilized later.
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-check-cfg=cfg(no_never_type)");
+    let rustc_version = version().unwrap();
 
-    let minor = match rustc_minor_version() {
-        Some(minor) => minor,
-        None => return,
-    };
-    if minor < 100 {
+    if rustc_version.minor < 100 {
         println!("cargo:rustc-cfg=no_never_type");
     }
-}
-
-fn rustc_minor_version() -> Option<u32> {
-    let rustc = env::var_os("RUSTC")?;
-    let output = Command::new(rustc).arg("--version").output().ok()?;
-    let version = str::from_utf8(&output.stdout).ok()?;
-    let mut pieces = version.split('.');
-    if pieces.next() != Some("rustc 1") {
-        return None;
-    }
-    pieces.next()?.parse().ok()
 }

--- a/intel-sgx/async-usercalls/src/lib.rs
+++ b/intel-sgx/async-usercalls/src/lib.rs
@@ -38,7 +38,7 @@
 //! [tokio]: https://docs.rs/tokio/latest/tokio/
 
 #![feature(sgx_platform)]
-#![feature(never_type)]
+#![cfg_attr(no_never_type, feature(never_type))]
 #![cfg_attr(test, feature(unboxed_closures))]
 #![cfg_attr(test, feature(fn_traits))]
 


### PR DESCRIPTION
Latest nightly compiler (`1.100`) fails to build `async-usercalls` due to the stabilized `never_type` feature. See the failure here: https://github.com/fortanix/rust-sgx/actions/runs/33515166527/job/99880253018. This PR is influced by the serde's approach to the similar problem. 