### PR TITLE
update sdkms client usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,21 +555,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide 0.7.2",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
 name = "base16"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +578,12 @@ checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 dependencies = [
  "byteorder 1.5.0",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1188,7 +1164,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio 1.2.0",
+ "mio",
  "parking_lot",
  "rustix 1.1.3",
  "signal-hook",
@@ -1568,7 +1544,7 @@ dependencies = [
  "sgx_pkix",
  "url 1.7.2",
  "uuid 0.6.5",
- "uuid 0.8.2",
+ "uuid 1.18.1",
  "vme-pkix",
  "yasna 0.3.2",
 ]
@@ -1763,7 +1739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2082,12 +2058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,6 +2129,30 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes 1.7.1",
+ "headers-core",
+ "http 0.2.12",
+ "httpdate",
+ "mime 0.3.17",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.12",
+]
 
 [[package]]
 name = "heck"
@@ -2333,7 +2327,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2439,7 +2433,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.7.0",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.5",
  "tokio",
  "tower",
  "tower-service",
@@ -2990,32 +2984,12 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3368,15 +3342,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -4069,12 +4034,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4293,19 +4252,19 @@ dependencies = [
 
 [[package]]
 name = "sdkms"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b12e3cb05862db268118482cbad26eee384b479de1924fe5404028e3444481a"
+checksum = "1b97c41b4e479383257e0f868303a5683d90e9f374b8818b0b418ec04ea22a12"
 dependencies = [
+ "base64 0.13.1",
  "bitflags 1.2.1",
- "chrono",
- "hyper 0.10.16",
+ "headers",
  "log 0.4.28",
- "rustc-serialize",
  "serde",
  "serde_json",
- "url 1.7.2",
- "uuid 0.8.2",
+ "simple-hyper-client",
+ "time 0.3.41",
+ "uuid 1.18.1",
 ]
 
 [[package]]
@@ -4606,6 +4565,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4652,7 +4622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 1.2.0",
+ "mio",
  "signal-hook",
 ]
 
@@ -4670,6 +4640,20 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simple-hyper-client"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad8561dab46cf18be56eef057219f48f576d6bb91847cc33d7d4f2779bcd217"
+dependencies = [
+ "futures-executor",
+ "headers",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "tokio",
+ "tokio-stream",
+]
 
 [[package]]
 name = "slab"
@@ -4691,6 +4675,16 @@ checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4765,6 +4759,17 @@ name = "syn"
 version = "2.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.41",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.41",
@@ -5018,21 +5023,19 @@ checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
- "backtrace",
  "bytes 1.7.1",
  "libc",
