### PR TITLE
[RTE-1156] Bump SGX crate versions for sgx-isa 0.6 & sgxs 0.9.0 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aesm-client"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "byteorder 1.5.0",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-ql"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "byteorder 1.5.0",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-ql-sys"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "dcap-retrieve-pckid"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aesm-client",
  "anyhow",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "em-app"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "b64-ct",
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runner-sgx"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "fortanix-sgx-tools"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "aesm-client",
  "anyhow",
@@ -3551,7 +3551,7 @@ dependencies = [
 
 [[package]]
 name = "pcs"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "b64-ct",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "report-test"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "enclave-runner 0.8.0",
@@ -4668,7 +4668,7 @@ dependencies = [
 
 [[package]]
 name = "sgx_pkix"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "byteorder 1.5.0",
  "lazy_static",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "sgxs-loaders"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "aesm-client",
  "anyhow",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "tdx-ql"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap 4.4.18",
  "nix 0.30.1",

--- a/em-app/Cargo.toml
+++ b/em-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "em-app"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["fortanix.com"]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/aesm-client/Cargo.toml
+++ b/intel-sgx/aesm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aesm-client"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/dcap-ql-sys/Cargo.toml
+++ b/intel-sgx/dcap-ql-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-ql-sys"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Fortanix, Inc."]
 links = "sgx_dcap_ql"
 build = "build.rs"

--- a/intel-sgx/dcap-ql/Cargo.toml
+++ b/intel-sgx/dcap-ql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-ql"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/dcap-retrieve-pckid/Cargo.toml
+++ b/intel-sgx/dcap-retrieve-pckid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dcap-retrieve-pckid"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/enclave-runner-sgx/Cargo.toml
+++ b/intel-sgx/enclave-runner-sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runner-sgx"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/fortanix-sgx-tools/Cargo.toml
+++ b/intel-sgx/fortanix-sgx-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fortanix-sgx-tools"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/pcs/Cargo.toml
+++ b/intel-sgx/pcs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcs"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/report-test/Cargo.toml
+++ b/intel-sgx/report-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "report-test"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/intel-sgx/sgx_pkix/Cargo.toml
+++ b/intel-sgx/sgx_pkix/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Unfortunately crates.io prevents us from changing the name to `sgx-pkix`
 name = "sgx_pkix"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"

--- a/intel-sgx/sgxs-loaders/Cargo.toml
+++ b/intel-sgx/sgxs-loaders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgxs-loaders"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 edition = "2018"

--- a/intel-sgx/tdx-ql/Cargo.toml
+++ b/intel-sgx/tdx-ql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdx-ql"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 readme = "README.md"
 authors = ["Fortanix, Inc."]


### PR DESCRIPTION
We have new versions:

- sgx-isa_v0.6.0
- sgxs_v0.9.0

Both crates are already published. Crates that depend on them need updated dependency requirements and new releases:

- aesm-client 0.6.2 → 0.6.3
- enclave-runner-sgx 0.1.3 → 0.1.4
- sgxs-loaders 0.5.1 → 0.5.2
- report-test 0.5.2 → 0.5.3
- fortanix-sgx-tools 0.6.3 → 0.6.4
- pcs 0.8.3 → 0.8.4
- em-app 0.5.2 → 0.5.3
- dcap-ql-sys 0.2.2 → 0.2.3
- dcap-ql 0.4.2 → 0.4.3
- dcap-retrieve-pckid 0.3.3 → 0.3.4
- sgx_pkix 0.3.0 → 0.3.1
- tdx-ql 0.1.0 → 0.1.1

These releases update their `sgx-isa` / `sgxs` dependency requirements to be compatible with new versions.