- "mio 0.8.11",
- "num_cpus",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5048,13 +5051,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.41",
- "syn 2.0.115",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5085,6 +5088,17 @@ checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.4",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -5355,20 +5369,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.17",
- "serde",
-]
-
-[[package]]
-name = "uuid"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
+ "getrandom 0.3.4",
  "js-sys",
  "serde",
  "wasm-bindgen",

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -18,14 +18,14 @@ mbedtls = { version = ">=0.12.0, <0.14.0", default-features = false, features = 
 pkix = ">=0.1.2, <0.3.0"
 
 rustc-serialize = "0.3.24"
-sdkms = { version = "0.3", default-features = false }
+sdkms = { version = "0.5.1", default-features = false }
 serde = "1.0"
 serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_json = "1.0"
 url = "1"
 uuid = { version = "0.6.3", features = ["v4", "serde"] }
-uuid_sdkms = { package = "uuid", version = "0.8", features = ["v4", "serde"] }
+uuid_sdkms = { package = "uuid", version = "1", features = ["v4", "serde"] }
 
 yasna = { version = "0.3", features = ["num-bigint", "bit-vec"] }
 

--- a/em-app/src/utils.rs
+++ b/em-app/src/utils.rs
@@ -9,6 +9,7 @@ use std::io::Read;
 pub use em_client::models;
 
 use hyper::client::Pool;
+use hyper::header::{Authorization, Basic, Bearer, ContentType};
 use hyper::net::HttpsConnector;
 use em_client::{Api, Client};
 use mbedtls::alloc::{List as MbedtlsList};
@@ -27,6 +28,73 @@ use crate::mbedtls_hyper::MbedSSLClient;
 
 pub fn convert_uuid(api_uuid: Uuid) -> SdkmsUuid {
     SdkmsUuid::from_bytes(*api_uuid.as_bytes())
+}
+
+fn sdkms_response_error(operation: &str, response: &mut hyper::client::Response) -> String {
+    let mut message = format!("SDKMS {} failed with status {}", operation, response.status);
+    let mut error_body = String::new();
+    if response.read_to_string(&mut error_body).is_ok() && !error_body.is_empty() {
+        message.push_str(&format!(": {}", error_body));
+    }
+    message
+}
+
+fn sdkms_authenticate(
+    client: &hyper::Client,
+    api_endpoint: &str,
+    app_id: &Uuid,
+) -> Result<String, String> {
+    let mut response = client.post(&format!("{}/sys/v1/session/auth", api_endpoint))
+        .header(Authorization(Basic {
+            username: app_id.to_string(),
+            password: Some(String::new()),
+        }))
+        .send().map_err(|e| format!("SDKMS authenticate failed: {:?}", e))?;
+    if !response.status.is_success() {
+        return Err(sdkms_response_error("authenticate", &mut response));
+    }
+
+    let response: sdkms::api_model::AuthResponse = serde_json::from_reader(&mut response)
+        .map_err(|e| format!("Failed parsing SDKMS authentication response: {:?}", e))?;
+    Ok(response.access_token)
+}
+
+fn sdkms_export_sobject(
+    client: &hyper::Client,
+    api_endpoint: &str,
+    access_token: &str,
+    dataset_id: String,
+) -> Result<sdkms::api_model::Sobject, String> {
+    let key_id = sdkms::api_model::SobjectDescriptor::Name(dataset_id);
+    let request_body = serde_json::to_vec(&key_id)
+        .map_err(|e| format!("Failed encoding SDKMS export request: {:?}", e))?;
+    let mut response = client.post(&format!("{}/crypto/v1/keys/export", api_endpoint))
+        .header(Authorization(Bearer {
+            token: access_token.to_owned(),
+        }))
+        .header(ContentType::json())
+        .body(request_body.as_slice())
+        .send().map_err(|e| format!("Failed SDKMS export operation: {:?}", e))?;
+    if !response.status.is_success() {
+        return Err(sdkms_response_error("export", &mut response));
+    }
+
+    serde_json::from_reader(&mut response)
+        .map_err(|e| format!("Failed parsing SDKMS export response: {:?}", e))
+}
+
+fn sdkms_terminate_session(
+    client: &hyper::Client,
+    api_endpoint: &str,
+    access_token: String,
+) -> Result<(), String> {
+    let mut response = client.post(&format!("{}/sys/v1/session/terminate", api_endpoint))
+        .header(Authorization(Bearer { token: access_token }))
+        .send().map_err(|e| format!("SDKMS session termination failed: {:?}", e))?;
+    if !response.status.is_success() {
+        return Err(sdkms_response_error("session termination", &mut response));
+    }
+    Ok(())
 }
 
 /// Computes a Sha256 hash of an input
@@ -103,17 +171,13 @@ pub fn get_sdkms_dataset(
     
     let ssl = MbedSSLClient::new(Arc::new(config), true);
     let connector = HttpsConnector::new(ssl);
-    let client = Arc::new(hyper::Client::with_connector(Pool::with_connector(Default::default(), connector)));
+    let client = hyper::Client::with_connector(Pool::with_connector(Default::default(), connector));
 
-    let client = sdkms::SdkmsClient::builder()
-        .with_api_endpoint(&sdkms_url)
-        .with_hyper_client(client)
-        .build().map_err(|e| format!("SDKMS Build failed: {:?}", e))?
-        .authenticate_with_cert(Some(&convert_uuid(app_id))).map_err(|e| format!("SDKMS authenticate failed: {:?}", e))?;
-
-    let key_id = sdkms::api_model::SobjectDescriptor::Name(dataset_id);
-    
-    let result = client.export_sobject(&key_id).map_err(|e| format!("Failed SDKMS export operation: {:?}", e))?;
+    let api_endpoint = sdkms_url.trim_end_matches('/');
+    let access_token = sdkms_authenticate(&client, api_endpoint, &app_id)?;
+    let result = sdkms_export_sobject(&client, api_endpoint, &access_token, dataset_id);
+    let _ = sdkms_terminate_session(&client, api_endpoint, access_token);
+    let result = result?;
     
     result.value.ok_or("Missing value in exported object".to_string())
 }


### PR DESCRIPTION
Since new upstream sdkms use hyper 0.14 it's hard to migrate. So this commit update code to not rely on client from sdkms but just use types from it.